### PR TITLE
adds filter fields to cache key name hash

### DIFF
--- a/redisvl/extensions/llmcache/base.py
+++ b/redisvl/extensions/llmcache/base.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-from redisvl.redis.utils import hashify
-
 
 class BaseLLMCache:
     def __init__(self, ttl: Optional[int] = None):
@@ -79,14 +77,3 @@ class BaseLLMCache:
         """Async store the specified key-value pair in the cache along with
         metadata."""
         raise NotImplementedError
-
-    def hash_input(self, prompt: str) -> str:
-        """Hashes the input prompt using SHA256.
-
-        Args:
-            prompt (str): Input string to be hashed.
-
-        Returns:
-            str: Hashed string.
-        """
-        return hashify(prompt)

--- a/redisvl/extensions/llmcache/schema.py
+++ b/redisvl/extensions/llmcache/schema.py
@@ -32,7 +32,7 @@ class CacheEntry(BaseModel):
     def generate_id(cls, values):
         # Ensure entry_id is set
         if not values.get("entry_id"):
-            values["entry_id"] = hashify(values["prompt"])
+            values["entry_id"] = hashify(values["prompt"], values.get("filters"))
         return values
 
     @validator("metadata")

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -43,6 +43,6 @@ def buffer_to_array(buffer: bytes, dtype: Any = np.float32) -> List[float]:
 def hashify(content: str, extras: Optional[Dict[str, Any]] = None) -> str:
     """Create a secure hash of some arbitrary input text and optional dictionary."""
     if extras:
-        extra_string = " ".join([str(k) + str(v) for k, v in extras.items()])
+        extra_string = " ".join([str(k) + str(v) for k, v in sorted(extras.items())])
         content = content + extra_string
     return hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -40,6 +40,9 @@ def buffer_to_array(buffer: bytes, dtype: Any = np.float32) -> List[float]:
     return np.frombuffer(buffer, dtype=dtype).tolist()
 
 
-def hashify(content: str) -> str:
-    """Create a secure hash of some arbitrary input text."""
+def hashify(content: str, extras: Optional[Dict[str, Any]] = None) -> str:
+    """Create a secure hash of some arbitrary input text and optional dictionary."""
+    if extras:
+        extra_string = " ".join([str(k) + str(v) for k, v in extras.items()])
+        content = content + extra_string
     return hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/tests/unit/test_llmcache_schema.py
+++ b/tests/unit/test_llmcache_schema.py
@@ -48,7 +48,7 @@ def test_cache_entry_to_dict():
         filters={"category": "technology"},
     )
     result = entry.to_dict()
-    assert result["entry_id"] == hashify("What is AI?")
+    assert result["entry_id"] == hashify("What is AI?", {"category": "technology"})
     assert result["metadata"] == json.dumps({"author": "John"})
     assert result["prompt_vector"] == array_to_buffer([0.1, 0.2, 0.3])
     assert result["category"] == "technology"


### PR DESCRIPTION
This PR aims to prevent cache entries being overwritten when the exact same prompt string is used, but other cache entry data - like user id, or some other field - is different.