### PR TITLE
add hf reranker, fix edit on github, searchindex links

### DIFF
--- a/docs/api/reranker.rst
+++ b/docs/api/reranker.rst
@@ -12,3 +12,15 @@ CohereReranker
 .. autoclass:: CohereReranker
    :show-inheritance:
    :members:
+
+
+HFCrossEncoderReranker
+========================
+
+.. _hfcrossencoderreranker_api:
+
+.. currentmodule:: redisvl.utils.rerank.hf_cross_encoder
+
+.. autoclass:: HFCrossEncoderReranker
+   :show-inheritance:
+   :members:

--- a/docs/api/searchindex.rst
+++ b/docs/api/searchindex.rst
@@ -8,15 +8,15 @@ Search Index Classes
 
    * - Class
      - Description
-   * - `SearchIndex <#searchindex_api>`_
+   * - :ref:`searchindex_api`
      - Primary class to write, read, and search across data structures in Redis.
-   * - `AsyncSearchIndex <#asyncsearchindex_api>`_
+   * - :ref:`asyncsearchindex_api`
      - Async version of the SearchIndex to write, read, and search across data structures in Redis.
+
+.. _searchindex_api:
 
 SearchIndex
 ===========
-
-.. _searchindex_api:
 
 .. currentmodule:: redisvl.index
 
@@ -24,10 +24,10 @@ SearchIndex
    :inherited-members:
    :members:
 
+.. _asyncsearchindex_api:
+
 AsyncSearchIndex
 ================
-
-.. _asyncsearchindex_api:
 
 .. currentmodule:: redisvl.index
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,8 +79,8 @@ html_context = {
 html_logo = "_static/Redis_Favicon_32x32_Red.png"
 html_favicon = "_static/Redis_Favicon_32x32_Red.png"
 html_context = {
-    "github_user": "Redis",
-    "github_repo": "Redis-VL-python",
+    "github_user": "redis",
+    "github_repo": "redis-vl-python",
     "github_version": "main",
     "doc_path": "docs",
 }


### PR DESCRIPTION
Misc documentation changes:

- Add missing HFCrossEncoderReranker to API docs
- Fix internal (anchor) links in Search Index API docs
- Fix "edit on GitHub" link