### PR TITLE
Fix notebook CI

### DIFF
--- a/docs/examples/openai_qna.ipynb
+++ b/docs/examples/openai_qna.ipynb
@@ -861,7 +861,7 @@
    "source": [
     "from redisvl.extensions.llmcache import SemanticCache\n",
     "\n",
-    "cache = SemanticCache(redis_url=\"redis://localhost:6379\", distance_threshold=0.2)"
+    "cache = SemanticCache(name=\"qna_cache\", redis_url=\"redis://localhost:6379\", distance_threshold=0.2)"
    ]
   },
   {

--- a/docs/user_guide/llmcache_03.ipynb
+++ b/docs/user_guide/llmcache_03.ipynb
@@ -350,7 +350,7 @@
    "source": [
     "llmcache.store(\"This is a TTL test\", \"This is a TTL test response\")\n",
     "\n",
-    "time.sleep(5)"
+    "time.sleep(6)"
    ]
   },
   {

--- a/docs/user_guide/llmcache_03.ipynb
+++ b/docs/user_guide/llmcache_03.ipynb
@@ -732,7 +732,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.9"
   },
   "orig_nbformat": 4
  },

--- a/docs/user_guide/vectorizers_04.ipynb
+++ b/docs/user_guide/vectorizers_04.ipynb
@@ -614,7 +614,7 @@
    "source": [
     "from redisvl.extensions.llmcache import SemanticCache\n",
     "\n",
-    "cache = SemanticCache(vectorizer=custom_vectorizer)\n",
+    "cache = SemanticCache(name=\"custom_cache\", vectorizer=custom_vectorizer)\n",
     "\n",
     "cache.store(\"this is a test prompt\", \"this is a test response\")\n",
     "cache.check(\"this is also a test prompt\")"


### PR DESCRIPTION
Because our notebooks are run in parallel using threads, for expedited testing purposes, and using a single redis instance, there were situations where different caches were created with the same name... causing collisions.