### PR TITLE
Expose show_progress_bar

### DIFF
--- a/redisvl/utils/vectorize/text/huggingface.py
+++ b/redisvl/utils/vectorize/text/huggingface.py
@@ -99,7 +99,7 @@ class HFTextVectorizer(BaseVectorizer):
 
         if preprocess:
             text = preprocess(text)
-        embedding = self._client.encode([text])[0]
+        embedding = self._client.encode([text], **kwargs)[0]
         return self._process_embedding(embedding.tolist(), as_buffer, **kwargs)
 
     def embed_many(
@@ -135,7 +135,7 @@ class HFTextVectorizer(BaseVectorizer):
 
         embeddings: List = []
         for batch in self.batchify(texts, batch_size, preprocess):
-            batch_embeddings = self._client.encode(batch)
+            batch_embeddings = self._client.encode(batch, **kwargs)
             embeddings.extend(
                 [
                     self._process_embedding(embedding.tolist(), as_buffer, **kwargs)


### PR DESCRIPTION
Address https://github.com/redis/redis-vl-python/issues/232

Now  **kwargs are being passed from `hf.embed()` and `hf.embed_many()` to the underlying `model.encode()`

```
from redisvl.utils.vectorize import HFTextVectorizer
from tqdm.auto import tqdm
hf = HFTextVectorizer(model="sentence-transformers/all-MiniLM-L6-v2")
# Embed a sentence
test = hf.embed("This is a test sentence.", show_progress_bar=True) #progress bar would show
test = hf.embed("This is a test sentence.") #progress bar would show (default behavior as before)
test = hf.embed("This is a test sentence.", show_progress_bar=False) #progress bar would NOT show

# Uncomment to see vector embedding output
print(test[:10])
```