### PR TITLE
Expose aggregation API from SearchIndex

### DIFF
--- a/redisvl/exceptions.py
+++ b/redisvl/exceptions.py
@@ -4,3 +4,7 @@ class RedisVLException(Exception):
 
 class RedisModuleVersionError(RedisVLException):
     """Invalid module versions installed"""
+
+
+class RedisSearchError(RedisVLException):
+    """Error while performing a search or aggregate request"""

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -256,9 +256,9 @@ class SemanticRouter(BaseModel):
         )
 
         try:
-            aggregation_result: AggregateResult = self._index.client.ft(  # type: ignore
-                self._index.name
-            ).aggregate(aggregate_request, vector_range_query.params)
+            aggregation_result: AggregateResult = self._index.aggregate(
+                aggregate_request, vector_range_query.params
+            )
         except ResponseError as e:
             if "VSS is not yet supported on FT.AGGREGATE" in str(e):
                 raise RuntimeError(
@@ -308,9 +308,9 @@ class SemanticRouter(BaseModel):
         )
 
         try:
-            aggregation_result: AggregateResult = self._index.client.ft(  # type: ignore
-                self._index.name
-            ).aggregate(aggregate_request, vector_range_query.params)
+            aggregation_result: AggregateResult = self._index.aggregate(
+                aggregate_request, vector_range_query.params
+            )
         except ResponseError as e:
             if "VSS is not yet supported on FT.AGGREGATE" in str(e):
                 raise RuntimeError(

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from redis.commands.search.aggregation import AggregateResult
     from redis.commands.search.document import Document
     from redis.commands.search.result import Result
     from redisvl.query.query import BaseQuery
@@ -629,7 +630,7 @@ class SearchIndex(BaseSearchIndex):
             return convert_bytes(obj[0])
         return None
 
-    def aggregate(self, *args, **kwargs) -> List[List[Any]]:
+    def aggregate(self, *args, **kwargs) -> "AggregateResult":
         """Perform an aggregation operation against the index.
 
         Wrapper around the aggregation API that adds the index name
@@ -1167,7 +1168,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             return convert_bytes(obj[0])
         return None
 
-    async def aggregate(self, *args, **kwargs) -> List[List[Any]]:
+    async def aggregate(self, *args, **kwargs) -> "AggregateResult":
         """Perform an aggregation operation against the index.
 
         Wrapper around the aggregation API that adds the index name

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -25,7 +25,7 @@ import redis
 import redis.asyncio as aredis
 from redis.commands.search.indexDefinition import IndexDefinition
 
-from redisvl.exceptions import RedisModuleVersionError
+from redisvl.exceptions import RedisModuleVersionError, RedisSearchError
 from redisvl.index.storage import BaseStorage, HashStorage, JsonStorage
 from redisvl.query import BaseQuery, CountQuery, FilterQuery
 from redisvl.query.filter import FilterExpression
@@ -643,11 +643,9 @@ class SearchIndex(BaseSearchIndex):
             return self._redis_client.ft(self.schema.index.name).aggregate(  # type: ignore
                 *args, **kwargs
             )
-        except:
-            logger.exception("Error while searching")
-            raise
+       except Exception as e:
+            raise RedisSearchError(f"Error while aggregating: {str(e)}") from e
 
-    @check_index_exists()
     def search(self, *args, **kwargs) -> "Result":
         """Perform a search against the index.
 
@@ -662,9 +660,8 @@ class SearchIndex(BaseSearchIndex):
             return self._redis_client.ft(self.schema.index.name).search(  # type: ignore
                 *args, **kwargs
             )
-        except:
-            logger.exception("Error while searching")
-            raise
+       except Exception as e:
+            raise RedisSearchError(f"Error while searching: {str(e)}") from e
 
     def _query(self, query: BaseQuery) -> List[Dict[str, Any]]:
         """Execute a query and process results."""
@@ -1184,11 +1181,9 @@ class AsyncSearchIndex(BaseSearchIndex):
             return await self._redis_client.ft(self.schema.index.name).aggregate(  # type: ignore
                 *args, **kwargs
             )
-        except:
-            logger.exception("Error while searching")
-            raise
+        except Exception as e:
+            raise RedisSearchError(f"Error while aggregating: {str(e)}") from e
 
-    @check_async_index_exists()
     async def search(self, *args, **kwargs) -> "Result":
         """Perform a search on this index.
 
@@ -1203,9 +1198,8 @@ class AsyncSearchIndex(BaseSearchIndex):
             return await self._redis_client.ft(self.schema.index.name).search(  # type: ignore
                 *args, **kwargs
             )
-        except:
-            logger.exception("Error while searching")
-            raise
+        except Exception as e:
+            raise RedisSearchError(f"Error while searching: {str(e)}") from e
 
     async def _query(self, query: BaseQuery) -> List[Dict[str, Any]]:
         """Asynchronously execute a query and process results."""

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -629,13 +629,31 @@ class SearchIndex(BaseSearchIndex):
             return convert_bytes(obj[0])
         return None
 
+    def aggregate(self, *args, **kwargs) -> List[List[Any]]:
+        """Perform an aggregation operation against the index.
+
+        Wrapper around the aggregation API that adds the index name
+        to the query and passes along the rest of the arguments
+        to the redis-py ft().aggregate() method.
+
+        Returns:
+            Result: Raw Redis aggregation results.
+        """
+        try:
+            return self._redis_client.ft(self.schema.index.name).aggregate(  # type: ignore
+                *args, **kwargs
+            )
+        except:
+            logger.exception("Error while searching")
+            raise
+
     @check_index_exists()
     def search(self, *args, **kwargs) -> "Result":
         """Perform a search against the index.
 
-        Wrapper around redis.search.Search that adds the index name
-        to the search query and passes along the rest of the arguments
-        to the redis-py ft.search() method.
+        Wrapper around the search API that adds the index name
+        to the query and passes along the rest of the arguments
+        to the redis-py ft().search() method.
 
         Returns:
             Result: Raw Redis search results.
@@ -1151,6 +1169,24 @@ class AsyncSearchIndex(BaseSearchIndex):
         if obj:
             return convert_bytes(obj[0])
         return None
+
+    async def aggregate(self, *args, **kwargs) -> List[List[Any]]:
+        """Perform an aggregation operation against the index.
+
+        Wrapper around the aggregation API that adds the index name
+        to the query and passes along the rest of the arguments
+        to the redis-py ft().aggregate() method.
+
+        Returns:
+            Result: Raw Redis aggregation results.
+        """
+        try:
+            return await self._redis_client.ft(self.schema.index.name).aggregate(  # type: ignore
+                *args, **kwargs
+            )
+        except:
+            logger.exception("Error while searching")
+            raise
 
     @check_async_index_exists()
     async def search(self, *args, **kwargs) -> "Result":

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -1,5 +1,6 @@
 import pytest
 
+from redisvl.exceptions import RedisSearchError
 from redisvl.index import AsyncSearchIndex
 from redisvl.query import VectorQuery
 from redisvl.redis.utils import convert_bytes
@@ -291,7 +292,7 @@ async def test_check_index_exists_before_delete(async_client, async_index):
     await async_index.set_client(async_client)
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
-    with pytest.raises(ValueError):
+    with pytest.raises(RedisSearchError):
         await async_index.delete()
 
 
@@ -307,7 +308,7 @@ async def test_check_index_exists_before_search(async_client, async_index):
         return_fields=["user", "credit_score", "age", "job", "location"],
         num_results=7,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(RedisSearchError):
         await async_index.search(query.query, query_params=query.params)
 
 
@@ -317,5 +318,5 @@ async def test_check_index_exists_before_info(async_client, async_index):
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RedisSearchError):
         await async_index.info()

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -1,5 +1,6 @@
 import pytest
 
+from redisvl.exceptions import RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.query import VectorQuery
 from redisvl.redis.connection import RedisConnectionFactory, validate_modules
@@ -251,7 +252,7 @@ def test_check_index_exists_before_delete(client, index):
     index.set_client(client)
     index.create(overwrite=True, drop=True)
     index.delete(drop=True)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RedisSearchError):
         index.delete()
 
 
@@ -266,7 +267,7 @@ def test_check_index_exists_before_search(client, index):
         return_fields=["user", "credit_score", "age", "job", "location"],
         num_results=7,
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RedisSearchError):
         index.search(query.query, query_params=query.params)
 
 
@@ -275,7 +276,7 @@ def test_check_index_exists_before_info(client, index):
     index.create(overwrite=True, drop=True)
     index.delete(drop=True)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RedisSearchError):
         index.info()
 
 


### PR DESCRIPTION
In order to support more advanced queries, we expose the `aggregate` method to pass through to the core Redis FT.AGGREGATE API. This PR also simplifies and standardizes error handling for Redis searches/aggregations on the index.