### PR TITLE
Fix recommender link

### DIFF
--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -7,6 +7,6 @@
 - title: Redis RAG Workbench
   website: https://github.com/redis-developer/redis-rag-workbench
 - title: LLM Recommender for Hotels
-  website: https://github.com/redis-applied-ai/LLM-Recommender
+  website: https://github.com/redis-developer/LLM-Recommender
 - title: Agentic RAG
   website: https://github.com/redis-developer/agentic-rag


### PR DESCRIPTION
Looks like it points to the wrong GitHub org.