### PR TITLE
Refactor query classes

### DIFF
--- a/docs/api/query.rst
+++ b/docs/api/query.rst
@@ -3,7 +3,9 @@
 Query
 *****
 
-.. _query_api:
+Query classes in RedisVL provide a structured way to define simple or complex
+queries for different use cases. Each query class wraps the ``redis-py`` Query module
+https://github.com/redis/redis-py/blob/master/redis/commands/search/query.py with extended functionality for ease-of-use.
 
 
 VectorQuery
@@ -15,19 +17,22 @@ VectorQuery
 .. autoclass:: VectorQuery
    :members:
    :inherited-members:
+   :show-inheritance:
+   :exclude-members: add_filter,get_args,highlight,return_field,summarize
 
 
-RangeQuery
-==========
+VectorRangeQuery
+================
 
 
 .. currentmodule:: redisvl.query
 
 
-.. autoclass:: RangeQuery
+.. autoclass:: VectorRangeQuery
    :members:
    :inherited-members:
-
+   :show-inheritance:
+   :exclude-members: add_filter,get_args,highlight,return_field,summarize
 
 FilterQuery
 ===========
@@ -39,6 +44,8 @@ FilterQuery
 .. autoclass:: FilterQuery
    :members:
    :inherited-members:
+   :show-inheritance:
+   :exclude-members: add_filter,get_args,highlight,return_field,summarize
 
 
 
@@ -51,3 +58,5 @@ CountQuery
 .. autoclass:: CountQuery
    :members:
    :inherited-members:
+   :show-inheritance:
+   :exclude-members: add_filter,get_args,highlight,return_field,summarize

--- a/docs/user_guide/hybrid_queries_02.ipynb
+++ b/docs/user_guide/hybrid_queries_02.ipynb
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,15 +94,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m08:48:47\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
-      "\u001b[32m08:48:47\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. user_queries\n"
+      "\u001b[32m14:06:19\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
+      "\u001b[32m14:06:19\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. user_queries\n"
      ]
     }
    ],
@@ -113,10 +113,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# load data to redis\n",
     "keys = index.load(data)"
    ]
   },
@@ -141,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -175,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -227,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -299,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -326,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -352,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -415,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -441,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -467,7 +468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -493,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -519,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -554,7 +555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -582,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -608,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -645,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -688,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -732,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -772,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -797,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -822,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -856,7 +857,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -898,7 +899,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -932,7 +933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -973,7 +974,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1004,7 +1005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1032,24 +1033,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Other Redis Queries\n",
-    "\n",
-    "Sometimes there may be a case where RedisVL does not cover the explicit functionality required by the query either because of new releases that haven't been implemented in the client, or because of a very specific use case. In these cases, it is possible to use the ``SearchIndex.search`` method to execute query with a redis-py ``Query`` object or through a raw redis string.\n",
-    "\n",
-    "For example\n",
-    "\n",
-    "### Redis-Py"
+    "## Advanced Query Modifiers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See all modifier options available on the query API docs: https://www.redisvl.com/api/query.html"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>age</th><th>user</th><th>credit_score</th><th>job</th><th>office_location</th></tr><tr><td>0.109129190445</td><td>100</td><td>tyler</td><td>high</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0.266666650772</td><td>94</td><td>nancy</td><td>high</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.653301358223</td><td>35</td><td>joe</td><td>medium</td><td>dentist</td><td>-122.0839,37.3861</td></tr><tr><td>0</td><td>18</td><td>john</td><td>high</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0.217882037163</td><td>15</td><td>taimur</td><td>low</td><td>CEO</td><td>-122.0839,37.3861</td></tr><tr><td>0</td><td>14</td><td>derrick</td><td>low</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.158808946609</td><td>12</td><td>tim</td><td>high</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr></table>"
+       "<table><tr><th>vector_distance</th><th>age</th><th>user</th><th>credit_score</th><th>job</th><th>office_location</th></tr><tr><td>0.109129190445</td><td>100</td><td>tyler</td><td>high</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0</td><td>18</td><td>john</td><td>high</td><td>engineer</td><td>-122.4194,37.7749</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1060,14 +1062,16 @@
     }
    ],
    "source": [
-    "# Manipulate the Redis-py Query object\n",
-    "redis_py_query = v.query\n",
+    "# Sort by a different field and change dialect\n",
+    "v = VectorQuery(\n",
+    "    vector=[0.1, 0.1, 0.5],\n",
+    "    vector_field_name=\"user_embedding\",\n",
+    "    return_fields=[\"user\", \"credit_score\", \"age\", \"job\",  \"office_location\"],\n",
+    "    num_results=5,\n",
+    "    filter_expression=is_engineer\n",
+    ").sort_by(\"age\", asc=False).dialect(3)\n",
     "\n",
-    "# choose to sort by age instead of vector distance\n",
-    "redis_py_query.sort_by(\"age\", asc=False)\n",
-    "\n",
-    "# run the query with the ``SearchIndex.search`` method\n",
-    "result = index.search(redis_py_query, v.params)\n",
+    "result = index.query(v)\n",
     "result_print(result)"
    ]
   },
@@ -1077,7 +1081,28 @@
    "source": [
     "### Raw Redis Query String\n",
     "\n",
-    "So one case might be where you simply want to have a search that only filters on a tag field and don't need other functionality. Conversely, you may need to have a query that is more complex than what is currently supported by RedisVL. In these cases, you can use the ``SearchIndex.search`` again with just a raw redis query string."
+    "Sometimes it's helpful to convert these classes into their raw Redis query strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'@job:(\"engineer\")=>[KNN 5 @user_embedding $vector AS vector_distance] RETURN 6 user credit_score age job office_location vector_distance SORTBY age DESC DIALECT 3 LIMIT 0 5'"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# check out the complex query from above\n",
+    "str(v)"
    ]
   },
   {
@@ -1104,49 +1129,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 'user_queries_docs:0e511391dcf346639669bdba70a189c0', 'payload': None, 'user': 'john', 'age': '18', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '==\\x00\\x00\\x00?'}\n",
-      "{'id': 'user_queries_docs:d204e8e5df90467dbff5b2fb6f800a78', 'payload': None, 'user': 'nancy', 'age': '94', 'job': 'doctor', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '333?=\\x00\\x00\\x00?'}\n",
-      "{'id': 'user_queries_docs:7cf3d6b1a4044966b4f0c5d3725a5e03', 'payload': None, 'user': 'tyler', 'age': '100', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '=>\\x00\\x00\\x00?'}\n",
-      "{'id': 'user_queries_docs:f6581edaaeaf432a85c1d1df8fdf5edc', 'payload': None, 'user': 'tim', 'age': '12', 'job': 'dermatologist', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '>>\\x00\\x00\\x00?'}\n"
-     ]
-    }
-   ],
-   "source": [
-    "results = index.search(str(t))\n",
-    "for r in results.docs:\n",
-    "    print(r.__dict__)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Inspecting Queries\n",
-    "\n",
-    "In this example, we will show how to inspect the query that is generated by RedisVL. This can be useful for debugging purposes or for understanding how the query is being executed.\n",
-    "\n",
-    "Let's again take the example of a query that combines a numeric filter with a tag filter. This will search for users that are between the ages of between 18 and 100, have a high credit score, and sort by closest vector distance to the query vector."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'((@credit_score:{high} @age:[18 +inf]) @age:[-inf 100])=>[KNN 10 @user_embedding $vector AS vector_distance] RETURN 6 user credit_score age job office_location vector_distance SORTBY vector_distance ASC DIALECT 2 LIMIT 0 10'"
+       "'((@credit_score:{high} @age:[18 +inf]) @age:[-inf 100])'"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1158,15 +1150,42 @@
     "\n",
     "combined = t & low & high\n",
     "\n",
-    "v.set_filter(combined)\n",
-    "\n",
-    "# Using the str() method, you can see what Redis Query this will emit.\n",
-    "str(v)"
+    "str(combined)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The RedisVL `SearchIndex` class exposes a `search()` method which is a simple wrapper around the `FT.SEARCH` API.\n",
+    "Provide any valid Redis query string."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'id': 'user_queries_docs:43dc726b8a9541a6ab40ddedc8e48657', 'payload': None, 'user': 'john', 'age': '18', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '==\\x00\\x00\\x00?'}\n",
+      "{'id': 'user_queries_docs:93fdc65248a64fd390ed77aa3c248c23', 'payload': None, 'user': 'nancy', 'age': '94', 'job': 'doctor', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '333?=\\x00\\x00\\x00?'}\n",
+      "{'id': 'user_queries_docs:f1d1f69e5e6c41cb9b7ae70ed8f75da5', 'payload': None, 'user': 'tyler', 'age': '100', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '=>\\x00\\x00\\x00?'}\n",
+      "{'id': 'user_queries_docs:5dc68e47ef6d4a0f885c67368f0710b7', 'payload': None, 'user': 'tim', 'age': '12', 'job': 'dermatologist', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '>>\\x00\\x00\\x00?'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = index.search(str(t))\n",
+    "for r in results.docs:\n",
+    "    print(r.__dict__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.9"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/redisvl/extensions/session_manager/semantic_session.py
+++ b/redisvl/extensions/session_manager/semantic_session.py
@@ -120,12 +120,8 @@ class SemanticSessionManager(BaseSessionManager):
             filter_expression=self._default_session_filter,
             return_fields=return_fields,
         )
-
-        sorted_query = query.query
-        sorted_query.sort_by(self.timestamp_field_name, asc=True)
-        messages = [
-            doc.__dict__ for doc in self._index.search(sorted_query, query.params).docs
-        ]
+        query.sort_by(self.timestamp_field_name, asc=True)
+        messages = self._index.query(query)
 
         return self._format_context(messages, as_text=False)
 
@@ -255,12 +251,8 @@ class SemanticSessionManager(BaseSessionManager):
             return_fields=return_fields,
             num_results=top_k,
         )
-
-        sorted_query = query.query
-        sorted_query.sort_by(self.timestamp_field_name, asc=False)
-        messages = [
-            doc.__dict__ for doc in self._index.search(sorted_query, query.params).docs
-        ]
+        query.sort_by(self.timestamp_field_name, asc=False)
+        messages = self._index.query(query)
 
         if raw:
             return messages[::-1]

--- a/redisvl/extensions/session_manager/standard_session.py
+++ b/redisvl/extensions/session_manager/standard_session.py
@@ -103,12 +103,8 @@ class StandardSessionManager(BaseSessionManager):
             filter_expression=self._default_session_filter,
             return_fields=return_fields,
         )
-
-        sorted_query = query.query
-        sorted_query.sort_by(self.timestamp_field_name, asc=True)
-        messages = [
-            doc.__dict__ for doc in self._index.search(sorted_query, query.params).docs
-        ]
+        query.sort_by(self.timestamp_field_name, asc=True)
+        messages = self._index.query(query)
 
         return self._format_context(messages, as_text=False)
 
@@ -160,12 +156,8 @@ class StandardSessionManager(BaseSessionManager):
             return_fields=return_fields,
             num_results=top_k,
         )
-
-        sorted_query = query.query
-        sorted_query.sort_by(self.timestamp_field_name, asc=False)
-        messages = [
-            doc.__dict__ for doc in self._index.search(sorted_query, query.params).docs
-        ]
+        query.sort_by(self.timestamp_field_name, asc=False)
+        messages = self._index.query(query)
 
         if raw:
             return messages[::-1]

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -65,7 +65,7 @@ def process_results(
     unpack_json = (
         (storage_type == StorageType.JSON)
         and isinstance(query, FilterQuery)
-        and not query._return_fields # type: ignore
+        and not query._return_fields  # type: ignore
     )
 
     # Process records

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -710,7 +710,7 @@ class SearchIndex(BaseSearchIndex):
 
         offset = 0
         while True:
-            query.set_paging(offset, page_size)
+            query.paging(offset, page_size)
             results = self._query(query)
             if not results:
                 break
@@ -1194,7 +1194,7 @@ class AsyncSearchIndex(BaseSearchIndex):
 
         first = 0
         while True:
-            query.set_paging(first, page_size)
+            query.paging(first, page_size)
             results = await self._query(query)
             if not results:
                 break

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -65,7 +65,7 @@ def process_results(
     unpack_json = (
         (storage_type == StorageType.JSON)
         and isinstance(query, FilterQuery)
-        and not query._return_fields
+        and not query._return_fields # type: ignore
     )
 
     # Process records

--- a/redisvl/query/__init__.py
+++ b/redisvl/query/__init__.py
@@ -4,6 +4,14 @@ from redisvl.query.query import (
     FilterQuery,
     RangeQuery,
     VectorQuery,
+    VectorRangeQuery,
 )
 
-__all__ = ["BaseQuery", "VectorQuery", "FilterQuery", "RangeQuery", "CountQuery"]
+__all__ = [
+    "BaseQuery",
+    "VectorQuery",
+    "FilterQuery",
+    "RangeQuery",
+    "VectorRangeQuery",
+    "CountQuery"
+]

--- a/redisvl/query/__init__.py
+++ b/redisvl/query/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
     "FilterQuery",
     "RangeQuery",
     "VectorRangeQuery",
-    "CountQuery"
+    "CountQuery",
 ]

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -28,7 +28,7 @@ class BaseQuery(RedisQuery):
 
     def _build_query_string(self) -> str:
         """Build the full Redis query string."""
-        pass
+        raise NotImplementedError("Must be implemented by subclasses")
 
     def set_filter(self, filter_expression: Optional[FilterExpression] = None):
         """Set the filter expression for the query.
@@ -45,11 +45,12 @@ class BaseQuery(RedisQuery):
         elif isinstance(filter_expression, FilterExpression):
             self._filter_expression = filter_expression
         else:
-            raise TypeError("filter_expression must be of type FilterExpression or None")
+            raise TypeError(
+                "filter_expression must be of type FilterExpression or None"
+            )
 
         # Reset the query string
         self._query_string = self._build_query_string()
-
 
     @property
     def filter(self) -> FilterExpression:
@@ -167,8 +168,8 @@ class CountQuery(BaseQuery):
         return str(self._filter_expression)
 
 
-class BaseVectorQuery(BaseQuery):
-    DTYPES: Dict[str, np.dtype] = {
+class BaseVectorQuery:
+    DTYPES: Dict[str, Any] = {
         "float32": np.float32,
         "float64": np.float64,
     }
@@ -176,7 +177,7 @@ class BaseVectorQuery(BaseQuery):
     VECTOR_PARAM: str = "vector"
 
 
-class VectorQuery(BaseVectorQuery):
+class VectorQuery(BaseVectorQuery, BaseQuery):
     def __init__(
         self,
         vector: Union[List[float], bytes],
@@ -268,7 +269,7 @@ class VectorQuery(BaseVectorQuery):
         return {self.VECTOR_PARAM: vector}
 
 
-class VectorRangeQuery(BaseVectorQuery):
+class VectorRangeQuery(BaseVectorQuery, BaseQuery):
     DISTANCE_THRESHOLD_PARAM: str = "distance_threshold"
 
     def __init__(

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -50,13 +50,6 @@ class BaseQuery(RedisQuery):
         # Reset the query string
         self._query_string = self._build_query_string()
 
-    def get_filter(self) -> FilterExpression:
-        """Get the filter expression for the query.
-
-        Returns:
-            FilterExpression: The filter for the query.
-        """
-        return self.filter
 
     @property
     def filter(self) -> FilterExpression:

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -19,7 +19,9 @@ def vectorizer():
 @pytest.fixture
 def cache(vectorizer, redis_url):
     cache_instance = SemanticCache(
-        vectorizer=vectorizer, distance_threshold=0.2, redis_url="redis://localhost:6379"
+        vectorizer=vectorizer,
+        distance_threshold=0.2,
+        redis_url="redis://localhost:6379",
     )
     yield cache_instance
     cache_instance._index.delete(True)  # Clean up index

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -19,7 +19,7 @@ def vectorizer():
 @pytest.fixture
 def cache(vectorizer, redis_url):
     cache_instance = SemanticCache(
-        vectorizer=vectorizer, distance_threshold=0.2, redis_url=redis_url
+        vectorizer=vectorizer, distance_threshold=0.2, redis_url="redis://localhost:6379"
     )
     yield cache_instance
     cache_instance._index.delete(True)  # Clean up index
@@ -265,9 +265,6 @@ def test_check_no_match(cache, vectorizer):
 def test_check_invalid_input(cache):
     with pytest.raises(ValueError):
         cache.check()
-
-    with pytest.raises(TypeError):
-        cache.check(prompt="test", return_fields="bad value")
 
 
 def test_bad_connection_info(vectorizer):

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -21,7 +21,7 @@ def cache(vectorizer, redis_url):
     cache_instance = SemanticCache(
         vectorizer=vectorizer,
         distance_threshold=0.2,
-        redis_url="redis://localhost:6379",
+        redis_url=redis_url,
     )
     yield cache_instance
     cache_instance._index.delete(True)  # Clean up index

--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -464,8 +464,7 @@ def test_semantic_add_and_get_relevant(semantic_session):
     default_context = semantic_session.get_relevant("list of fruits and vegetables")
     assert len(default_context) == 5  # 2 pairs of prompt:response, and system
     assert default_context == semantic_session.get_relevant(
-        "list of fruits and vegetables",
-        distance_threshold=0.5
+        "list of fruits and vegetables", distance_threshold=0.5
     )
 
     # test tool calls can also be returned

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -18,6 +18,7 @@ def test_count_query():
     count_query = CountQuery(filter_expression)
 
     # Check properties
+    assert isinstance(count_query)
     assert isinstance(count_query.query, Query)
     assert isinstance(count_query.params, dict)
     assert count_query.params == {}
@@ -41,11 +42,12 @@ def test_filter_query():
     assert filter_query._return_fields == return_fields
     assert filter_query._num_results == 10
     assert filter_query.get_filter() == filter_expression
+    assert isinstance(filter_query, Query)
     assert isinstance(filter_query.query, Query)
     assert isinstance(filter_query.params, dict)
     assert filter_query.params == {}
     assert filter_query._dialect == 2
-    assert filter_query._sort_by == None
+    assert filter_query._sortby == None
     assert filter_query._in_order == False
 
     # Test set_filter functionality
@@ -53,17 +55,17 @@ def test_filter_query():
     filter_query.set_filter(new_filter_expression)
     assert filter_query.get_filter() == new_filter_expression
 
-    # Test set_paging functionality
-    filter_query.set_paging(5, 7)
-    assert filter_query._first == 5
-    assert filter_query._limit == 7
+    # Test paging functionality
+    filter_query.paging(5, 7)
+    assert filter_query._offset == 5
+    assert filter_query._num == 7
     assert filter_query._num_results == 10
 
     # Test sort_by functionality
     filter_query = FilterQuery(
         filter_expression, return_fields, num_results=10, sort_by="price"
     )
-    assert filter_query._sort_by == "price"
+    assert filter_query._sortby is not None
 
     # Test in_order functionality
     filter_query = FilterQuery(
@@ -80,14 +82,15 @@ def test_vector_query():
 
     # Check properties
     assert vector_query._vector == sample_vector
-    assert vector_query._field == "vector_field"
+    assert vector_query._vector_field_name == "vector_field"
     assert vector_query._num_results == 10
     assert "field1" in vector_query._return_fields
+    assert isinstance(vector_query, Query)
     assert isinstance(vector_query.query, Query)
     assert isinstance(vector_query.params, dict)
     assert vector_query.params != {}
     assert vector_query._dialect == 3
-    assert vector_query._sort_by == None
+    assert vector_query._sortby.args[0] == VectorQuery.DISTANCE_ID
     assert vector_query._in_order == False
 
     # Test set_filter functionality
@@ -95,10 +98,10 @@ def test_vector_query():
     vector_query.set_filter(new_filter_expression)
     assert vector_query.get_filter() == new_filter_expression
 
-    # Test set_paging functionality
-    vector_query.set_paging(5, 7)
-    assert vector_query._first == 5
-    assert vector_query._limit == 7
+    # Test paging functionality
+    vector_query.paging(5, 7)
+    assert vector_query._offset == 5
+    assert vector_query._num == 7
     assert vector_query._num_results == 10
 
     # Test sort_by functionality
@@ -110,8 +113,18 @@ def test_vector_query():
         num_results=10,
         sort_by="field2",
     )
-    assert vector_query._sort_by == "field2"
+    assert vector_query._sortby.args[0] == "field2"
 
+    # Test in_order functionality
+    vector_query = VectorQuery(
+        sample_vector,
+        "vector_field",
+        ["field1", "field2"],
+        dialect=3,
+        num_results=10,
+        in_order=True
+    )
+    assert vector_query._in_order
 
 def test_range_query():
     # Create a filter expression
@@ -124,25 +137,29 @@ def test_range_query():
 
     # Check properties
     assert range_query._vector == sample_vector
-    assert range_query._field == "vector_field"
+    assert range_query._vector_field_name == "vector_field"
     assert range_query._num_results == 10
     assert range_query.distance_threshold == 0.2
     assert "field1" in range_query._return_fields
+    assert isinstance(range_query, Query)
     assert isinstance(range_query.query, Query)
     assert isinstance(range_query.params, dict)
     assert range_query.params != {}
-    assert range_query._sort_by == None
-    assert range_query._sort_by == None
+    assert range_query._sortby.args[0] == RangeQuery.DISTANCE_ID
+
+    # Test set_distance_threshold functionality
+    range_query.set_distance_threshold(0.1)
+    assert range_query.distance_threshold == 0.1
 
     # Test set_filter functionality
     new_filter_expression = Tag("category") == "Outdoor"
     range_query.set_filter(new_filter_expression)
     assert range_query.get_filter() == new_filter_expression
 
-    # Test set_paging functionality
-    range_query.set_paging(5, 7)
-    assert range_query._first == 5
-    assert range_query._limit == 7
+    # Test paging functionality
+    range_query.paging(5, 7)
+    assert range_query._offset == 5
+    assert range_query._num == 7
     assert range_query._num_results == 10
 
     # Test sort_by functionality
@@ -154,4 +171,16 @@ def test_range_query():
         num_results=10,
         sort_by="field1",
     )
-    assert range_query._sort_by == "field1"
+    assert range_query._sortby.args[0] == "field1"
+
+    # Test in_order functionality
+    range_query = RangeQuery(
+        sample_vector,
+        "vector_field",
+        ["field1"],
+        filter_expression,
+        num_results=10,
+        in_order=True
+    )
+    assert range_query._in_order
+

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -1,5 +1,4 @@
 import pytest
-
 from redis.commands.search.query import Query
 from redis.commands.search.result import Result
 
@@ -124,9 +123,10 @@ def test_vector_query():
         ["field1", "field2"],
         dialect=3,
         num_results=10,
-        in_order=True
+        in_order=True,
     )
     assert vector_query._in_order
+
 
 def test_range_query():
     # Create a filter expression
@@ -182,7 +182,7 @@ def test_range_query():
         ["field1"],
         filter_expression,
         num_results=10,
-        in_order=True
+        in_order=True,
     )
     assert range_query._in_order
 
@@ -193,7 +193,7 @@ def test_range_query():
         CountQuery(),
         FilterQuery(),
         VectorQuery(vector=[1, 2, 3], vector_field_name="vector"),
-        RangeQuery(vector=[1, 2, 3], vector_field_name="vector")
+        RangeQuery(vector=[1, 2, 3], vector_field_name="vector"),
     ],
 )
 def test_query_modifiers(query):

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -28,7 +28,7 @@ def test_count_query():
     # Test set_filter functionality
     new_filter_expression = Tag("category") == "Sportswear"
     count_query.set_filter(new_filter_expression)
-    assert count_query.get_filter() == new_filter_expression
+    assert count_query.filter == new_filter_expression
 
     fake_result = Result([2], "")
     assert process_results(fake_result, count_query, "json") == 2
@@ -43,7 +43,7 @@ def test_filter_query():
     # Check properties
     assert filter_query._return_fields == return_fields
     assert filter_query._num_results == 10
-    assert filter_query.get_filter() == filter_expression
+    assert filter_query.filter == filter_expression
     assert isinstance(filter_query, Query)
     assert isinstance(filter_query.query, Query)
     assert isinstance(filter_query.params, dict)
@@ -55,7 +55,7 @@ def test_filter_query():
     # Test set_filter functionality
     new_filter_expression = Tag("category") == "Sportswear"
     filter_query.set_filter(new_filter_expression)
-    assert filter_query.get_filter() == new_filter_expression
+    assert filter_query.filter == new_filter_expression
 
     # Test paging functionality
     filter_query.paging(5, 7)
@@ -98,7 +98,7 @@ def test_vector_query():
     # Test set_filter functionality
     new_filter_expression = Tag("category") == "Sportswear"
     vector_query.set_filter(new_filter_expression)
-    assert vector_query.get_filter() == new_filter_expression
+    assert vector_query.filter == new_filter_expression
 
     # Test paging functionality
     vector_query.paging(5, 7)
@@ -156,7 +156,7 @@ def test_range_query():
     # Test set_filter functionality
     new_filter_expression = Tag("category") == "Outdoor"
     range_query.set_filter(new_filter_expression)
-    assert range_query.get_filter() == new_filter_expression
+    assert range_query.filter == new_filter_expression
 
     # Test paging functionality
     range_query.paging(5, 7)


### PR DESCRIPTION
In order to support more advanced query params/settings of the Redis query engine, we needed a more flexible and customizable way to build RedisVL queries.

This PR introduces a simple refactor to inherit all redis-py Query module capabilities for each query type.

Source: https://github.com/redis/redis-py/blob/master/redis/commands/search/query.py

Updated user guide is still in flight **