### PR TITLE
Fix sentence transformers reranker import

### DIFF
--- a/redisvl/utils/rerank/cohere.py
+++ b/redisvl/utils/rerank/cohere.py
@@ -83,7 +83,7 @@ class CohereReranker(BaseReranker):
             from cohere import AsyncClient, Client
         except ImportError:
             raise ImportError(
-                "Cohere vectorizer requires the cohere library. \
+                "Cohere reranker requires the cohere library. \
                     Please install with `pip install cohere`"
             )
 


### PR DESCRIPTION
Sentence transformers was not being dynamically imported into the reranker module for hugging face, causing dependency issues for anyone using a reranker. Fixes https://github.com/redis/redis-vl-python/issues/229