### PR TITLE
Refactor search index to improve connection handling

### DIFF
--- a/docs/examples/openai_qna.ipynb
+++ b/docs/examples/openai_qna.ipynb
@@ -651,7 +651,7 @@
     "client = redis.Redis.from_url(\"redis://localhost:6379\")\n",
     "schema = IndexSchema.from_yaml(\"wiki_schema.yaml\")\n",
     "\n",
-    "index = AsyncSearchIndex(schema, client)\n",
+    "index = await AsyncSearchIndex(schema).set_client(client)\n",
     "\n",
     "await index.create()"
    ]

--- a/docs/user_guide/getting_started_01.ipynb
+++ b/docs/user_guide/getting_started_01.ipynb
@@ -486,7 +486,7 @@
     "client = Redis.from_url(\"redis://localhost:6379\")\n",
     "\n",
     "index = AsyncSearchIndex.from_dict(schema)\n",
-    "index.set_client(client)"
+    "await index.set_client(client)"
    ]
   },
   {

--- a/redisvl/extensions/session_manager/standard_session.py
+++ b/redisvl/extensions/session_manager/standard_session.py
@@ -51,7 +51,7 @@ class StandardSessionManager(BaseSessionManager):
             self._client = RedisConnectionFactory.get_redis_connection(
                 redis_url, **connection_kwargs
             )
-            RedisConnectionFactory.validate_redis(self._client)
+            RedisConnectionFactory.validate_sync_redis(self._client)
 
         self.set_scope(session_tag, user_tag)
 

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -63,7 +63,7 @@ def test_search_index_from_dict(async_index_from_dict):
 
 @pytest.mark.asyncio
 async def test_search_index_from_existing(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True)
 
     try:
@@ -106,7 +106,9 @@ async def test_search_index_from_existing_complex(async_client):
             },
         ],
     }
-    async_index = AsyncSearchIndex.from_dict(schema, redis_client=async_client)
+    async_index = await AsyncSearchIndex.from_dict(schema).set_client(
+        redis_client=async_client
+    )
     await async_index.create(overwrite=True)
 
     try:
@@ -127,25 +129,32 @@ def test_search_index_no_prefix(index_schema):
     assert async_index.key("foo") == "foo"
 
 
-def test_search_index_redis_url(redis_url, index_schema):
-    async_index = AsyncSearchIndex(schema=index_schema, redis_url=redis_url)
+@pytest.mark.asyncio
+async def test_search_index_redis_url(redis_url, index_schema):
+    async_index = await AsyncSearchIndex(schema=index_schema).connect(
+        redis_url=redis_url
+    )
     assert async_index.client
 
     async_index.disconnect()
     assert async_index.client == None
 
 
-def test_search_index_client(async_client, index_schema):
-    async_index = AsyncSearchIndex(schema=index_schema, redis_client=async_client)
+@pytest.mark.asyncio
+async def test_search_index_client(async_client, index_schema):
+    async_index = await AsyncSearchIndex(schema=index_schema).set_client(
+        redis_client=async_client
+    )
     assert async_index.client == async_client
 
 
-def test_search_index_set_client(async_client, client, async_index):
-    async_index.set_client(async_client)
+@pytest.mark.asyncio
+async def test_search_index_set_client(async_client, client, async_index):
+    await async_index.set_client(async_client)
     assert async_index.client == async_client
     # should not be able to set the sync client here
     with pytest.raises(TypeError):
-        async_index.set_client(client)
+        await async_index.set_client(client)
 
     async_index.disconnect()
     assert async_index.client == None
@@ -153,7 +162,7 @@ def test_search_index_set_client(async_client, client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_create(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     assert await async_index.exists()
     assert async_index.name in convert_bytes(
@@ -163,7 +172,7 @@ async def test_search_index_create(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_delete(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
     assert not await async_index.exists()
@@ -174,7 +183,7 @@ async def test_search_index_delete(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_clear(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     data = [{"id": "1", "test": "foo"}]
     await async_index.load(data, id_field="id")
@@ -186,7 +195,7 @@ async def test_search_index_clear(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_drop_key(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
     keys = await async_index.load(data, id_field="id")
@@ -199,7 +208,7 @@ async def test_search_index_drop_key(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_drop_keys(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     data = [
         {"id": "1", "test": "foo"},
@@ -219,7 +228,7 @@ async def test_search_index_drop_keys(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_load_and_fetch(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     data = [{"id": "1", "test": "foo"}]
     await async_index.load(data, id_field="id")
@@ -238,7 +247,7 @@ async def test_search_index_load_and_fetch(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_load_preprocess(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     data = [{"id": "1", "test": "foo"}]
 
@@ -263,14 +272,14 @@ async def test_search_index_load_preprocess(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_search_index_load_empty(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     await async_index.load([])
 
 
 @pytest.mark.asyncio
 async def test_no_id_field(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     bad_data = [{"wrong_key": "1", "value": "test"}]
 
@@ -281,7 +290,7 @@ async def test_no_id_field(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_check_index_exists_before_delete(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
     with pytest.raises(ValueError):
@@ -290,7 +299,7 @@ async def test_check_index_exists_before_delete(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_check_index_exists_before_search(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
 
@@ -306,7 +315,7 @@ async def test_check_index_exists_before_search(async_client, async_index):
 
 @pytest.mark.asyncio
 async def test_check_index_exists_before_info(async_client, async_index):
-    async_index.set_client(async_client)
+    await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
 

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -163,8 +163,18 @@ def test_validate_redis(client):
     redis_version = client.info()["redis_version"]
     if not compare_versions(redis_version, "7.2.0"):
         pytest.skip("Not using a late enough version of Redis")
-    RedisConnectionFactory.validate_redis(client)
+    RedisConnectionFactory.validate_sync_redis(client)
     lib_name = client.client_info()
+    assert lib_name["lib-name"] == EXPECTED_LIB_NAME
+
+
+@pytest.mark.asyncio
+async def test_validate_async_redis(async_client):
+    redis_version = (await async_client.info())["redis_version"]
+    if not compare_versions(redis_version, "7.2.0"):
+        pytest.skip("Not using a late enough version of Redis")
+    await RedisConnectionFactory.validate_async_redis(async_client)
+    lib_name = await async_client.client_info()
     assert lib_name["lib-name"] == EXPECTED_LIB_NAME
 
 
@@ -172,6 +182,16 @@ def test_validate_redis_custom_lib_name(client):
     redis_version = client.info()["redis_version"]
     if not compare_versions(redis_version, "7.2.0"):
         pytest.skip("Not using a late enough version of Redis")
-    RedisConnectionFactory.validate_redis(client, "langchain_v0.1.0")
+    RedisConnectionFactory.validate_sync_redis(client, "langchain_v0.1.0")
     lib_name = client.client_info()
+    assert lib_name["lib-name"] == f"redis-py(redisvl_v{__version__};langchain_v0.1.0)"
+
+
+@pytest.mark.asyncio
+async def test_validate_async_redis_custom_lib_name(async_client):
+    redis_version = (await async_client.info())["redis_version"]
+    if not compare_versions(redis_version, "7.2.0"):
+        pytest.skip("Not using a late enough version of Redis")
+    await RedisConnectionFactory.validate_async_redis(async_client, "langchain_v0.1.0")
+    lib_name = await async_client.client_info()
     assert lib_name["lib-name"] == f"redis-py(redisvl_v{__version__};langchain_v0.1.0)"

--- a/tests/integration/test_flow_async.py
+++ b/tests/integration/test_flow_async.py
@@ -49,7 +49,7 @@ json_schema = {
 async def test_simple(async_client, schema, sample_data):
     index = AsyncSearchIndex.from_dict(schema)
     # assign client (only for testing)
-    index.set_client(async_client)
+    await index.set_client(async_client)
     # create the index
     await index.create(overwrite=True, drop=True)
 


### PR DESCRIPTION
We were leaning on a hack to run some async code in a sync setting. This was both dangerous and an anti-pattern. We also needed to refactor some of the shared and non-shared content between the BaseSearchIndex and derivatives.