### PR TITLE
manually parse special attributes that have no associated value

### DIFF
--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -98,17 +98,22 @@ def convert_index_info_to_schema(index_info: Dict[str, Any]) -> Dict[str, Any]:
         return vector_attrs
 
     def parse_attrs(attrs):
-        # 'SORTABLE', 'UNF', 'NOSTEM' don't have corresponding values.
+        # 'SORTABLE', 'NOSTEM' don't have corresponding values.
         # Their presence indicates boolean True
+        # TODO 'WITHSUFFIXTRIE' is another boolean attr, but is not returned by ft.info
         original = attrs.copy()
         parsed_attrs = {}
         if "NOSTEM" in attrs:
             parsed_attrs["no_stem"] = True
             attrs.remove("NOSTEM")
-        for special_attr in ["SORTABLE", "UNF"]:
-            if special_attr in attrs:
-                parsed_attrs[special_attr.lower()] = True
-                attrs.remove(special_attr)
+        if "CASESENSITIVE" in attrs:
+            parsed_attrs["case_sensitive"] = True
+            attrs.remove("CASESENSITIVE")
+        if "SORTABLE" in attrs:
+            parsed_attrs["sortable"] = True
+            attrs.remove("SORTABLE")
+            if "UNF" in attrs:
+                attrs.remove("UNF")  # UNF present on sortable numeric fields only
 
         try:
             parsed_attrs.update(

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -98,7 +98,25 @@ def convert_index_info_to_schema(index_info: Dict[str, Any]) -> Dict[str, Any]:
         return vector_attrs
 
     def parse_attrs(attrs):
-        return {attrs[i].lower(): attrs[i + 1] for i in range(6, len(attrs), 2)}
+        # 'SORTABLE', 'UNF', 'NOSTEM' don't have corresponding values.
+        # Their presence indicates boolean True
+        original = attrs.copy()
+        parsed_attrs = {}
+        if "NOSTEM" in attrs:
+            parsed_attrs["no_stem"] = True
+            attrs.remove("NOSTEM")
+        for special_attr in ["SORTABLE", "UNF"]:
+            if special_attr in attrs:
+                parsed_attrs[special_attr.lower()] = True
+                attrs.remove(special_attr)
+
+        try:
+            parsed_attrs.update(
+                {attrs[i].lower(): attrs[i + 1] for i in range(6, len(attrs), 2)}
+            )
+        except IndexError as e:
+            raise IndexError(f"Error parsing index attributes {original}, {str(e)}")
+        return parsed_attrs
 
     schema_fields = []
 

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -6,7 +6,15 @@ from redisvl.redis.connection import RedisConnectionFactory, validate_modules
 from redisvl.redis.utils import convert_bytes
 from redisvl.schema import IndexSchema, StorageType
 
-fields = [{"name": "test", "type": "tag"}]
+fields = [
+    {"name": "test", "type": "tag"},
+    {"name": "test_text", "type": "text"},
+    {
+        "name": "test_text_attrs",
+        "type": "text",
+        "attrs": {"no_stem": True, "sortable": True},
+    },
+]
 
 
 @pytest.fixture
@@ -87,7 +95,7 @@ def test_search_index_from_existing_complex(client):
                 "name": "age",
                 "type": "numeric",
                 "path": "$.metadata.age",
-                "attrs": {"sortable": False},
+                "attrs": {"sortable": True},
             },
             {
                 "name": "user_embedding",

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -14,6 +14,9 @@ fields = [
         "type": "text",
         "attrs": {"no_stem": True, "sortable": True},
     },
+    {"name": "test_tag", "type": "tag", "attrs": {"case_sensitive": True}},
+    {"name": "test_numeric", "type": "numeric"},
+    {"name": "test_numeric_attrs", "type": "numeric", "attrs": {"sortable": True}},
 ]
 
 


### PR DESCRIPTION
When converting existing index info into a schema certain attributes have a name and value, while others are indicated as True/False only by their presence in the attributes list. These have to be removed and parsed manually before parsing the remaining items.