### PR TITLE
Add client info reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,62 +38,62 @@ jobs:
           name: dist
           path: dist/
 
-  test-pypi-publish:
-    needs: build
-    runs-on: ubuntu-latest
+  # test-pypi-publish:
+  #   needs: build
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+  #     - name: Install Poetry
+  #       uses: snok/install-poetry@v1
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: dist
+  #         path: dist/
 
-      - name: Publish to TestPyPI
-        env:
-          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI }}
-        run: poetry config repositories.test-pypi https://test.pypi.org/legacy/; poetry config pypi-token.test-pypi $POETRY_PYPI_TOKEN_TESTPYPI; poetry publish --repository test-pypi
+  #     - name: Publish to TestPyPI
+  #       env:
+  #         POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI }}
+  #       run: poetry config repositories.test-pypi https://test.pypi.org/legacy/; poetry config pypi-token.test-pypi $POETRY_PYPI_TOKEN_TESTPYPI; poetry publish --repository test-pypi
 
-  pre-release-checks:
-    needs: test-pypi-publish
-    runs-on: ubuntu-latest
+  # pre-release-checks:
+  #   needs: test-pypi-publish
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+  #     - name: Install Poetry
+  #       uses: snok/install-poetry@v1
 
-      - name: Install dependencies
-        run: |
-          poetry install --all-extras
+  #     - name: Install dependencies
+  #       run: |
+  #         poetry install --all-extras
 
-      - name: Install published package from TestPyPI
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
-          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          AZURE_OPENAI_API_KEY: ${{secrets.AZURE_OPENAI_API_KEY}}
-          AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
-          AZURE_OPENAI_DEPLOYMENT_NAME: ${{secrets.AZURE_OPENAI_DEPLOYMENT_NAME}}
-          OPENAI_API_VERSION: ${{secrets.OPENAI_API_VERSION}}
-        run:
-          poetry run pip install --index-url https://test.pypi.org/simple/ --no-deps redisvl-test; poetry run test-cov
+  #     - name: Install published package from TestPyPI
+  #       env:
+  #         OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
+  #         GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
+  #         GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  #         COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+  #         AZURE_OPENAI_API_KEY: ${{secrets.AZURE_OPENAI_API_KEY}}
+  #         AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
+  #         AZURE_OPENAI_DEPLOYMENT_NAME: ${{secrets.AZURE_OPENAI_DEPLOYMENT_NAME}}
+  #         OPENAI_API_VERSION: ${{secrets.OPENAI_API_VERSION}}
+  #       run:
+  #         poetry run pip install --index-url https://test.pypi.org/simple/ --no-deps redisvl-test; poetry run test-cov
 
   publish:
     needs: build #pre-release-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,62 +38,62 @@ jobs:
           name: dist
           path: dist/
 
-  # test-pypi-publish:
-  #   needs: build
-  #   runs-on: ubuntu-latest
+  test-pypi-publish:
+    needs: build
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install Poetry
-  #       uses: snok/install-poetry@v1
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: dist
-  #         path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
-  #     - name: Publish to TestPyPI
-  #       env:
-  #         POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI }}
-  #       run: poetry config repositories.test-pypi https://test.pypi.org/legacy/; poetry config pypi-token.test-pypi $POETRY_PYPI_TOKEN_TESTPYPI; poetry publish --repository test-pypi
+      - name: Publish to TestPyPI
+        env:
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI }}
+        run: poetry config repositories.test-pypi https://test.pypi.org/legacy/; poetry config pypi-token.test-pypi $POETRY_PYPI_TOKEN_TESTPYPI; poetry publish --repository test-pypi
 
-  # pre-release-checks:
-  #   needs: test-pypi-publish
-  #   runs-on: ubuntu-latest
+  pre-release-checks:
+    needs: test-pypi-publish
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install Poetry
-  #       uses: snok/install-poetry@v1
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
 
-  #     - name: Install dependencies
-  #       run: |
-  #         poetry install --all-extras
+      - name: Install dependencies
+        run: |
+          poetry install --all-extras
 
-  #     - name: Install published package from TestPyPI
-  #       env:
-  #         OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
-  #         GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
-  #         GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  #         COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-  #         AZURE_OPENAI_API_KEY: ${{secrets.AZURE_OPENAI_API_KEY}}
-  #         AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
-  #         AZURE_OPENAI_DEPLOYMENT_NAME: ${{secrets.AZURE_OPENAI_DEPLOYMENT_NAME}}
-  #         OPENAI_API_VERSION: ${{secrets.OPENAI_API_VERSION}}
-  #       run:
-  #         poetry run pip install --index-url https://test.pypi.org/simple/ --no-deps redisvl-test; poetry run test-cov
+      - name: Install published package from TestPyPI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
+          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          AZURE_OPENAI_API_KEY: ${{secrets.AZURE_OPENAI_API_KEY}}
+          AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
+          AZURE_OPENAI_DEPLOYMENT_NAME: ${{secrets.AZURE_OPENAI_DEPLOYMENT_NAME}}
+          OPENAI_API_VERSION: ${{secrets.OPENAI_API_VERSION}}
+        run:
+          poetry run pip install --index-url https://test.pypi.org/simple/ --no-deps redisvl-test; poetry run test-cov
 
   publish:
     needs: build #pre-release-checks

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ scratch
 wiki_schema.yaml
 docs/_build/
 .venv
+.env
 coverage.xml
 dist/

--- a/conftest.py
+++ b/conftest.py
@@ -6,12 +6,6 @@ from redisvl.redis.connection import RedisConnectionFactory
 from testcontainers.compose import DockerCompose
 
 
-# @pytest.fixture(scope="session")
-# def event_loop():
-#     loop = asyncio.get_event_loop_policy().new_event_loop()
-#     yield loop
-#     loop.close()
-
 
 @pytest.fixture(scope="session", autouse=True)
 def redis_container():

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -97,21 +97,6 @@ def setup_redis():
     return decorator
 
 
-# def setup_async_redis():
-#     def decorator(func):
-#         @wraps(func)
-#         def wrapper(self, *args, **kwargs):
-#             result = func(self, *args, **kwargs)
-#             RedisConnectionFactory.validate_async_redis(
-#                 self._redis_client, self._lib_name
-#             )
-#             return result
-
-#         return wrapper
-
-#     return decorator
-
-
 def check_index_exists():
     def decorator(func):
         @wraps(func)

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -97,19 +97,19 @@ def setup_redis():
     return decorator
 
 
-def setup_async_redis():
-    def decorator(func):
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            result = func(self, *args, **kwargs)
-            RedisConnectionFactory.validate_async_redis(
-                self._redis_client, self._lib_name
-            )
-            return result
+# def setup_async_redis():
+#     def decorator(func):
+#         @wraps(func)
+#         def wrapper(self, *args, **kwargs):
+#             result = func(self, *args, **kwargs)
+#             RedisConnectionFactory.validate_async_redis(
+#                 self._redis_client, self._lib_name
+#             )
+#             return result
 
-        return wrapper
+#         return wrapper
 
-    return decorator
+#     return decorator
 
 
 def check_index_exists():
@@ -741,7 +741,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         )
         return self.set_client(client)
 
-    @setup_async_redis()
+    @setup_redis()
     def set_client(self, client: aredis.Redis):
         """Manually set the Redis client to use with the search index.
 

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -123,6 +123,7 @@ class RedisConnectionFactory:
         # fallback to env var REDIS_URL
         return AsyncRedis.from_url(get_address_from_env(), **kwargs)
 
+    @staticmethod
     def validate_redis(
         client: Union[Redis, AsyncRedis],
         lib_name: Optional[str] = None,
@@ -159,7 +160,7 @@ class RedisConnectionFactory:
     ) -> None:
         """Validates the sync client."""
         # Set client library name
-        client.client_setinfo("LIB-NAME", make_lib_name(lib_name))
+        client.client_setinfo("LIB-NAME", make_lib_name(lib_name)) # type: ignore
 
         # Get list of modules
         modules_list = convert_bytes(client.module_list())
@@ -175,7 +176,7 @@ class RedisConnectionFactory:
     ) -> None:
         """Validates the async client."""
         # Set client library name
-        res = await client.client_setinfo("LIB-NAME", make_lib_name(lib_name))
+        res = await client.client_setinfo("LIB-NAME", make_lib_name(lib_name)) # type: ignore
         print("SET ASYNC CLIENT NAME", res, flush=True)
 
         # Get list of modules

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -164,6 +164,7 @@ class RedisConnectionFactory:
         try:
             client.client_setinfo("LIB-NAME", _lib_name)  # type: ignore
         except ResponseError:
+            # Fall back to a simple log echo
             client.echo(_lib_name)
 
         # Get list of modules
@@ -184,6 +185,7 @@ class RedisConnectionFactory:
         try:
             await client.client_setinfo("LIB-NAME", _lib_name)  # type: ignore
         except ResponseError:
+            # Fall back to a simple log echo
             await client.echo(_lib_name)
 
         # Get list of modules

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -160,7 +160,7 @@ class RedisConnectionFactory:
     ) -> None:
         """Validates the sync client."""
         # Set client library name
-        client.client_setinfo("LIB-NAME", make_lib_name(lib_name)) # type: ignore
+        client.client_setinfo("LIB-NAME", make_lib_name(lib_name))  # type: ignore
 
         # Get list of modules
         modules_list = convert_bytes(client.module_list())
@@ -176,7 +176,7 @@ class RedisConnectionFactory:
     ) -> None:
         """Validates the async client."""
         # Set client library name
-        res = await client.client_setinfo("LIB-NAME", make_lib_name(lib_name)) # type: ignore
+        res = await client.client_setinfo("LIB-NAME", make_lib_name(lib_name))  # type: ignore
         print("SET ASYNC CLIENT NAME", res, flush=True)
 
         # Get list of modules

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -58,23 +58,7 @@ def test_validate_redis(client):
     assert lib_name["lib-name"] == EXPECTED_LIB_NAME
 
 
-@pytest.mark.asyncio
-async def test_validate_async_redis(async_client):
-    client = await async_client
-    RedisConnectionFactory.validate_async_redis(client)
-    lib_name = await client.client_info()
-    assert lib_name["lib-name"] == EXPECTED_LIB_NAME
-
-
-def test_custom_lib_name(client):
+def test_validate_redis_custom_lib_name(client):
     RedisConnectionFactory.validate_redis(client, "langchain_v0.1.0")
     lib_name = client.client_info()
-    assert lib_name["lib-name"] == f"redis-py(redisvl_v{__version__};langchain_v0.1.0)"
-
-
-@pytest.mark.asyncio
-async def test_async_custom_lib_name(async_client):
-    client = await async_client
-    RedisConnectionFactory.validate_async_redis(client, "langchain_v0.1.0")
-    lib_name = await client.client_info()
     assert lib_name["lib-name"] == f"redis-py(redisvl_v{__version__};langchain_v0.1.0)"

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -11,6 +11,35 @@ from redisvl.version import __version__
 EXPECTED_LIB_NAME = f"redis-py(redisvl_v{__version__})"
 
 
+def compare_versions(version1, version2):
+    """
+    Compare two Redis version strings numerically.
+
+    Parameters:
+    version1 (str): The first version string (e.g., "7.2.4").
+    version2 (str): The second version string (e.g., "6.2.1").
+
+    Returns:
+    int: -1 if version1 < version2, 0 if version1 == version2, 1 if version1 > version2.
+    """
+    v1_parts = list(map(int, version1.split(".")))
+    v2_parts = list(map(int, version2.split(".")))
+
+    for v1, v2 in zip(v1_parts, v2_parts):
+        if v1 < v2:
+            return False
+        elif v1 > v2:
+            return True
+
+    # If the versions are equal so far, compare the lengths of the version parts
+    if len(v1_parts) < len(v2_parts):
+        return False
+    elif len(v1_parts) > len(v2_parts):
+        return True
+
+    return True
+
+
 def test_get_address_from_env(redis_url):
     assert get_address_from_env() == redis_url
 
@@ -53,12 +82,18 @@ def test_unknown_redis():
 
 
 def test_validate_redis(client):
+    redis_version = client.info()["redis_version"]
+    if not compare_versions(redis_version, "7.2.0"):
+        pytest.skip("Not using a late enough version of Redis")
     RedisConnectionFactory.validate_redis(client)
     lib_name = client.client_info()
     assert lib_name["lib-name"] == EXPECTED_LIB_NAME
 
 
 def test_validate_redis_custom_lib_name(client):
+    redis_version = client.info()["redis_version"]
+    if not compare_versions(redis_version, "7.2.0"):
+        pytest.skip("Not using a late enough version of Redis")
     RedisConnectionFactory.validate_redis(client, "langchain_v0.1.0")
     lib_name = client.client_info()
     assert lib_name["lib-name"] == f"redis-py(redisvl_v{__version__};langchain_v0.1.0)"


### PR DESCRIPTION
We need to be able to track the usage of clients for measuring adoption and impact. The `CLIENT SETINFO` command can be used for this purpose. The required string format is documented [here](https://redis.io/docs/latest/commands/client-setinfo/#:~:text=The%20CLIENT%20SETINFO%20command%20assigns,CLIENT%20LIST%20and%20CLIENT%20INFO%20).

### Variants

- Standalone RedisVL:
```
CLIENT SETINFO LIB-NAME redis-py(redisvl_v0.2.0)
CLIENT SETINFO LIB-VER 5.0.4
```

- Abstraction layers (like LlamaIndex or LangChain):
```
CLIENT SETINFO LIB-NAME redis-py(redisvl_v0.2.0;llama-index-vector-stores-redis_v0.1.0)
CLIENT SETINFO LIB-VER 5.0.4
```

### Constraints
- RedisVL uses both Async connection and standard connection instances from Redis Py
	- So the technique to run this command needs to properly handle this...
- Other wrappers around RedisVL like LangChain and LlamaIndex will need to pass through their lib_name
- These libraries generally support the notion of providing your own client instance OR providing the connection string and performing the connection on your behalf -- which also adds some difficulty.


### Planned Route

In order to build the proper name string, all clients that wrap redis-py will need to use the following format:
```
{package-name}_v{version}
```

RedisVL will implement the default which is `redisvl_v0.x.x`, but outer wrappers of RedisVL can implement their own by using a lib_name `kwarg` on the index class like 

```
SearchIndex(lib_name="langchain_v0.2.1")
```