### PR TITLE
Add async support to semantic cache extension

### DIFF
--- a/redisvl/extensions/llmcache/base.py
+++ b/redisvl/extensions/llmcache/base.py
@@ -31,7 +31,11 @@ class BaseLLMCache:
             self._ttl = None
 
     def clear(self) -> None:
-        """Clear the LLMCache of all keys in the index."""
+        """Clear the cache of all keys in the index."""
+        raise NotImplementedError
+
+    async def aclear(self) -> None:
+        """Async clear the cache of all keys in the index."""
         raise NotImplementedError
 
     def check(
@@ -41,6 +45,17 @@ class BaseLLMCache:
         num_results: int = 1,
         return_fields: Optional[List[str]] = None,
     ) -> List[dict]:
+        """Check the cache based on a prompt or vector."""
+        raise NotImplementedError
+
+    async def acheck(
+        self,
+        prompt: Optional[str] = None,
+        vector: Optional[List[float]] = None,
+        num_results: int = 1,
+        return_fields: Optional[List[str]] = None,
+    ) -> List[dict]:
+        """Async check the cache based on a prompt or vector."""
         raise NotImplementedError
 
     def store(
@@ -50,7 +65,18 @@ class BaseLLMCache:
         vector: Optional[List[float]] = None,
         metadata: Optional[dict] = {},
     ) -> str:
-        """Stores the specified key-value pair in the cache along with
+        """Store the specified key-value pair in the cache along with
+        metadata."""
+        raise NotImplementedError
+
+    async def astore(
+        self,
+        prompt: str,
+        response: str,
+        vector: Optional[List[float]] = None,
+        metadata: Optional[dict] = {},
+    ) -> str:
+        """Async store the specified key-value pair in the cache along with
         metadata."""
         raise NotImplementedError
 

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -8,7 +8,7 @@ from redisvl.extensions.llmcache.schema import (
     CacheHit,
     SemanticCacheIndexSchema,
 )
-from redisvl.index import SearchIndex
+from redisvl.index import AsyncSearchIndex, SearchIndex
 from redisvl.query import RangeQuery
 from redisvl.query.filter import FilterExpression
 from redisvl.utils.utils import current_timestamp, serialize, validate_vector_dims
@@ -26,6 +26,9 @@ class SemanticCache(BaseLLMCache):
     inserted_at_field_name: str = "inserted_at"
     updated_at_field_name: str = "updated_at"
     metadata_field_name: str = "metadata"
+
+    _index: SearchIndex
+    _aindex: Optional[AsyncSearchIndex] = None
 
     def __init__(
         self,
@@ -69,6 +72,12 @@ class SemanticCache(BaseLLMCache):
         """
         super().__init__(ttl)
 
+        self.redis_kwargs = {
+            "redis_client": redis_client,
+            "redis_url": redis_url,
+            "connection_kwargs": connection_kwargs,
+        }
+
         # Use the index name as the key prefix by default
         if "prefix" in kwargs:
             prefix = kwargs["prefix"]
@@ -81,7 +90,8 @@ class SemanticCache(BaseLLMCache):
                 model="sentence-transformers/all-mpnet-base-v2"
             )
 
-        # Process fields
+        # Process fields and other settings
+        self.set_threshold(distance_threshold)
         self.return_fields = [
             self.entry_id_field_name,
             self.prompt_field_name,
@@ -94,7 +104,6 @@ class SemanticCache(BaseLLMCache):
         # Create semantic cache schema and index
         schema = SemanticCacheIndexSchema.from_params(name, prefix, vectorizer.dims)
         schema = self._modify_schema(schema, filterable_fields)
-
         self._index = SearchIndex(schema=schema)
 
         # Handle redis connection
@@ -114,12 +123,18 @@ class SemanticCache(BaseLLMCache):
                     "If you wish to overwrite the index schema, set overwrite=True during initialization."
                 )
 
-        # Initialize other components
-        self._set_vectorizer(vectorizer)
-        self.set_threshold(distance_threshold)
-
-        # Create the index
+        # Create the search index
         self._index.create(overwrite=overwrite, drop=False)
+
+        # Initialize and validate vectorizer
+        if not isinstance(vectorizer, BaseVectorizer):
+            raise TypeError("Must provide a valid redisvl.vectorizer class.")
+
+        validate_vector_dims(
+            vectorizer.dims,
+            self._index.schema.fields[self.vector_field_name].attrs.dims,  # type: ignore
+        )
+        self._vectorizer = vectorizer
 
     def _modify_schema(
         self,
@@ -144,6 +159,21 @@ class SemanticCache(BaseLLMCache):
                 self.return_fields.append(field_name)
 
         return schema
+
+    async def _get_async_index(self) -> AsyncSearchIndex:
+        """Lazily construct the async search index class."""
+        if not self._aindex:
+            # Construct async index if necessary
+            self._aindex = AsyncSearchIndex(schema=self._index.schema)
+            # Connect Redis async client
+            redis_client = self.redis_kwargs["redis_client"]
+            redis_url = self.redis_kwargs["redis_url"]
+            connection_kwargs = self.redis_kwargs["connection_kwargs"]
+            if redis_client is not None:
+                await self._aindex.set_client(redis_client)
+            elif redis_url:
+                await self._aindex.connect(redis_url, **connection_kwargs)  # type: ignore
+        return self._aindex
 
     @property
     def index(self) -> SearchIndex:
@@ -179,35 +209,24 @@ class SemanticCache(BaseLLMCache):
             )
         self._distance_threshold = float(distance_threshold)
 
-    def _set_vectorizer(self, vectorizer: BaseVectorizer) -> None:
-        """Sets the vectorizer for the LLM cache.
-
-        Must be a valid subclass of BaseVectorizer and have equivalent
-        dimensions to the vector field defined in the schema.
-
-        Args:
-            vectorizer (BaseVectorizer): The RedisVL vectorizer to use for
-                vectorizing cache entries.
-
-        Raises:
-            TypeError: If the vectorizer is not a valid type.
-            ValueError: If the vector dimensions are mismatched.
-        """
-        if not isinstance(vectorizer, BaseVectorizer):
-            raise TypeError("Must provide a valid redisvl.vectorizer class.")
-
-        schema_vector_dims = self._index.schema.fields[self.vector_field_name].attrs.dims  # type: ignore
-        validate_vector_dims(vectorizer.dims, schema_vector_dims)
-        self._vectorizer = vectorizer
-
     def clear(self) -> None:
         """Clear the cache of all keys while preserving the index."""
         self._index.clear()
+
+    async def aclear(self) -> None:
+        """"""
+        aindex = await self._get_async_index()
+        await aindex.clear()
 
     def delete(self) -> None:
         """Clear the semantic cache of all keys and remove the underlying search
         index."""
         self._index.delete(drop=True)
+
+    async def adelete(self) -> None:
+        """"""
+        aindex = await self._get_async_index()
+        await aindex.delete(drop=True)
 
     def drop(
         self, ids: Optional[List[str]] = None, keys: Optional[List[str]] = None
@@ -224,10 +243,33 @@ class SemanticCache(BaseLLMCache):
         if keys is not None:
             self._index.drop_keys(keys)
 
+    async def adrop(
+        self, ids: Optional[List[str]] = None, keys: Optional[List[str]] = None
+    ) -> None:
+        """Async expire specific entries from the cache by id or specific
+        Redis key.
+
+        Args:
+            ids (Optional[str]): The document ID or IDs to remove from the cache.
+            keys (Optional[str]): The Redis keys to remove from the cache.
+        """
+        aindex = await self._get_async_index()
+
+        if ids is not None:
+            await aindex.drop_keys([self._index.key(id) for id in ids])
+        if keys is not None:
+            await aindex.drop_keys(keys)
+
     def _refresh_ttl(self, key: str) -> None:
         """Refresh the time-to-live for the specified key."""
         if self._ttl:
             self._index.client.expire(key, self._ttl)  # type: ignore
+
+    async def _async_refresh_ttl(self, key: str) -> None:
+        """Async refresh the time-to-live for the specified key."""
+        aindex = await self._get_async_index()
+        if self._ttl:
+            await aindex.client.expire(key, self._ttl)  # type: ignore
 
     def _vectorize_prompt(self, prompt: Optional[str]) -> List[float]:
         """Converts a text prompt to its vector representation using the
@@ -236,6 +278,14 @@ class SemanticCache(BaseLLMCache):
             raise TypeError("Prompt must be a string.")
 
         return self._vectorizer.embed(prompt)
+
+    async def _avectorize_prompt(self, prompt: Optional[str]) -> List[float]:
+        """Converts a text prompt to its vector representation using the
+        configured vectorizer."""
+        if not isinstance(prompt, str):
+            raise TypeError("Prompt must be a string.")
+
+        return await self._vectorizer.aembed(prompt)
 
     def _check_vector_dims(self, vector: List[float]):
         """Checks the size of the provided vector and raises an error if it
@@ -333,6 +383,98 @@ class SemanticCache(BaseLLMCache):
 
         return cache_hits
 
+    async def acheck(
+        self,
+        prompt: Optional[str] = None,
+        vector: Optional[List[float]] = None,
+        num_results: int = 1,
+        return_fields: Optional[List[str]] = None,
+        filter_expression: Optional[FilterExpression] = None,
+        distance_threshold: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Async check the semantic cache for results similar to the specified prompt
+        or vector.
+
+        This method searches the cache using vector similarity with
+        either a raw text prompt (converted to a vector) or a provided vector as
+        input. It checks for semantically similar prompts and fetches the cached
+        LLM responses.
+
+        Args:
+            prompt (Optional[str], optional): The text prompt to search for in
+                the cache.
+            vector (Optional[List[float]], optional): The vector representation
+                of the prompt to search for in the cache.
+            num_results (int, optional): The number of cached results to return.
+                Defaults to 1.
+            return_fields (Optional[List[str]], optional): The fields to include
+                in each returned result. If None, defaults to all available
+                fields in the cached entry.
+            filter_expression (Optional[FilterExpression]) : Optional filter expression
+                that can be used to filter cache results. Defaults to None and
+                the full cache will be searched.
+            distance_threshold (Optional[float]): The threshold for semantic
+                vector distance.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dicts containing the requested
+                return fields for each similar cached response.
+
+        Raises:
+            ValueError: If neither a `prompt` nor a `vector` is specified.
+            ValueError: if 'vector' has incorrect dimensions.
+            TypeError: If `return_fields` is not a list when provided.
+
+        .. code-block:: python
+
+            response = await cache.acheck(
+                prompt="What is the captial city of France?"
+            )
+        """
+        aindex = await self._get_async_index()
+
+        if not (prompt or vector):
+            raise ValueError("Either prompt or vector must be specified.")
+
+        # overrides
+        distance_threshold = distance_threshold or self._distance_threshold
+        return_fields = return_fields or self.return_fields
+        vector = vector or await self._avectorize_prompt(prompt)
+
+        self._check_vector_dims(vector)
+
+        if not isinstance(return_fields, list):
+            raise TypeError("return_fields must be a list of field names")
+
+        query = RangeQuery(
+            vector=vector,
+            vector_field_name=self.vector_field_name,
+            return_fields=self.return_fields,
+            distance_threshold=distance_threshold,
+            num_results=num_results,
+            return_score=True,
+            filter_expression=filter_expression,
+        )
+
+        cache_hits: List[Dict[Any, str]] = []
+
+        # Search the cache!
+        cache_search_results = await aindex.query(query)
+
+        for cache_search_result in cache_search_results:
+            key = cache_search_result["id"]
+            await self._async_refresh_ttl(key)
+
+            # Create cache hit
+            cache_hit = CacheHit(**cache_search_result)
+            cache_hit_dict = {
+                k: v for k, v in cache_hit.to_dict().items() if k in return_fields
+            }
+            cache_hit_dict["key"] = key
+            cache_hits.append(cache_hit_dict)
+
+        return cache_hits
+
     def store(
         self,
         prompt: str,
@@ -392,6 +534,67 @@ class SemanticCache(BaseLLMCache):
         )
         return keys[0]
 
+    async def astore(
+        self,
+        prompt: str,
+        response: str,
+        vector: Optional[List[float]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Async stores the specified key-value pair in the cache along with metadata.
+
+        Args:
+            prompt (str): The user prompt to cache.
+            response (str): The LLM response to cache.
+            vector (Optional[List[float]], optional): The prompt vector to
+                cache. Defaults to None, and the prompt vector is generated on
+                demand.
+            metadata (Optional[Dict[str, Any]], optional): The optional metadata to cache
+                alongside the prompt and response. Defaults to None.
+            filters (Optional[Dict[str, Any]]): The optional tag to assign to the cache entry.
+                Defaults to None.
+
+        Returns:
+            str: The Redis key for the entries added to the semantic cache.
+
+        Raises:
+            ValueError: If neither prompt nor vector is specified.
+            ValueError: if vector has incorrect dimensions.
+            TypeError: If provided metadata is not a dictionary.
+
+        .. code-block:: python
+
+            key = await cache.astore(
+                prompt="What is the captial city of France?",
+                response="Paris",
+                metadata={"city": "Paris", "country": "France"}
+            )
+        """
+        aindex = await self._get_async_index()
+
+        # Vectorize prompt if necessary and create cache payload
+        vector = vector or self._vectorize_prompt(prompt)
+
+        self._check_vector_dims(vector)
+
+        # Build cache entry for the cache
+        cache_entry = CacheEntry(
+            prompt=prompt,
+            response=response,
+            prompt_vector=vector,
+            metadata=metadata,
+            filters=filters,
+        )
+
+        # Load cache entry with TTL
+        keys = await aindex.load(
+            data=[cache_entry.to_dict()],
+            ttl=self._ttl,
+            id_field=self.entry_id_field_name,
+        )
+        return keys[0]
+
     def update(self, key: str, **kwargs) -> None:
         """Update specific fields within an existing cache entry. If no fields
         are passed, then only the document TTL is refreshed.
@@ -431,3 +634,48 @@ class SemanticCache(BaseLLMCache):
             self._index.client.hset(key, mapping=kwargs)  # type: ignore
 
         self._refresh_ttl(key)
+
+    async def aupdate(self, key: str, **kwargs) -> None:
+        """Async update specific fields within an existing cache entry. If no fields
+        are passed, then only the document TTL is refreshed.
+
+        Args:
+            key (str): the key of the document to update using kwargs.
+
+        Raises:
+            ValueError if an incorrect mapping is provided as a kwarg.
+            TypeError if metadata is provided and not of type dict.
+
+        .. code-block:: python
+
+            key = await cache.astore('this is a prompt', 'this is a response')
+            await cache.aupdate(
+                key,
+                metadata={"hit_count": 1, "model_name": "Llama-2-7b"}
+            )
+        """
+        aindex = await self._get_async_index()
+
+        if kwargs:
+            for k, v in kwargs.items():
+
+                # Make sure the item is in the index schema
+                if k not in set(
+                    self._index.schema.field_names + [self.metadata_field_name]
+                ):
+                    raise ValueError(f"{k} is not a valid field within the cache entry")
+
+                # Check for metadata and deserialize
+                if k == self.metadata_field_name:
+                    if isinstance(v, dict):
+                        kwargs[k] = serialize(v)
+                    else:
+                        raise TypeError(
+                            "If specified, cached metadata must be a dictionary."
+                        )
+
+            kwargs.update({self.updated_at_field_name: current_timestamp()})
+
+            await aindex.load(data=[kwargs], keys=[key])
+
+        await self._async_refresh_ttl(key)

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -61,6 +61,7 @@ class BaseVectorizer(BaseModel, ABC):
         as_buffer: bool = False,
         **kwargs,
     ) -> List[List[float]]:
+        # Fallback to standard embedding call if no async support
         return self.embed_many(texts, preprocess, batch_size, as_buffer, **kwargs)
 
     async def aembed(
@@ -70,6 +71,7 @@ class BaseVectorizer(BaseModel, ABC):
         as_buffer: bool = False,
         **kwargs,
     ) -> List[float]:
+        # Fallback to standard embedding call if no async support
         return self.embed(text, preprocess, as_buffer, **kwargs)
 
     def batchify(self, seq: list, size: int, preprocess: Optional[Callable] = None):

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -53,7 +53,6 @@ class BaseVectorizer(BaseModel, ABC):
     ) -> List[float]:
         raise NotImplementedError
 
-    @abstractmethod
     async def aembed_many(
         self,
         texts: List[str],
@@ -62,9 +61,8 @@ class BaseVectorizer(BaseModel, ABC):
         as_buffer: bool = False,
         **kwargs,
     ) -> List[List[float]]:
-        raise NotImplementedError
+        return self.embed_many(texts, preprocess, batch_size, as_buffer, **kwargs)
 
-    @abstractmethod
     async def aembed(
         self,
         text: str,
@@ -72,7 +70,7 @@ class BaseVectorizer(BaseModel, ABC):
         as_buffer: bool = False,
         **kwargs,
     ) -> List[float]:
-        raise NotImplementedError
+        return self.embed(text, preprocess, as_buffer, **kwargs)
 
     def batchify(self, seq: list, size: int, preprocess: Optional[Callable] = None):
         for pos in range(0, len(seq), size):

--- a/redisvl/utils/vectorize/text/cohere.py
+++ b/redisvl/utils/vectorize/text/cohere.py
@@ -235,25 +235,6 @@ class CohereTextVectorizer(BaseVectorizer):
             ]
         return embeddings
 
-    async def aembed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 1000,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[List[float]]:
-        raise NotImplementedError
-
-    async def aembed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[float]:
-        raise NotImplementedError
-
     @property
     def type(self) -> str:
         return "cohere"

--- a/redisvl/utils/vectorize/text/huggingface.py
+++ b/redisvl/utils/vectorize/text/huggingface.py
@@ -144,25 +144,6 @@ class HFTextVectorizer(BaseVectorizer):
             )
         return embeddings
 
-    async def aembed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 1000,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[List[float]]:
-        raise NotImplementedError
-
-    async def aembed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[float]:
-        raise NotImplementedError
-
     @property
     def type(self) -> str:
         return "hf"

--- a/redisvl/utils/vectorize/text/vertexai.py
+++ b/redisvl/utils/vectorize/text/vertexai.py
@@ -194,25 +194,6 @@ class VertexAITextVectorizer(BaseVectorizer):
         result = self._client.get_embeddings([text])
         return self._process_embedding(result[0].values, as_buffer)
 
-    async def aembed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 1000,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[List[float]]:
-        raise NotImplementedError
-
-    async def aembed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[float]:
-        raise NotImplementedError
-
     @property
     def type(self) -> str:
         return "vertexai"

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -152,9 +152,7 @@ async def test_search_index_client(async_client, index_schema):
 async def test_search_index_set_client(async_client, client, async_index):
     await async_index.set_client(async_client)
     assert async_index.client == async_client
-    # should not be able to set the sync client here
-    with pytest.raises(TypeError):
-        await async_index.set_client(client)
+    await async_index.set_client(client)
 
     async_index.disconnect()
     assert async_index.client == None

--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -464,8 +464,7 @@ def test_semantic_add_and_get_relevant(semantic_session):
     default_context = semantic_session.get_relevant("list of fruits and vegetables")
     assert len(default_context) == 5  # 2 pairs of prompt:response, and system
     assert default_context == semantic_session.get_relevant(
-        "list of fruits and vegetables",
-        distance_threshold=0.5
+        "list of fruits and vegetables", distance_threshold=0.5
     )
 
     # test tool calls can also be returned


### PR DESCRIPTION
This PR introduces new async compliant methods to the semantic cache class using lazy index construction. Because the `AsyncSearchIndex` requires an async redis python client, we needed to construct that class lazily upon first usage within the semantic cache class. This PR fixes some unclosed connection errors and is also in support of https://github.com/BerriAI/litellm/pull/5412 at LiteLLM.
