### PR TITLE
moves extension field names into constants file

### DIFF
--- a/redisvl/extensions/constants.py
+++ b/redisvl/extensions/constants.py
@@ -1,0 +1,29 @@
+"""
+Constants used within the extension classes SemanticCache, BaseSessionManager,
+StandardSessionManager,SemanticSessionManager and SemanticRouter.
+These constants are also used within theses classes corresponding schema.
+"""
+
+# BaseSessionManager
+ID_FIELD_NAME: str = "entry_id"
+ROLE_FIELD_NAME: str = "role"
+CONTENT_FIELD_NAME: str = "content"
+TOOL_FIELD_NAME: str = "tool_call_id"
+TIMESTAMP_FIELD_NAME: str = "timestamp"
+SESSION_FIELD_NAME: str = "session_tag"
+
+# SemanticSessionManager
+SESSION_VECTOR_FIELD_NAME: str = "vector_field"
+
+# SemanticCache
+REDIS_KEY_FIELD_NAME: str = "key"
+ENTRY_ID_FIELD_NAME: str = "entry_id"
+PROMPT_FIELD_NAME: str = "prompt"
+RESPONSE_FIELD_NAME: str = "response"
+CACHE_VECTOR_FIELD_NAME: str = "prompt_vector"
+INSERTED_AT_FIELD_NAME: str = "inserted_at"
+UPDATED_AT_FIELD_NAME: str = "updated_at"
+METADATA_FIELD_NAME: str = "metadata"
+
+# SemanticRouter
+ROUTE_VECTOR_FIELD_NAME: str = "vector"

--- a/redisvl/extensions/llmcache/schema.py
+++ b/redisvl/extensions/llmcache/schema.py
@@ -2,6 +2,13 @@ from typing import Any, Dict, List, Optional
 
 from pydantic.v1 import BaseModel, Field, root_validator, validator
 
+from redisvl.extensions.constants import (
+    CACHE_VECTOR_FIELD_NAME,
+    INSERTED_AT_FIELD_NAME,
+    PROMPT_FIELD_NAME,
+    RESPONSE_FIELD_NAME,
+    UPDATED_AT_FIELD_NAME,
+)
 from redisvl.redis.utils import array_to_buffer, hashify
 from redisvl.schema import IndexSchema
 from redisvl.utils.utils import current_timestamp, deserialize, serialize
@@ -110,12 +117,12 @@ class SemanticCacheIndexSchema(IndexSchema):
         return cls(
             index={"name": name, "prefix": prefix},  # type: ignore
             fields=[  # type: ignore
-                {"name": "prompt", "type": "text"},
-                {"name": "response", "type": "text"},
-                {"name": "inserted_at", "type": "numeric"},
-                {"name": "updated_at", "type": "numeric"},
+                {"name": PROMPT_FIELD_NAME, "type": "text"},
+                {"name": RESPONSE_FIELD_NAME, "type": "text"},
+                {"name": INSERTED_AT_FIELD_NAME, "type": "numeric"},
+                {"name": UPDATED_AT_FIELD_NAME, "type": "numeric"},
                 {
-                    "name": "prompt_vector",
+                    "name": CACHE_VECTOR_FIELD_NAME,
                     "type": "vector",
                     "attrs": {
                         "dims": vector_dims,

--- a/redisvl/extensions/router/schema.py
+++ b/redisvl/extensions/router/schema.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional
 
 from pydantic.v1 import BaseModel, Field, validator
 
+from redisvl.extensions.constants import ROUTE_VECTOR_FIELD_NAME
 from redisvl.schema import IndexInfo, IndexSchema
 
 
@@ -104,7 +105,7 @@ class SemanticRouterIndexSchema(IndexSchema):
                 {"name": "route_name", "type": "tag"},
                 {"name": "reference", "type": "text"},
                 {
-                    "name": "vector",
+                    "name": ROUTE_VECTOR_FIELD_NAME,
                     "type": "vector",
                     "attrs": {
                         "algorithm": "flat",

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -8,6 +8,7 @@ from redis import Redis
 from redis.commands.search.aggregation import AggregateRequest, AggregateResult, Reducer
 from redis.exceptions import ResponseError
 
+from redisvl.extensions.constants import ROUTE_VECTOR_FIELD_NAME
 from redisvl.extensions.router.schema import (
     DistanceAggregationMethod,
     Route,
@@ -226,7 +227,7 @@ class SemanticRouter(BaseModel):
         """Classify to a single route using a vector."""
         vector_range_query = RangeQuery(
             vector=vector,
-            vector_field_name="vector",
+            vector_field_name=ROUTE_VECTOR_FIELD_NAME,
             distance_threshold=distance_threshold,
             return_fields=["route_name"],
         )
@@ -278,7 +279,7 @@ class SemanticRouter(BaseModel):
         """Classify to multiple routes, up to max_k (int), using a vector."""
         vector_range_query = RangeQuery(
             vector=vector,
-            vector_field_name="vector",
+            vector_field_name=ROUTE_VECTOR_FIELD_NAME,
             distance_threshold=distance_threshold,
             return_fields=["route_name"],
         )

--- a/redisvl/extensions/session_manager/base_session.py
+++ b/redisvl/extensions/session_manager/base_session.py
@@ -1,16 +1,15 @@
 from typing import Any, Dict, List, Optional, Union
 
+from redisvl.extensions.constants import (
+    CONTENT_FIELD_NAME,
+    ROLE_FIELD_NAME,
+    TOOL_FIELD_NAME,
+)
 from redisvl.extensions.session_manager.schema import ChatMessage
 from redisvl.utils.utils import create_uuid
 
 
 class BaseSessionManager:
-    id_field_name: str = "entry_id"
-    role_field_name: str = "role"
-    content_field_name: str = "content"
-    tool_field_name: str = "tool_call_id"
-    timestamp_field_name: str = "timestamp"
-    session_field_name: str = "session_tag"
 
     def __init__(
         self,
@@ -107,11 +106,11 @@ class BaseSessionManager:
                 context.append(chat_message.content)
             else:
                 chat_message_dict = {
-                    self.role_field_name: chat_message.role,
-                    self.content_field_name: chat_message.content,
+                    ROLE_FIELD_NAME: chat_message.role,
+                    CONTENT_FIELD_NAME: chat_message.content,
                 }
                 if chat_message.tool_call_id is not None:
-                    chat_message_dict[self.tool_field_name] = chat_message.tool_call_id
+                    chat_message_dict[TOOL_FIELD_NAME] = chat_message.tool_call_id
 
                 context.append(chat_message_dict)  # type: ignore
 

--- a/redisvl/extensions/session_manager/schema.py
+++ b/redisvl/extensions/session_manager/schema.py
@@ -2,6 +2,15 @@ from typing import Dict, List, Optional
 
 from pydantic.v1 import BaseModel, Field, root_validator
 
+from redisvl.extensions.constants import (
+    CONTENT_FIELD_NAME,
+    ID_FIELD_NAME,
+    ROLE_FIELD_NAME,
+    SESSION_FIELD_NAME,
+    SESSION_VECTOR_FIELD_NAME,
+    TIMESTAMP_FIELD_NAME,
+    TOOL_FIELD_NAME,
+)
 from redisvl.redis.utils import array_to_buffer
 from redisvl.schema import IndexSchema
 from redisvl.utils.utils import current_timestamp
@@ -31,18 +40,28 @@ class ChatMessage(BaseModel):
     @root_validator(pre=True)
     @classmethod
     def generate_id(cls, values):
-        if "timestamp" not in values:
-            values["timestamp"] = current_timestamp()
-        if "entry_id" not in values:
-            values["entry_id"] = f'{values["session_tag"]}:{values["timestamp"]}'
+        ###if "timestamp" not in values:
+        ###    values["timestamp"] = current_timestamp()
+        if TIMESTAMP_FIELD_NAME not in values:  ###
+            values[TIMESTAMP_FIELD_NAME] = current_timestamp()  ###
+        ###if "entry_id" not in values:
+        ###    values["entry_id"] = f'{values["session_tag"]}:{values["timestamp"]}'
+        if ID_FIELD_NAME not in values:  ###
+            values[ID_FIELD_NAME] = (
+                f"{values[SESSION_FIELD_NAME]}:{values[TIMESTAMP_FIELD_NAME]}"  ###
+            )
         return values
 
     def to_dict(self) -> Dict:
         data = self.dict(exclude_none=True)
 
         # handle optional fields
-        if "vector_field" in data:
-            data["vector_field"] = array_to_buffer(data["vector_field"])
+        ###if "vector_field" in data:
+        ###    data["vector_field"] = array_to_buffer(data["vector_field"])
+        if SESSION_VECTOR_FIELD_NAME in data:
+            data[SESSION_VECTOR_FIELD_NAME] = array_to_buffer(
+                data[SESSION_VECTOR_FIELD_NAME]
+            )
 
         return data
 
@@ -55,11 +74,11 @@ class StandardSessionIndexSchema(IndexSchema):
         return cls(
             index={"name": name, "prefix": prefix},  # type: ignore
             fields=[  # type: ignore
-                {"name": "role", "type": "tag"},
-                {"name": "content", "type": "text"},
-                {"name": "tool_call_id", "type": "tag"},
-                {"name": "timestamp", "type": "numeric"},
-                {"name": "session_tag", "type": "tag"},
+                {"name": ROLE_FIELD_NAME, "type": "tag"},
+                {"name": CONTENT_FIELD_NAME, "type": "text"},
+                {"name": TOOL_FIELD_NAME, "type": "tag"},
+                {"name": TIMESTAMP_FIELD_NAME, "type": "numeric"},
+                {"name": SESSION_FIELD_NAME, "type": "tag"},
             ],
         )
 
@@ -72,13 +91,13 @@ class SemanticSessionIndexSchema(IndexSchema):
         return cls(
             index={"name": name, "prefix": prefix},  # type: ignore
             fields=[  # type: ignore
-                {"name": "role", "type": "tag"},
-                {"name": "content", "type": "text"},
-                {"name": "tool_call_id", "type": "tag"},
-                {"name": "timestamp", "type": "numeric"},
-                {"name": "session_tag", "type": "tag"},
+                {"name": ROLE_FIELD_NAME, "type": "tag"},
+                {"name": CONTENT_FIELD_NAME, "type": "text"},
+                {"name": TOOL_FIELD_NAME, "type": "tag"},
+                {"name": TIMESTAMP_FIELD_NAME, "type": "numeric"},
+                {"name": SESSION_FIELD_NAME, "type": "tag"},
                 {
-                    "name": "vector_field",
+                    "name": SESSION_VECTOR_FIELD_NAME,
                     "type": "vector",
                     "attrs": {
                         "dims": vectorizer_dims,

--- a/redisvl/extensions/session_manager/schema.py
+++ b/redisvl/extensions/session_manager/schema.py
@@ -40,15 +40,11 @@ class ChatMessage(BaseModel):
     @root_validator(pre=True)
     @classmethod
     def generate_id(cls, values):
-        ###if "timestamp" not in values:
-        ###    values["timestamp"] = current_timestamp()
-        if TIMESTAMP_FIELD_NAME not in values:  ###
-            values[TIMESTAMP_FIELD_NAME] = current_timestamp()  ###
-        ###if "entry_id" not in values:
-        ###    values["entry_id"] = f'{values["session_tag"]}:{values["timestamp"]}'
-        if ID_FIELD_NAME not in values:  ###
+        if TIMESTAMP_FIELD_NAME not in values:
+            values[TIMESTAMP_FIELD_NAME] = current_timestamp()
+        if ID_FIELD_NAME not in values:
             values[ID_FIELD_NAME] = (
-                f"{values[SESSION_FIELD_NAME]}:{values[TIMESTAMP_FIELD_NAME]}"  ###
+                f"{values[SESSION_FIELD_NAME]}:{values[TIMESTAMP_FIELD_NAME]}"
             )
         return values
 
@@ -56,8 +52,6 @@ class ChatMessage(BaseModel):
         data = self.dict(exclude_none=True)
 
         # handle optional fields
-        ###if "vector_field" in data:
-        ###    data["vector_field"] = array_to_buffer(data["vector_field"])
         if SESSION_VECTOR_FIELD_NAME in data:
             data[SESSION_VECTOR_FIELD_NAME] = array_to_buffer(
                 data[SESSION_VECTOR_FIELD_NAME]

--- a/tests/integration/test_session_manager.py
+++ b/tests/integration/test_session_manager.py
@@ -1,6 +1,7 @@
 import pytest
 from redis.exceptions import ConnectionError
 
+from redisvl.extensions.constants import ID_FIELD_NAME
 from redisvl.extensions.session_manager import (
     SemanticSessionManager,
     StandardSessionManager,
@@ -261,7 +262,7 @@ def test_standard_drop(standard_session):
 
     # test drop(id) removes the specified element
     context = standard_session.get_recent(top_k=10, raw=True)
-    middle_id = context[3][standard_session.id_field_name]
+    middle_id = context[3][ID_FIELD_NAME]
     standard_session.drop(middle_id)
     context = standard_session.get_recent(top_k=6)
     assert context == [
@@ -527,7 +528,7 @@ def test_semantic_drop(semantic_session):
 
     # test drop(id) removes the specified element
     context = semantic_session.get_recent(top_k=5, raw=True)
-    middle_id = context[2][semantic_session.id_field_name]
+    middle_id = context[2][ID_FIELD_NAME]
     semantic_session.drop(middle_id)
     context = semantic_session.get_recent(top_k=4)
     assert context == [


### PR DESCRIPTION
Currently our cache, session, and router classes and their corresponding schema have fields like “vector_field_name” and “timestamp” hard coded into them. Since they must match between class and schema and we don’t want users to modify them they should be moved to a separate constants.py file.