### PR TITLE
Fix Num filter should handle 0 value

### DIFF
--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -375,9 +375,8 @@ class Num(FilterField):
 
     def __str__(self) -> str:
         """Return the Redis Query string for the Numeric filter"""
-        if not self._value:
+        if self._value is None:
             return "*"
-
         if self._operator == FilterOperator.EQ or self._operator == FilterOperator.NE:
             return self.OPERATOR_MAP[self._operator] % (
                 self._field,

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -400,3 +400,17 @@ def test_sort_vector_query(index, sorted_vector_query):
 def test_sort_range_query(index, sorted_range_query):
     t = Text("job") % ""
     search(sorted_range_query, index, t, 7, sort=True)
+
+def test_query_with_chunk_number_zero():
+    doc_base_id = "8675309"
+    file_id = "e9ffbac9ff6f67cc"
+    chunk_num = 0
+
+    filter_conditions = (
+        (Tag("doc_base_id") == doc_base_id) &
+        (Tag("file_id") == file_id) &
+        (Num("chunk_number") == chunk_num)
+    )
+
+    expected_query_str = '((@doc_base_id:{8675309} @file_id:{e9ffbac9ff6f67cc}) @chunk_number:[0 0])'
+    assert str(filter_conditions) == expected_query_str, "Query with chunk_number zero is incorrect"

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -285,3 +285,7 @@ def test_filters_combination():
     tf3 = Text("text_field") == None
     tf4 = Geo("geo_field") == GeoRadius(1.0, 2.0, 3, "km")
     assert str(tf1 & tf2 & tf3 & tf4) == str(tf1 & tf4)
+
+def test_num_filter_zero():
+    num_filter = Num("chunk_number") == 0
+    assert str(num_filter) == "@chunk_number:[0 0]", "Num filter should handle zero correctly"


### PR DESCRIPTION
Ensures that the Num class correctly handles 0 as a valid value. This PR modifies the `__str__` method to check if the value is `None` explicitly instead of using a condition that treats 0 as false.

Context:
```
Q: Is there a way possible to set the filter to a num 0. Below is the client query,
filter_conditions: FilterExpression = ((Tag("doc_base_id") == doc_base.id) &
                        (Tag("file_id") == file_id) &
                        (Num("chunk_number") == chunk_num))
When I instantiate the query with a non-zero chunk_number, the generated query looks as expected and the result only contains the requested chunk:
[doc_base.id](http://doc_base.id/)
'AIGuildDemo'
file_id
'e9ffbac9ff6f67cc'
chunk_num
1
str(filter_conditions)
'((@doc_base_id:{AIGuildDemo} @file_id:{e9ffbac9ff6f67cc}) @chunk_number:[1 1])'
However, when I set chunk_num to 0, chunk_number gets left out of the query entirely, and the result of the query is all chunks with that doc_base_id and file_id:
[doc_base.id](http://doc_base.id/)
'AIGuildDemo'
file_id
'e9ffbac9ff6f67cc'
chunk_num
0
str(filter_conditions)
'(@doc_base_id:{AIGuildDemo} @file_id:{e9ffbac9ff6f67cc})'
Based on a look through redisvl documentation, it seems that this issue might be related to this feature where passing “None” will drop the filter
Is there way way to use redisvl to filter entries where chunk_number is 0?
```