### PR TITLE
Fix index loading empty array

### DIFF
--- a/tests/unit/test_async_search_index.py
+++ b/tests/unit/test_async_search_index.py
@@ -130,6 +130,13 @@ async def test_search_index_load_preprocess(async_client, async_index):
 
 
 @pytest.mark.asyncio
+async def test_search_index_load_empty(async_client, async_index):
+    async_index.set_client(async_client)
+    await async_index.create(overwrite=True, drop=True)
+    await async_index.load([])
+
+
+@pytest.mark.asyncio
 async def test_no_id_field(async_client, async_index):
     async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -125,6 +125,12 @@ def test_search_index_load_preprocess(client, index):
         index.load(data, id_field="id", preprocess=bad_preprocess)
 
 
+def test_search_index_load_empty(client, index):
+    index.set_client(client)
+    index.create(overwrite=True, drop=True)
+    index.load([])
+
+
 def test_no_id_field(client, index):
     index.set_client(client)
     index.create(overwrite=True, drop=True)


### PR DESCRIPTION
This PR fixes the case when a user tries to load an empty array using `index.load([], ...)`. Currently, this borks and throws an exception for something that should have been captured in one of our tests. 

Test conditions added, and big fixed.