### PR TITLE
resets cache ttl when no arg is passed

### DIFF
--- a/redisvl/extensions/llmcache/base.py
+++ b/redisvl/extensions/llmcache/base.py
@@ -27,6 +27,8 @@ class BaseLLMCache:
             if not isinstance(ttl, int):
                 raise ValueError(f"TTL must be an integer value, got {ttl}")
             self._ttl = int(ttl)
+        else:
+            self._ttl = None
 
     def clear(self) -> None:
         """Clear the LLMCache of all keys in the index."""

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -70,6 +70,12 @@ def test_set_ttl(cache):
     assert cache.ttl == 5
 
 
+def test_reset_ttl(cache):
+    cache.set_ttl(4)
+    cache.set_ttl()
+    assert cache.ttl is None
+
+
 # Test basic store and check functionality
 def test_store_and_check(cache, vectorizer):
     prompt = "This is a test prompt."


### PR DESCRIPTION
This PR resets the cache entry TTL to infinite/no expiration if we call `set_ttl()` with no arguments. Otherwise once a TTL is set, it can only be changed to another integer.