### PR TITLE
Makes setting scope fully optional in session managers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -143,10 +143,10 @@ def clear_db(redis):
 def app_name():
     return "test_app"
 
-@pytest.fixture
-def session_tag():
-    return "123"
+##@pytest.fixture
+##def session_tag():
+##    return "123"
 
-@pytest.fixture
-def user_tag():
-    return "abc"
+##@pytest.fixture
+##def user_tag():
+##    return "abc"

--- a/conftest.py
+++ b/conftest.py
@@ -143,10 +143,3 @@ def clear_db(redis):
 def app_name():
     return "test_app"
 
-##@pytest.fixture
-##def session_tag():
-##    return "123"
-
-##@pytest.fixture
-##def user_tag():
-##    return "abc"

--- a/docs/user_guide/session_manager_07.ipynb
+++ b/docs/user_guide/session_manager_07.ipynb
@@ -74,7 +74,7 @@
    ],
    "source": [
     "from redisvl.extensions.session_manager import SemanticSessionManager\n",
-    "user_session = SemanticSessionManager(name='llm_chef', session_tag='123', user_tag='abc')\n",
+    "user_session = SemanticSessionManager(name='llm_chef')\n",
     "user_session.add_message({\"role\":\"system\", \"content\":\"You are a helpful chef, assisting people in making delicious meals\"})\n",
     "\n",
     "client = CohereClient()"

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -205,6 +205,9 @@ class SemanticCache(BaseLLMCache):
 
         return_fields = return_fields or self.default_return_fields
 
+        if self.entry_id_field_name not in return_fields:
+            return_fields.append(self.entry_id_field_name)
+
         if not isinstance(return_fields, list):
             raise TypeError("return_fields must be a list of field names")
 

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -222,7 +222,8 @@ class SemanticCache(BaseLLMCache):
         cache_hits: List[Dict[str, Any]] = self._index.query(query)
         # Process cache hits
         for hit in cache_hits:
-            self._refresh_ttl(hit[self.entry_id_field_name])
+            id = hit[self.entry_id_field_name]
+            self._refresh_ttl(self._index.key(id))
             # Check for metadata and deserialize
             if self.metadata_field_name in hit:
                 hit[self.metadata_field_name] = self.deserialize(

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -205,9 +205,6 @@ class SemanticCache(BaseLLMCache):
 
         return_fields = return_fields or self.default_return_fields
 
-        if self.entry_id_field_name not in return_fields:
-            return_fields.append(self.entry_id_field_name)
-
         if not isinstance(return_fields, list):
             raise TypeError("return_fields must be a list of field names")
 
@@ -225,8 +222,8 @@ class SemanticCache(BaseLLMCache):
         cache_hits: List[Dict[str, Any]] = self._index.query(query)
         # Process cache hits
         for hit in cache_hits:
-            id = hit[self.entry_id_field_name]
-            self._refresh_ttl(self._index.key(id))
+            key = hit["id"]
+            self._refresh_ttl(key)
             # Check for metadata and deserialize
             if self.metadata_field_name in hit:
                 hit[self.metadata_field_name] = self.deserialize(

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -13,7 +13,7 @@ from redisvl.utils.vectorize import BaseVectorizer, HFTextVectorizer
 class SemanticCache(BaseLLMCache):
     """Semantic Cache for Large Language Models."""
 
-    entry_id_field_name: str = "id"
+    entry_id_field_name: str = "_id"
     prompt_field_name: str = "prompt"
     vector_field_name: str = "prompt_vector"
     response_field_name: str = "response"

--- a/redisvl/extensions/session_manager/base_session.py
+++ b/redisvl/extensions/session_manager/base_session.py
@@ -7,7 +7,7 @@ from redisvl.query.filter import FilterExpression
 
 
 class BaseSessionManager:
-    id_field_name: str = "id_field"
+    id_field_name: str = "_id"
     role_field_name: str = "role"
     content_field_name: str = "content"
     tool_field_name: str = "tool_call_id"
@@ -61,7 +61,7 @@ class BaseSessionManager:
         top_k: int = 5,
         as_text: bool = False,
         raw: bool = False,
-        tag_filter: Optional[FilterExpression] = None,
+        session_tag: Optional[str] = None,
     ) -> Union[List[str], List[Dict[str, str]]]:
         """Retreive the recent conversation history in sequential order.
 
@@ -72,8 +72,8 @@ class BaseSessionManager:
                 or list of alternating prompts and responses.
             raw (bool): Whether to return the full Redis hash entry or just the
                 prompt and response
-            tag_filter (Optional[FilterExpression]) : The tag filter to filter
-                results by. Default is None and all sessions are searched.
+            session_tag (str): Tag to be added to entries to link to a specific
+                session. Defaults to instance uuid.
 
         Returns:
             Union[str, List[str]]: A single string transcription of the session

--- a/redisvl/extensions/session_manager/base_session.py
+++ b/redisvl/extensions/session_manager/base_session.py
@@ -1,6 +1,9 @@
 from typing import Any, Dict, List, Optional, Union
+from uuid import uuid4
 
 from redis import Redis
+
+from redisvl.query.filter import FilterExpression
 
 
 class BaseSessionManager:
@@ -9,12 +12,12 @@ class BaseSessionManager:
     content_field_name: str = "content"
     tool_field_name: str = "tool_call_id"
     timestamp_field_name: str = "timestamp"
+    session_field_name: str = "session_tag"
 
     def __init__(
         self,
         name: str,
-        session_tag: str,
-        user_tag: str,
+        session_tag: Optional[str] = None,
     ):
         """Initialize session memory with index
 
@@ -26,29 +29,10 @@ class BaseSessionManager:
         Args:
             name (str): The name of the session manager index.
             session_tag (str): Tag to be added to entries to link to a specific
-                session.
-            user_tag (str): Tag to be added to entries to link to a specific user.
+                session. Defaults to instance uuid.
         """
         self._name = name
-        self._user_tag = user_tag
-        self._session_tag = session_tag
-
-    def set_scope(
-        self,
-        session_tag: Optional[str] = None,
-        user_tag: Optional[str] = None,
-    ) -> None:
-        """Set the filter to apply to querries based on the desired scope.
-
-        This new scope persists until another call to set_scope is made, or if
-        scope specified in calls to get_recent.
-
-        Args:
-            session_tag (str): Id of the specific session to filter to. Default is
-                None.
-            user_tag (str): Id of the specific user to filter to. Default is None.
-        """
-        raise NotImplementedError
+        self._session_tag = session_tag or uuid4().hex
 
     def clear(self) -> None:
         """Clears the chat session history."""
@@ -75,23 +59,21 @@ class BaseSessionManager:
     def get_recent(
         self,
         top_k: int = 5,
-        session_tag: Optional[str] = None,
-        user_tag: Optional[str] = None,
         as_text: bool = False,
         raw: bool = False,
+        tag_filter: Optional[FilterExpression] = None,
     ) -> Union[List[str], List[Dict[str, str]]]:
         """Retreive the recent conversation history in sequential order.
 
         Args:
             top_k (int): The number of previous exchanges to return. Default is 5.
                 Note that one exchange contains both a prompt and response.
-            session_tag (str): Tag to be added to entries to link to a specific
-                session.
-            user_tag (str): Tag to be added to entries to link to a specific user.
             as_text (bool): Whether to return the conversation as a single string,
                 or list of alternating prompts and responses.
             raw (bool): Whether to return the full Redis hash entry or just the
                 prompt and response
+            tag_filter (Optional[FilterExpression]) : The tag filter to filter
+                results by. Default is None and all sessions are searched.
 
         Returns:
             Union[str, List[str]]: A single string transcription of the session
@@ -113,6 +95,7 @@ class BaseSessionManager:
                 recent conversation history.
             as_text (bool): Whether to return the conversation as a single string,
                 or list of alternating prompts and responses.
+
         Returns:
             Union[str, List[str]]: A single string transcription of the session
                 or list of strings if as_text is false.
@@ -141,7 +124,9 @@ class BaseSessionManager:
                     )
             return statements
 
-    def store(self, prompt: str, response: str) -> None:
+    def store(
+        self, prompt: str, response: str, session_tag: Optional[str] = None
+    ) -> None:
         """Insert a prompt:response pair into the session memory. A timestamp
         is associated with each exchange so that they can be later sorted
         in sequential ordering after retrieval.
@@ -149,25 +134,32 @@ class BaseSessionManager:
         Args:
             prompt (str): The user prompt to the LLM.
             response (str): The corresponding LLM response.
+            session_tag (Optional[str]): The tag to mark the message with. Defaults to None.
         """
         raise NotImplementedError
 
-    def add_messages(self, messages: List[Dict[str, str]]) -> None:
+    def add_messages(
+        self, messages: List[Dict[str, str]], session_tag: Optional[str] = None
+    ) -> None:
         """Insert a list of prompts and responses into the session memory.
         A timestamp is associated with each so that they can be later sorted
         in sequential ordering after retrieval.
 
         Args:
             messages (List[Dict[str, str]]): The list of user prompts and LLM responses.
+            session_tag (Optional[str]): The tag to mark the messages with. Defaults to None.
         """
         raise NotImplementedError
 
-    def add_message(self, message: Dict[str, str]) -> None:
+    def add_message(
+        self, message: Dict[str, str], session_tag: Optional[str] = None
+    ) -> None:
         """Insert a single prompt or response into the session memory.
         A timestamp is associated with it so that it can be later sorted
         in sequential ordering after retrieval.
 
         Args:
             message (Dict[str,str]): The user prompt or LLM response.
+            session_tag (Optional[str]): The tag to mark the message with. Defaults to None.
         """
         raise NotImplementedError

--- a/redisvl/extensions/session_manager/semantic_session.py
+++ b/redisvl/extensions/session_manager/semantic_session.py
@@ -255,19 +255,18 @@ class SemanticSessionManager(BaseSessionManager):
         """Retreive the recent conversation history in sequential order.
 
         Args:
-            as_text (bool): Whether to return the conversation as a single string,
-                          or list of alternating prompts and responses.
             top_k (int): The number of previous exchanges to return. Default is 5.
-                Note that one exchange contains both a prompt and a respoonse.
             session_tag (str): Tag to be added to entries to link to a specific
                 session.
             user_tag (str): Tag to be added to entries to link to a specific user.
+            as_text (bool): Whether to return the conversation as a single string,
+                or list of alternating prompts and responses.
             raw (bool): Whether to return the full Redis hash entry or just the
                 prompt and response
 
         Returns:
             Union[str, List[str]]: A single string transcription of the session
-                                   or list of strings if as_text is false.
+                or list of strings if as_text is false.
 
         Raises:
             ValueError: if top_k is not an integer greater than or equal to 0.

--- a/redisvl/extensions/session_manager/semantic_session.py
+++ b/redisvl/extensions/session_manager/semantic_session.py
@@ -64,7 +64,7 @@ class SemanticSessionManager(BaseSessionManager):
 
         Args:
             name (str): The name of the session manager index.
-            session_tag (str): Tag to be added to entries to link to a specific
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
                 session. Defaults to instance uuid.
             prefix (Optional[str]): Prefix for the keys for this session data.
                 Defaults to None and will be replaced with the index name.
@@ -105,7 +105,7 @@ class SemanticSessionManager(BaseSessionManager):
 
         self._index.create(overwrite=False)
 
-        self._default_tag_filter = Tag(self.session_field_name) == self._session_tag
+        self._default_session_filter = Tag(self.session_field_name) == self._session_tag
 
     def clear(self) -> None:
         """Clears the chat session history."""
@@ -115,24 +115,23 @@ class SemanticSessionManager(BaseSessionManager):
         """Clear all conversation keys and remove the search index."""
         self._index.delete(drop=True)
 
-    def drop(self, id_field: Optional[str] = None) -> None:
+    def drop(self, id: Optional[str] = None) -> None:
         """Remove a specific exchange from the conversation history.
 
         Args:
-            id_field (Optional[str]): The id_field of the entry to delete.
+            id (Optional[str]): The id of the session entry to delete.
                 If None then the last entry is deleted.
         """
-        if id_field:
-            sep = self._index.key_separator
-            key = sep.join([self._index.schema.index.name, id_field])
-        else:
-            key = self.get_recent(top_k=1, raw=True)[0]["id"]  # type: ignore
-        self._index.client.delete(key)  # type: ignore
+        if id is None:
+            id = self.get_recent(top_k=1, raw=True)[0][self.id_field_name]  # type: ignore
+
+        self._index.client.delete(self._index.key(id))  # type: ignore
 
     @property
     def messages(self) -> Union[List[str], List[Dict[str, str]]]:
         """Returns the full chat history."""
         # TODO raw or as_text?
+        # TODO refactor method to use get_recent and support other session tags
         return_fields = [
             self.id_field_name,
             self.session_field_name,
@@ -143,7 +142,7 @@ class SemanticSessionManager(BaseSessionManager):
         ]
 
         query = FilterQuery(
-            filter_expression=self._default_tag_filter,
+            filter_expression=self._default_session_filter,
             return_fields=return_fields,
         )
 
@@ -159,7 +158,7 @@ class SemanticSessionManager(BaseSessionManager):
         as_text: bool = False,
         top_k: int = 5,
         fall_back: bool = False,
-        tag_filter: Optional[FilterExpression] = None,
+        session_tag: Optional[str] = None,
         raw: bool = False,
     ) -> Union[List[str], List[Dict[str, str]]]:
         """Searches the chat history for information semantically related to
@@ -177,8 +176,8 @@ class SemanticSessionManager(BaseSessionManager):
             top_k (int): The number of previous messages to return. Default is 5.
             fallback (bool): Whether to drop back to recent conversation history
                 if no relevant context is found.
-            tag_filter (Optional[FilterExpression]): The tag filter to filter results
-                by. Defaults to None and all messages will be searched.
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
+                session. Defaults to instance uuid.
             raw (bool): Whether to return the full Redis hash entry or just the
                 message.
 
@@ -202,6 +201,12 @@ class SemanticSessionManager(BaseSessionManager):
             self.vector_field_name,
         ]
 
+        session_filter = (
+            Tag(self.session_field_name) == session_tag
+            if session_tag
+            else self._default_session_filter
+        )
+
         query = RangeQuery(
             vector=self._vectorizer.embed(prompt),
             vector_field_name=self.vector_field_name,
@@ -209,7 +214,7 @@ class SemanticSessionManager(BaseSessionManager):
             distance_threshold=self._distance_threshold,
             num_results=top_k,
             return_score=True,
-            filter_expression=tag_filter or self._default_tag_filter,
+            filter_expression=session_filter,
         )
         hits = self._index.query(query)
 
@@ -225,7 +230,7 @@ class SemanticSessionManager(BaseSessionManager):
         top_k: int = 5,
         as_text: bool = False,
         raw: bool = False,
-        tag_filter: Optional[FilterExpression] = None,
+        session_tag: Optional[str] = None,
     ) -> Union[List[str], List[Dict[str, str]]]:
         """Retreive the recent conversation history in sequential order.
 
@@ -235,8 +240,8 @@ class SemanticSessionManager(BaseSessionManager):
                 or list of alternating prompts and responses.
             raw (bool): Whether to return the full Redis hash entry or just the
                 prompt and response
-            tag_filter (Optional[FilterExpression]): The tag filter to filter
-                results by. Defaults to None and all messages will be searched.
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
+                session. Defaults to instance uuid.
 
         Returns:
             Union[str, List[str]]: A single string transcription of the session
@@ -257,8 +262,14 @@ class SemanticSessionManager(BaseSessionManager):
             self.timestamp_field_name,
         ]
 
+        session_filter = (
+            Tag(self.session_field_name) == session_tag
+            if session_tag
+            else self._default_session_filter
+        )
+
         query = FilterQuery(
-            filter_expression=tag_filter or self._default_tag_filter,
+            filter_expression=session_filter,
             return_fields=return_fields,
             num_results=top_k,
         )
@@ -288,6 +299,8 @@ class SemanticSessionManager(BaseSessionManager):
         Args:
             prompt (str): The user prompt to the LLM.
             response (str): The corresponding LLM response.
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
+                session. Defaults to instance uuid.
         """
         self.add_messages(
             [
@@ -306,6 +319,8 @@ class SemanticSessionManager(BaseSessionManager):
 
         Args:
             messages (List[Dict[str, str]]): The list of user prompts and LLM responses.
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
+                session. Defaults to instance uuid.
         """
         sep = self._index.key_separator
         session_tag = session_tag or self._session_tag
@@ -337,5 +352,7 @@ class SemanticSessionManager(BaseSessionManager):
 
         Args:
             message (Dict[str,str]): The user prompt or LLM response.
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
+                session. Defaults to instance uuid.
         """
         self.add_messages([message], session_tag)

--- a/redisvl/extensions/session_manager/standard_session.py
+++ b/redisvl/extensions/session_manager/standard_session.py
@@ -5,15 +5,40 @@ from typing import Dict, List, Optional, Union
 from redis import Redis
 
 from redisvl.extensions.session_manager import BaseSessionManager
+from redisvl.index import SearchIndex
+from redisvl.query import FilterQuery
+from redisvl.query.filter import Tag
+from redisvl.schema.schema import IndexSchema
+
+
+class StandardSessionIndexSchema(IndexSchema):
+
+    @classmethod
+    def from_params(cls, name: str, prefix: str):
+
+        return cls(
+            index={"name": name, "prefix": prefix},  # type: ignore
+            fields=[  # type: ignore
+                {"name": "role", "type": "text"},
+                {"name": "content", "type": "text"},
+                {"name": "tool_call_id", "type": "text"},
+                {"name": "timestamp", "type": "numeric"},
+                {"name": "session_tag", "type": "tag"},
+                {"name": "user_tag", "type": "tag"},
+            ],
+        )
 
 
 class StandardSessionManager(BaseSessionManager):
+    session_field_name: str = "session_tag"
+    user_field_name: str = "user_tag"
 
     def __init__(
         self,
         name: str,
         session_tag: str,
         user_tag: str,
+        prefix: Optional[str] = None,
         redis_client: Optional[Redis] = None,
         redis_url: str = "redis://localhost:6379",
     ):
@@ -26,9 +51,11 @@ class StandardSessionManager(BaseSessionManager):
 
         Args:
             name (str): The name of the session manager index.
-            session_tag (str): Tag to be added to entries to link to a specific
+            session_tag (Optional[str]): Tag to be added to entries to link to a specific
                 session.
-            user_tag (str): Tag to be added to entries to link to a specific user.
+            user_tag (Optional[str]): Tag to be added to entries to link to a specific user.
+            prefix (Optional[str]): Prefix for the keys for this session data.
+                Defaults to None and will be replaced with the index name.
             redis_client (Optional[Redis]): A Redis client instance. Defaults to
                 None.
             redis_url (str): The URL of the Redis instance. Defaults to 'redis://localhost:6379'.
@@ -38,6 +65,17 @@ class StandardSessionManager(BaseSessionManager):
 
         """
         super().__init__(name, session_tag, user_tag)
+
+        prefix = prefix or name
+
+        schema = StandardSessionIndexSchema.from_params(name, prefix)
+        self._index = SearchIndex(schema=schema)
+        if redis_client:
+            self._index.set_client(redis_client)
+        else:
+            self._index.connect(redis_url=redis_url)
+
+        self._index.create(overwrite=False)
 
         if redis_client:
             self._client = redis_client
@@ -51,30 +89,38 @@ class StandardSessionManager(BaseSessionManager):
         session_tag: Optional[str] = None,
         user_tag: Optional[str] = None,
     ) -> None:
-        """Set the filter to apply to querries based on the desired scope.
+        """Set the tag filter to apply to querries based on the desired scope.
 
         This new scope persists until another call to set_scope is made, or if
-        scope is specified in calls to get_recent.
+        scope specified in calls to get_recent or get_relevant.
 
         Args:
             session_tag (str): Id of the specific session to filter to. Default is
-                None, which means session_tag will be unchanged.
+                None, which means all sessions will be in scope.
             user_tag (str): Id of the specific user to filter to. Default is None,
-                which means user_tag will be unchanged.
+                which means all users will be in scope.
         """
         if not (session_tag or user_tag):
             return
-
         self._session_tag = session_tag or self._session_tag
         self._user_tag = user_tag or self._user_tag
+        tag_filter = Tag(self.user_field_name) == []
+        if user_tag:
+            tag_filter = tag_filter & (Tag(self.user_field_name) == self._user_tag)
+        if session_tag:
+            tag_filter = tag_filter & (
+                Tag(self.session_field_name) == self._session_tag
+            )
+
+        self._tag_filter = tag_filter
 
     def clear(self) -> None:
         """Clears the chat session history."""
-        self._client.delete(self.key)
+        self._index.clear()
 
     def delete(self) -> None:
-        """Clears the chat session history."""
-        self._client.delete(self.key)
+        """Clear all conversation keys and remove the search index."""
+        self._index.delete(drop=True)
 
     def drop(self, id_field: Optional[str] = None) -> None:
         """Remove a specific exchange from the conversation history.
@@ -84,19 +130,36 @@ class StandardSessionManager(BaseSessionManager):
                 If None then the last entry is deleted.
         """
         if id_field:
-            messages = self._client.lrange(self.key, 0, -1)
-            messages = [json.loads(msg) for msg in messages]
-            messages = [msg for msg in messages if msg["id_field"] != id_field]
-            messages = [json.dumps(msg) for msg in messages]
-            self.clear()
-            self._client.rpush(self.key, *messages)
+            sep = self._index.key_separator
+            key = sep.join([self._index.schema.index.name, id_field])
         else:
-            self._client.rpop(self.key)
+            key = self.get_recent(top_k=1, raw=True)[0]["id"]  # type: ignore
+        self._index.client.delete(key)  # type: ignore
 
     @property
     def messages(self) -> Union[List[str], List[Dict[str, str]]]:
         """Returns the full chat history."""
-        return self.get_recent(top_k=-1)
+        # TODO raw or as_text?
+        return_fields = [
+            self.id_field_name,
+            self.session_field_name,
+            self.user_field_name,
+            self.role_field_name,
+            self.content_field_name,
+            self.tool_field_name,
+            self.timestamp_field_name,
+        ]
+
+        query = FilterQuery(
+            filter_expression=self._tag_filter,
+            return_fields=return_fields,
+        )
+
+        sorted_query = query.query
+        sorted_query.sort_by(self.timestamp_field_name, asc=True)
+        hits = self._index.search(sorted_query, query.params).docs
+
+        return self._format_context(hits, as_text=False)
 
     def get_recent(
         self,
@@ -110,7 +173,6 @@ class StandardSessionManager(BaseSessionManager):
 
         Args:
             top_k (int): The number of previous messages to return. Default is 5.
-                To get all messages set top_k = -1.
             session_tag (str): Tag to be added to entries to link to a specific
                 session.
             user_tag (str): Tag to be added to entries to link to a specific user.
@@ -124,24 +186,35 @@ class StandardSessionManager(BaseSessionManager):
                 or list of strings if as_text is false.
 
         Raises:
-            ValueError: if top_k is not an integer greater than or equal to -1.
+            ValueError: if top_k is not an integer greater than or equal to 0.
         """
-        if type(top_k) != int or top_k < -1:
-            raise ValueError("top_k must be an integer greater than or equal to -1")
-        if top_k == 0:
-            return []
-        elif top_k == -1:
-            top_k = 0
-        self.set_scope(session_tag, user_tag)
-        messages = self._client.lrange(self.key, -top_k, -1)
-        messages = [json.loads(msg) for msg in messages]
-        if raw:
-            return messages
-        return self._format_context(messages, as_text)
+        if type(top_k) != int or top_k < 0:
+            raise ValueError("top_k must be an integer greater than or equal to 0")
 
-    @property
-    def key(self):
-        return ":".join([self._name, self._user_tag, self._session_tag])
+        self.set_scope(session_tag, user_tag)
+        return_fields = [
+            self.id_field_name,
+            self.session_field_name,
+            self.user_field_name,
+            self.role_field_name,
+            self.content_field_name,
+            self.tool_field_name,
+            self.timestamp_field_name,
+        ]
+
+        query = FilterQuery(
+            filter_expression=self._tag_filter,
+            return_fields=return_fields,
+            num_results=top_k,
+        )
+
+        sorted_query = query.query
+        sorted_query.sort_by(self.timestamp_field_name, asc=False)
+        hits = self._index.search(sorted_query, query.params).docs
+
+        if raw:
+            return hits[::-1]
+        return self._format_context(hits[::-1], as_text)
 
     def store(self, prompt: str, response: str) -> None:
         """Insert a prompt:response pair into the session memory. A timestamp
@@ -153,7 +226,10 @@ class StandardSessionManager(BaseSessionManager):
             response (str): The corresponding LLM response.
         """
         self.add_messages(
-            [{"role": "user", "content": prompt}, {"role": "llm", "content": response}]
+            [
+                {self.role_field_name: "user", self.content_field_name: prompt},
+                {self.role_field_name: "llm", self.content_field_name: response},
+            ]
         )
 
     def add_messages(self, messages: List[Dict[str, str]]) -> None:
@@ -164,23 +240,23 @@ class StandardSessionManager(BaseSessionManager):
         Args:
             messages (List[Dict[str, str]]): The list of user prompts and LLM responses.
         """
+        sep = self._index.key_separator
         payloads = []
         for message in messages:
             timestamp = time()
+            id_field = sep.join([self._user_tag, self._session_tag, str(timestamp)])
             payload = {
-                self.id_field_name: ":".join(
-                    [self._user_tag, self._session_tag, str(timestamp)]
-                ),
+                self.id_field_name: id_field,
                 self.role_field_name: message[self.role_field_name],
                 self.content_field_name: message[self.content_field_name],
                 self.timestamp_field_name: timestamp,
+                self.session_field_name: self._session_tag,
+                self.user_field_name: self._user_tag,
             }
             if self.tool_field_name in message:
                 payload.update({self.tool_field_name: message[self.tool_field_name]})
-
-            payloads.append(json.dumps(payload))
-
-        self._client.rpush(self.key, *payloads)
+            payloads.append(payload)
+        self._index.load(data=payloads, id_field=self.id_field_name)
 
     def add_message(self, message: Dict[str, str]) -> None:
         """Insert a single prompt or response into the session memory.

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -114,6 +114,20 @@ def test_ttl_expiration(cache_with_ttl, vectorizer):
     assert len(check_result) == 0
 
 
+def test_ttl_refresh(cache_with_ttl, vectorizer):
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    vector = vectorizer.embed(prompt)
+
+    cache_with_ttl.store(prompt, response, vector=vector)
+
+    for _ in range(3):
+        sleep(1)
+        check_result = cache_with_ttl.check(vector=vector)
+
+    assert len(check_result) == 1
+
+
 def test_ttl_expiration_after_update(cache_with_ttl, vectorizer):
     prompt = "This is a test prompt."
     response = "This is a test response."

--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -30,12 +30,6 @@ def semantic_session(app_name, user_tag, session_tag):
 
 
 # test standard session manager
-def test_key_creation():
-    # test default key creation
-    session = StandardSessionManager(name="test_app", session_tag="123", user_tag="abc")
-    assert session.key == "test_app:abc:123"
-
-
 def test_specify_redis_client(client):
     session = StandardSessionManager(
         name="test_app", session_tag="abc", user_tag="123", redis_client=client
@@ -73,11 +67,8 @@ def test_standard_store_and_get(standard_session):
     no_context = standard_session.get_recent(top_k=0)
     assert len(no_context) == 0
 
-    # test that the full context is returned when top_k is -1
-    full_context = standard_session.get_recent(top_k=-1)
-    assert len(full_context) == 10
-
     # test that order is maintained
+    full_context = standard_session.get_recent(top_k=10)
     assert full_context == [
         {"role": "user", "content": "first prompt"},
         {"role": "llm", "content": "first response"},
@@ -127,8 +118,8 @@ def test_standard_add_and_get(standard_session):
             "tool_call_id": "tool call two",
         }
     )
-    standard_session.add_message({"role": "user", "content": "fourth prompt"})
-    standard_session.add_message({"role": "llm", "content": "fourth response"})
+    standard_session.add_message({"role": "user", "content": "third prompt"})
+    standard_session.add_message({"role": "llm", "content": "third response"})
 
     # test default context history size
     default_context = standard_session.get_recent()
@@ -139,12 +130,12 @@ def test_standard_add_and_get(standard_session):
     assert len(partial_context) == 3
     assert partial_context == [
         {"role": "tool", "content": "tool result 2", "tool_call_id": "tool call two"},
-        {"role": "user", "content": "fourth prompt"},
-        {"role": "llm", "content": "fourth response"},
+        {"role": "user", "content": "third prompt"},
+        {"role": "llm", "content": "third response"},
     ]
 
     # test that order is maintained
-    full_context = standard_session.get_recent(top_k=-1)
+    full_context = standard_session.get_recent(top_k=10)
     assert full_context == [
         {"role": "user", "content": "first prompt"},
         {"role": "llm", "content": "first response"},
@@ -152,8 +143,8 @@ def test_standard_add_and_get(standard_session):
         {"role": "llm", "content": "second response"},
         {"role": "tool", "content": "tool result 1", "tool_call_id": "tool call one"},
         {"role": "tool", "content": "tool result 2", "tool_call_id": "tool call two"},
-        {"role": "user", "content": "fourth prompt"},
-        {"role": "llm", "content": "fourth response"},
+        {"role": "user", "content": "third prompt"},
+        {"role": "llm", "content": "third response"},
     ]
 
 
@@ -195,7 +186,7 @@ def test_standard_add_messages(standard_session):
     ]
 
     # test that order is maintained
-    full_context = standard_session.get_recent(top_k=-1)
+    full_context = standard_session.get_recent(top_k=10)
     assert full_context == [
         {"role": "user", "content": "first prompt"},
         {"role": "llm", "content": "first response"},
@@ -230,33 +221,36 @@ def test_standard_messages_property(standard_session):
 
 def test_standard_set_scope(standard_session, app_name, user_tag, session_tag):
     # test calling set_scope with no params does not change scope
-    current_key = standard_session.key
+    standard_session.store("some prompt", "some response")
     standard_session.set_scope()
-    assert standard_session.key == current_key
-
-    # test passing either user_tag or session_tag only changes corresponding value
-    new_user = "def"
-    standard_session.set_scope(user_tag=new_user)
-    assert standard_session.key == f"{app_name}:{new_user}:{session_tag}"
-
-    new_session = "456"
-    standard_session.set_scope(session_tag=new_session)
-    assert standard_session.key == f"{app_name}:{new_user}:{new_session}"
+    context = standard_session.get_recent()
+    assert context == [
+        {"role": "user", "content": "some prompt"},
+        {"role": "llm", "content": "some response"},
+    ]
 
     # test that changing user and session id does indeed change access scope
+    new_user = "def"
+    standard_session.set_scope(user_tag=new_user)
     standard_session.store("new user prompt", "new user response")
+    context = standard_session.get_recent()
+    assert context == [
+        {"role": "user", "content": "new user prompt"},
+        {"role": "llm", "content": "new user response"},
+    ]
+
+    # test that previous user and session data is still accessible
+    previous_user = "abc"
+    standard_session.set_scope(user_tag=previous_user)
+    context = standard_session.get_recent()
+    assert context == [
+        {"role": "user", "content": "some prompt"},
+        {"role": "llm", "content": "some response"},
+    ]
 
     standard_session.set_scope(session_tag="789", user_tag="ghi")
     no_context = standard_session.get_recent()
     assert no_context == []
-
-    # change scope back to read previously stored entries
-    standard_session.set_scope(session_tag="456", user_tag="def")
-    previous_context = standard_session.get_recent()
-    assert previous_context == [
-        {"role": "user", "content": "new user prompt"},
-        {"role": "llm", "content": "new user response"},
-    ]
 
 
 def test_standard_get_recent_with_scope(standard_session, session_tag):
@@ -301,18 +295,11 @@ def test_standard_get_raw(standard_session):
     standard_session.store("second prompt", "second response")
     raw = standard_session.get_recent(raw=True)
     assert len(raw) == 4
-    assert raw[0].keys() == {
-        "id_field",
-        "role",
-        "content",
-        "timestamp",
-    }
     assert raw[0]["role"] == "user"
     assert raw[0]["content"] == "first prompt"
-    assert current_time <= raw[0]["timestamp"] <= time.time()
+    assert current_time <= float(raw[0]["timestamp"]) <= time.time()
     assert raw[1]["role"] == "llm"
     assert raw[1]["content"] == "first response"
-    assert raw[1]["timestamp"] > raw[0]["timestamp"]
 
 
 def test_standard_drop(standard_session):
@@ -331,7 +318,7 @@ def test_standard_drop(standard_session):
     ]
 
     # test drop(id) removes the specified element
-    context = standard_session.get_recent(top_k=-1, raw=True)
+    context = standard_session.get_recent(top_k=10, raw=True)
     middle_id = context[3]["id_field"]
     standard_session.drop(middle_id)
     context = standard_session.get_recent(top_k=6)
@@ -348,14 +335,7 @@ def test_standard_drop(standard_session):
 def test_standard_clear(standard_session):
     standard_session.store("some prompt", "some response")
     standard_session.clear()
-    empty_context = standard_session.get_recent(top_k=-1)
-    assert empty_context == []
-
-
-def test_standard_delete(standard_session):
-    standard_session.store("some prompt", "some response")
-    standard_session.delete()
-    empty_context = standard_session.get_recent(top_k=-1)
+    empty_context = standard_session.get_recent(top_k=10)
     assert empty_context == []
 
 


### PR DESCRIPTION
This PR removes the requirement that user and session tags be specified on session manager initialization. Session tags can be added when storing messages and filter expressions can be used to retrieve specific chat histories. A default uuid is used when no session is provided.