### PR TITLE
Add a default for the `dtype` field of `BaseVectorizer`

### DIFF
--- a/redisvl/schema/schema.py
+++ b/redisvl/schema/schema.py
@@ -170,12 +170,12 @@ class IndexSchema(BaseModel):
 
     @root_validator(pre=True)
     @classmethod
-    def validate_and_create_fields(cls, values):
+    def validate_and_create_ields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Validate uniqueness of field names and create valid field instances.
         """
         # Ensure index is a dictionary for validation
-        index = values.get("index")
+        index = values.get("index", {})
         if not isinstance(index, IndexInfo):
             index = IndexInfo(**index)
 

--- a/redisvl/schema/schema.py
+++ b/redisvl/schema/schema.py
@@ -170,7 +170,7 @@ class IndexSchema(BaseModel):
 
     @root_validator(pre=True)
     @classmethod
-    def validate_and_create_ields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_and_create_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Validate uniqueness of field names and create valid field instances.
         """

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Callable, List, Optional
 
-from pydantic.v1 import BaseModel, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from redisvl.redis.utils import array_to_buffer
 from redisvl.schema.fields import VectorDataType
@@ -21,7 +21,7 @@ class Vectorizers(Enum):
 class BaseVectorizer(BaseModel, ABC):
     model: str
     dims: int
-    dtype: str
+    dtype: str = Field(default="float32")
 
     @property
     def type(self) -> str:

--- a/tests/unit/test_base_vectorizer.py
+++ b/tests/unit/test_base_vectorizer.py
@@ -1,0 +1,32 @@
+from typing import List
+from redisvl.utils.vectorize.base import BaseVectorizer
+
+
+
+def test_base_vectorizer_defaults():
+    """
+    Test that the base vectorizer defaults are set correctly, with 
+    a default for dtype. Versions before 0.3.8 did not have this field.
+
+    A regression test for langchain-redis/#48
+    """
+    class SimpleVectorizer(BaseVectorizer):
+        model: str = "simple"
+        dims: int = 10
+        
+        def embed(self, text: str, **kwargs) -> List[float]:
+            return [0.0] * self.dims
+        
+        async def aembed(self, text: str, **kwargs) -> List[float]:
+            return [0.0] * self.dims
+        
+        async def aembed_many(self, texts: List[str], **kwargs) -> List[List[float]]:
+            return [[0.0] * self.dims] * len(texts)
+        
+        def embed_many(self, texts: List[str], **kwargs) -> List[List[float]]:
+            return [[0.0] * self.dims] * len(texts)
+
+    vectorizer = SimpleVectorizer()
+    assert vectorizer.model == "simple"
+    assert vectorizer.dims == 10
+    assert vectorizer.dtype == "float32"


### PR DESCRIPTION
In 0.3.8, we introduced a new field to `BaseVectorizer`, `dtype`, but did not give it a default value. This broke downstream software written against previous versions of redisvl that lacked this field.

Fixes [langchain/langchain-redis#48](https://github.com/langchain-ai/langchain-redis/issues/48).