### PR TITLE
feature: support Redis Sentinel URL scheme

### DIFF
--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -464,8 +464,7 @@ def test_semantic_add_and_get_relevant(semantic_session):
     default_context = semantic_session.get_relevant("list of fruits and vegetables")
     assert len(default_context) == 5  # 2 pairs of prompt:response, and system
     assert default_context == semantic_session.get_relevant(
-        "list of fruits and vegetables",
-        distance_threshold=0.5
+        "list of fruits and vegetables", distance_threshold=0.5
     )
 
     # test tool calls can also be returned

--- a/tests/unit/test_sentinel_url.py
+++ b/tests/unit/test_sentinel_url.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import ConnectionError
+
+from redisvl.redis.connection import RedisConnectionFactory
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+def test_sentinel_url_connection(use_async):
+    sentinel_url = (
+        "redis+sentinel://username:password@host1:26379,host2:26380/mymaster/0"
+    )
+
+    with patch("redisvl.redis.connection.Sentinel") as mock_sentinel:
+        mock_master = MagicMock()
+        mock_sentinel.return_value.master_for.return_value = mock_master
+
+        if use_async:
+            client = RedisConnectionFactory.get_async_redis_connection(sentinel_url)
+        else:
+            client = RedisConnectionFactory.get_redis_connection(sentinel_url)
+
+        mock_sentinel.assert_called_once()
+        call_args = mock_sentinel.call_args
+        assert call_args[0][0] == [("host1", 26379), ("host2", 26380)]
+        assert call_args[1]["sentinel_kwargs"] == {
+            "username": "username",
+            "password": "password",
+        }
+
+        mock_sentinel.return_value.master_for.assert_called_once()
+        master_for_args = mock_sentinel.return_value.master_for.call_args
+        assert master_for_args[0][0] == "mymaster"
+        assert master_for_args[1]["db"] == "0"
+
+        assert client == mock_master
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+def test_sentinel_url_connection_no_auth_no_db(use_async):
+    sentinel_url = "redis+sentinel://host1:26379,host2:26380/mymaster"
+
+    with patch("redisvl.redis.connection.Sentinel") as mock_sentinel:
+        mock_master = MagicMock()
+        mock_sentinel.return_value.master_for.return_value = mock_master
+
+        if use_async:
+            client = RedisConnectionFactory.get_async_redis_connection(sentinel_url)
+        else:
+            client = RedisConnectionFactory.get_redis_connection(sentinel_url)
+
+        mock_sentinel.assert_called_once()
+        call_args = mock_sentinel.call_args
+        assert call_args[0][0] == [("host1", 26379), ("host2", 26380)]
+        assert (
+            "sentinel_kwargs" not in call_args[1]
+            or call_args[1]["sentinel_kwargs"] == {}
+        )
+
+        mock_sentinel.return_value.master_for.assert_called_once()
+        master_for_args = mock_sentinel.return_value.master_for.call_args
+        assert master_for_args[0][0] == "mymaster"
+        assert "db" not in master_for_args[1]
+
+        assert client == mock_master
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+def test_sentinel_url_connection_error(use_async):
+    sentinel_url = "redis+sentinel://host1:26379,host2:26380/mymaster"
+
+    with patch("redisvl.redis.connection.Sentinel") as mock_sentinel:
+        mock_sentinel.return_value.master_for.side_effect = ConnectionError(
+            "Test connection error"
+        )
+
+        with pytest.raises(ConnectionError):
+            if use_async:
+                RedisConnectionFactory.get_async_redis_connection(sentinel_url)
+            else:
+                RedisConnectionFactory.get_redis_connection(sentinel_url)
+
+        mock_sentinel.assert_called_once()


### PR DESCRIPTION
Port of the support for Sentinel URL that was present in LangChain Community, see https://github.com/langchain-ai/langchain/blob/a03141ac51e36828dedcf2bfcb964df22b6a7f4a/libs/community/langchain_community/utilities/redis.py#L127