### PR TITLE
Standardize extensions redis init

### DIFF
--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -27,7 +27,7 @@ class SemanticCache(BaseLLMCache):
         ttl: Optional[int] = None,
         vectorizer: Optional[BaseVectorizer] = None,
         redis_client: Optional[Redis] = None,
-        redis_url: Optional[str] = None,
+        redis_url: str = "redis://localhost:6379",
         connection_kwargs: Dict[str, Any] = {},
         **kwargs,
     ):
@@ -47,7 +47,7 @@ class SemanticCache(BaseLLMCache):
                 Defaults to HFTextVectorizer.
             redis_client(Optional[Redis], optional): A redis client connection instance.
                 Defaults to None.
-            redis_url (Optional[str], optional): The redis url. Defaults to None.
+            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             connection_kwargs (Dict[str, Any]): The connection arguments
                 for the redis client. Defaults to empty {}.
 
@@ -97,8 +97,6 @@ class SemanticCache(BaseLLMCache):
             self._index.set_client(redis_client)
         elif redis_url:
             self._index.connect(redis_url=redis_url, **connection_kwargs)
-        else:
-            raise ValueError("Must provide either a redis client or redis url string.")
 
         # initialize other components
         self.default_return_fields = [

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -27,8 +27,8 @@ class SemanticCache(BaseLLMCache):
         ttl: Optional[int] = None,
         vectorizer: Optional[BaseVectorizer] = None,
         redis_client: Optional[Redis] = None,
-        redis_url: str = "redis://localhost:6379",
-        connection_args: Dict[str, Any] = {},
+        redis_url: Optional[str] = None,
+        connection_kwargs: Dict[str, Any] = {},
         **kwargs,
     ):
         """Semantic Cache for Large Language Models.
@@ -43,14 +43,13 @@ class SemanticCache(BaseLLMCache):
                 cache. Defaults to 0.1.
             ttl (Optional[int], optional): The time-to-live for records cached
                 in Redis. Defaults to None.
-            vectorizer (BaseVectorizer, optional): The vectorizer for the cache.
+            vectorizer (Optional[BaseVectorizer], optional): The vectorizer for the cache.
                 Defaults to HFTextVectorizer.
-            redis_client(Redis, optional): A redis client connection instance.
+            redis_client(Optional[Redis], optional): A redis client connection instance.
                 Defaults to None.
-            redis_url (str, optional): The redis url. Defaults to
-                "redis://localhost:6379".
-            connection_args (Dict[str, Any], optional): The connection arguments
-                for the redis client. Defaults to None.
+            redis_url (Optional[str], optional): The redis url. Defaults to None.
+            connection_kwargs (Dict[str, Any]): The connection arguments
+                for the redis client. Defaults to empty {}.
 
         Raises:
             TypeError: If an invalid vectorizer is provided.
@@ -96,8 +95,10 @@ class SemanticCache(BaseLLMCache):
         # handle redis connection
         if redis_client:
             self._index.set_client(redis_client)
+        elif redis_url:
+            self._index.connect(redis_url=redis_url, **connection_kwargs)
         else:
-            self._index.connect(redis_url=redis_url, **connection_args)
+            raise ValueError("Must provide either a redis client or redis url string.")
 
         # initialize other components
         self.default_return_fields = [

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -86,7 +86,7 @@ class SemanticRouter(BaseModel):
         vectorizer: Optional[BaseVectorizer] = None,
         routing_config: Optional[RoutingConfig] = None,
         redis_client: Optional[Redis] = None,
-        redis_url: Optional[str] = None,
+        redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
         **kwargs,
     ):
@@ -98,7 +98,7 @@ class SemanticRouter(BaseModel):
             vectorizer (BaseVectorizer, optional): The vectorizer used to embed route references. Defaults to default HFTextVectorizer.
             routing_config (RoutingConfig, optional): Configuration for routing behavior. Defaults to the default RoutingConfig.
             redis_client (Optional[Redis], optional): Redis client for connection. Defaults to None.
-            redis_url (Optional[str], optional): Redis URL for connection. Defaults to None.
+            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             overwrite (bool, optional): Whether to overwrite existing index. Defaults to False.
             **kwargs: Additional arguments.
         """
@@ -120,7 +120,7 @@ class SemanticRouter(BaseModel):
     def _initialize_index(
         self,
         redis_client: Optional[Redis] = None,
-        redis_url: Optional[str] = None,
+        redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
         **connection_kwargs,
     ):
@@ -132,8 +132,6 @@ class SemanticRouter(BaseModel):
             self._index.set_client(redis_client)
         elif redis_url:
             self._index.connect(redis_url=redis_url, **connection_kwargs)
-        else:
-            raise ValueError("Must provide either a redis client or redis url string.")
 
         existed = self._index.exists()
         self._index.create(overwrite=overwrite)
@@ -480,7 +478,7 @@ class SemanticRouter(BaseModel):
         cls,
         data: Dict[str, Any],
         redis_client: Optional[Redis] = None,
-        redis_url: Optional[str] = None,
+        redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
         **kwargs,
     ) -> "SemanticRouter":
@@ -489,7 +487,7 @@ class SemanticRouter(BaseModel):
         Args:
             data (Dict[str, Any]): The dictionary containing the semantic router data.
             redis_client (Optional[Redis]): Redis client for connection.
-            redis_url (Optional[str]): Redis URL for connection.
+            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             overwrite (bool): Whether to overwrite existing index.
             **kwargs: Additional arguments.
 
@@ -566,7 +564,7 @@ class SemanticRouter(BaseModel):
         cls,
         file_path: str,
         redis_client: Optional[Redis] = None,
-        redis_url: Optional[str] = None,
+        redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
         **kwargs,
     ) -> "SemanticRouter":
@@ -575,7 +573,7 @@ class SemanticRouter(BaseModel):
         Args:
             file_path (str): The path to the YAML file.
             redis_client (Optional[Redis]): Redis client for connection.
-            redis_url (Optional[str]): Redis URL for connection.
+            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             overwrite (bool): Whether to overwrite existing index.
             **kwargs: Additional arguments.
 

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -88,6 +88,7 @@ class SemanticRouter(BaseModel):
         redis_client: Optional[Redis] = None,
         redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
+        connection_kwargs: Dict[str, Any] = {},
         **kwargs,
     ):
         """Initialize the SemanticRouter.
@@ -100,7 +101,8 @@ class SemanticRouter(BaseModel):
             redis_client (Optional[Redis], optional): Redis client for connection. Defaults to None.
             redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             overwrite (bool, optional): Whether to overwrite existing index. Defaults to False.
-            **kwargs: Additional arguments.
+            connection_kwargs (Dict[str, Any]): The connection arguments
+                for the redis client. Defaults to empty {}.
         """
         # Set vectorizer default
         if vectorizer is None:
@@ -115,7 +117,7 @@ class SemanticRouter(BaseModel):
             vectorizer=vectorizer,
             routing_config=routing_config,
         )
-        self._initialize_index(redis_client, redis_url, overwrite)
+        self._initialize_index(redis_client, redis_url, overwrite, **connection_kwargs)
 
     def _initialize_index(
         self,
@@ -477,19 +479,12 @@ class SemanticRouter(BaseModel):
     def from_dict(
         cls,
         data: Dict[str, Any],
-        redis_client: Optional[Redis] = None,
-        redis_url: str = "redis://localhost:6379",
-        overwrite: bool = False,
         **kwargs,
     ) -> "SemanticRouter":
         """Create a SemanticRouter from a dictionary.
 
         Args:
             data (Dict[str, Any]): The dictionary containing the semantic router data.
-            redis_client (Optional[Redis]): Redis client for connection.
-            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
-            overwrite (bool): Whether to overwrite existing index.
-            **kwargs: Additional arguments.
 
         Returns:
             SemanticRouter: The semantic router instance.
@@ -531,9 +526,6 @@ class SemanticRouter(BaseModel):
             routes=routes,
             vectorizer=vectorizer,
             routing_config=routing_config,
-            redis_client=redis_client,
-            redis_url=redis_url,
-            overwrite=overwrite,
             **kwargs,
         )
 
@@ -563,19 +555,12 @@ class SemanticRouter(BaseModel):
     def from_yaml(
         cls,
         file_path: str,
-        redis_client: Optional[Redis] = None,
-        redis_url: str = "redis://localhost:6379",
-        overwrite: bool = False,
         **kwargs,
     ) -> "SemanticRouter":
         """Create a SemanticRouter from a YAML file.
 
         Args:
             file_path (str): The path to the YAML file.
-            redis_client (Optional[Redis]): Redis client for connection.
-            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
-            overwrite (bool): Whether to overwrite existing index.
-            **kwargs: Additional arguments.
 
         Returns:
             SemanticRouter: The semantic router instance.
@@ -601,9 +586,6 @@ class SemanticRouter(BaseModel):
             yaml_data = yaml.safe_load(f)
             return cls.from_dict(
                 yaml_data,
-                redis_client=redis_client,
-                redis_url=redis_url,
-                overwrite=overwrite,
                 **kwargs,
             )
 

--- a/redisvl/extensions/session_manager/semantic_session.py
+++ b/redisvl/extensions/session_manager/semantic_session.py
@@ -26,7 +26,7 @@ class SemanticSessionManager(BaseSessionManager):
         vectorizer: Optional[BaseVectorizer] = None,
         distance_threshold: float = 0.3,
         redis_client: Optional[Redis] = None,
-        redis_url: Optional[str] = None,
+        redis_url: str = "redis://localhost:6379",
         connection_kwargs: Dict[str, Any] = {},
         **kwargs,
     ):
@@ -50,8 +50,7 @@ class SemanticSessionManager(BaseSessionManager):
                 included in the context. Defaults to 0.3.
             redis_client (Optional[Redis]): A Redis client instance. Defaults to
                 None.
-            redis_url (Optional[str]): The URL of the Redis instance. Defaults
-                to None.
+            redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             connection_kwargs (Dict[str, Any]): The connection arguments
                 for the redis client. Defaults to empty {}.
 
@@ -99,8 +98,6 @@ class SemanticSessionManager(BaseSessionManager):
             self._index.set_client(redis_client)
         elif redis_url:
             self._index.connect(redis_url=redis_url, **connection_kwargs)
-        else:
-            raise ValueError("Must provide either a redis client or redis url string.")
 
         self._index.create(overwrite=False)
 

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -40,19 +40,17 @@ def cache_with_ttl(vectorizer, redis_url):
 
 
 @pytest.fixture
-def cache_with_redis_client(vectorizer, client, redis_url):
+def cache_with_redis_client(vectorizer, client):
     cache_instance = SemanticCache(
         vectorizer=vectorizer,
         redis_client=client,
         distance_threshold=0.2,
-        redis_url=redis_url,
     )
     yield cache_instance
     cache_instance.clear()  # Clear cache after each test
     cache_instance._index.delete(True)  # Clean up index
 
 
-# # Test handling invalid input for check method
 def test_bad_ttl(cache):
     with pytest.raises(ValueError):
         cache.set_ttl(2.5)
@@ -76,7 +74,6 @@ def test_reset_ttl(cache):
     assert cache.ttl is None
 
 
-# Test basic store and check functionality
 def test_store_and_check(cache, vectorizer):
     prompt = "This is a test prompt."
     response = "This is a test response."
@@ -91,7 +88,6 @@ def test_store_and_check(cache, vectorizer):
     assert "metadata" not in check_result[0]
 
 
-# Test clearing the cache
 def test_clear(cache, vectorizer):
     prompt = "This is a test prompt."
     response = "This is a test response."
@@ -139,7 +135,6 @@ def test_check_no_match(cache, vectorizer):
     assert len(check_result) == 0
 
 
-# Test handling invalid input for check method
 def test_check_invalid_input(cache):
     with pytest.raises(ValueError):
         cache.check()
@@ -148,7 +143,11 @@ def test_check_invalid_input(cache):
         cache.check(prompt="test", return_fields="bad value")
 
 
-# Test storing with metadata
+def test_no_connection_info(vectorizer):
+    with pytest.raises(ValueError):
+        SemanticCache(vectorizer=vectorizer, distance_threshold=0.2)
+
+
 def test_store_with_metadata(cache, vectorizer):
     prompt = "This is another test prompt."
     response = "This is another test response."
@@ -165,7 +164,6 @@ def test_store_with_metadata(cache, vectorizer):
     assert check_result[0]["prompt"] == prompt
 
 
-# Test storing with invalid metadata
 def test_store_with_invalid_metadata(cache, vectorizer):
     prompt = "This is another test prompt."
     response = "This is another test response."
@@ -179,7 +177,6 @@ def test_store_with_invalid_metadata(cache, vectorizer):
         cache.store(prompt, response, vector=vector, metadata=metadata)
 
 
-# Test setting and getting the distance threshold
 def test_distance_threshold(cache):
     initial_threshold = cache.distance_threshold
     new_threshold = 0.1
@@ -189,14 +186,12 @@ def test_distance_threshold(cache):
     assert cache.distance_threshold != initial_threshold
 
 
-# Test out of range distance threshold
 def test_distance_threshold_out_of_range(cache):
     out_of_range_threshold = -1
     with pytest.raises(ValueError):
         cache.set_threshold(out_of_range_threshold)
 
 
-# Test storing and retrieving multiple items
 def test_multiple_items(cache, vectorizer):
     prompts_responses = {
         "prompt1": "response1",
@@ -217,12 +212,10 @@ def test_multiple_items(cache, vectorizer):
         assert "metadata" not in check_result[0]
 
 
-# Test retrieving underlying SearchIndex for the cache.
 def test_get_index(cache):
     assert isinstance(cache.index, SearchIndex)
 
 
-# Test basic functionality with cache created with user-provided Redis client
 def test_store_and_check_with_provided_client(cache_with_redis_client, vectorizer):
     prompt = "This is a test prompt."
     response = "This is a test response."
@@ -237,13 +230,11 @@ def test_store_and_check_with_provided_client(cache_with_redis_client, vectorize
     assert "metadata" not in check_result[0]
 
 
-# Test deleting the cache
 def test_delete(cache_no_cleanup):
     cache_no_cleanup.delete()
     assert not cache_no_cleanup.index.exists()
 
 
-# Test we can only store and check vectors of correct dimensions
 def test_vector_size(cache, vectorizer):
     prompt = "This is test prompt."
     response = "This is a test response."

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from time import sleep
 
 import pytest
+from redis.exceptions import ConnectionError
 
 from redisvl.extensions.llmcache import SemanticCache
 from redisvl.index.index import SearchIndex
@@ -143,9 +144,13 @@ def test_check_invalid_input(cache):
         cache.check(prompt="test", return_fields="bad value")
 
 
-def test_no_connection_info(vectorizer):
-    with pytest.raises(ValueError):
-        SemanticCache(vectorizer=vectorizer, distance_threshold=0.2)
+def test_bad_connection_info(vectorizer):
+    with pytest.raises(ConnectionError):
+        SemanticCache(
+            vectorizer=vectorizer,
+            distance_threshold=0.2,
+            redis_url="redis://localhost:6389",
+        )
 
 
 def test_store_with_metadata(cache, vectorizer):

--- a/tests/integration/test_semantic_router.py
+++ b/tests/integration/test_semantic_router.py
@@ -225,3 +225,13 @@ def test_idempotent_to_dict(semantic_router):
         router_dict, redis_client=semantic_router._index.client
     )
     assert new_router.to_dict() == router_dict
+
+
+def test_no_connection_info(routes):
+    with pytest.raises(ValueError):
+        SemanticRouter(
+            name="test-router",
+            routes=routes,
+            routing_config=RoutingConfig(distance_threshold=0.3, max_k=2),
+            overwrite=False,
+        )

--- a/tests/integration/test_semantic_router.py
+++ b/tests/integration/test_semantic_router.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+from redis.exceptions import ConnectionError
 
 from redisvl.extensions.router import SemanticRouter
 from redisvl.extensions.router.schema import Route, RoutingConfig
@@ -227,11 +228,12 @@ def test_idempotent_to_dict(semantic_router):
     assert new_router.to_dict() == router_dict
 
 
-def test_no_connection_info(routes):
-    with pytest.raises(ValueError):
+def test_bad_connection_info(routes):
+    with pytest.raises(ConnectionError):
         SemanticRouter(
             name="test-router",
             routes=routes,
             routing_config=RoutingConfig(distance_threshold=0.3, max_k=2),
+            redis_url="redis://localhost:6389",  # bad connection url
             overwrite=False,
         )

--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -46,6 +46,16 @@ def test_specify_redis_client(client):
     assert isinstance(session._client, type(client))
 
 
+def test_specify_redis_url(client):
+    session = StandardSessionManager(
+        name="test_app",
+        session_tag="abc",
+        user_tag="123",
+        redis_url="redis://localhost:6379",
+    )
+    assert isinstance(session._client, type(client))
+
+
 def test_standard_bad_connection_info():
     with pytest.raises(ConnectionError):
         StandardSessionManager(

--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -2,6 +2,7 @@ import json
 import time
 
 import pytest
+from redis.exceptions import ConnectionError
 
 from redisvl.extensions.session_manager import (
     SemanticSessionManager,
@@ -45,9 +46,14 @@ def test_specify_redis_client(client):
     assert isinstance(session._client, type(client))
 
 
-def test_standard_no_connection_info():
-    with pytest.raises(ValueError):
-        StandardSessionManager(name="test_app", session_tag="abc", user_tag="123")
+def test_standard_bad_connection_info():
+    with pytest.raises(ConnectionError):
+        StandardSessionManager(
+            name="test_app",
+            session_tag="abc",
+            user_tag="123",
+            redis_url="redis://localhost:6389",  # bad url
+        )
 
 
 def test_standard_store_and_get(standard_session):
@@ -374,9 +380,14 @@ def test_semantic_specify_client(client):
     assert isinstance(session._index.client, type(client))
 
 
-def test_semantic_no_connection_info():
-    with pytest.raises(ValueError):
-        SemanticSessionManager(name="test_app", session_tag="abc", user_tag="123")
+def test_semantic_bad_connection_info():
+    with pytest.raises(ConnectionError):
+        SemanticSessionManager(
+            name="test_app",
+            session_tag="abc",
+            user_tag="123",
+            redis_url="redis://localhost:6389",
+        )
 
 
 def test_semantic_set_scope(semantic_session, app_name, user_tag, session_tag):


### PR DESCRIPTION
Standardizes the way our extension modules connect to redis.

- First check for client
- Then check for URL
- Then raise a CLEAR error if neither are provided