### PR TITLE
adds check to ensure correct embedding vector dimensions are used

### DIFF
--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -235,6 +235,8 @@ class SemanticCache(BaseLLMCache):
         return cache_hits
 
     def _check_vector_dims(self, vector: List[float]):
+        """Checks the size of the provided vector and raises an error if it
+        doesn't match the search index vector dimensions."""
         schema_vector_dims = self._index.schema.fields[self.vector_field_name].attrs.dims  # type: ignore
         if schema_vector_dims != len(vector):
             raise ValueError(


### PR DESCRIPTION
Currently our semantic cache allows for specifying the vector in calls to store() and check(), but if the vector dimension does not match the schema dimensions this fails silently. This PR adds a check to verify correct vector dimensions and raises an error if they do not match.