### PR TITLE
Properly handle asyncio.gather() call in SemanticCache.aheck

### DIFF
--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -462,7 +462,7 @@ class SemanticCache(BaseLLMCache):
             cache_search_results, return_fields  # type: ignore
         )
         # Extend TTL on keys
-        asyncio.gather(*[self._async_refresh_ttl(key) for key in redis_keys])
+        await asyncio.gather(*[self._async_refresh_ttl(key) for key in redis_keys])
 
         return cache_hits
 

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -272,7 +272,7 @@ async def test_async_ttl_expiration(cache_with_ttl, vectorizer):
     vector = vectorizer.embed(prompt)
 
     await cache_with_ttl.astore(prompt, response, vector=vector)
-    sleep(3)
+    await asyncio.sleep(3)
 
     check_result = await cache_with_ttl.acheck(vector=vector)
     assert len(check_result) == 0
@@ -442,7 +442,7 @@ async def test_async_updating_document(cache):
     check_result = await cache.acheck(prompt=prompt, return_fields=["updated_at"])
     key = check_result[0]["key"]
 
-    sleep(1)
+    await asyncio.sleep(1)
 
     metadata = {"foo": "bar"}
     await cache.aupdate(key=key, metadata=metadata)
@@ -479,7 +479,7 @@ async def test_async_ttl_expiration_after_update(cache_with_ttl, vectorizer):
     assert cache_with_ttl.ttl == 4
 
     await cache_with_ttl.astore(prompt, response, vector=vector)
-    sleep(5)
+    await asyncio.sleep(5)
 
     check_result = await cache_with_ttl.acheck(vector=vector)
     assert len(check_result) == 0


### PR DESCRIPTION
An `asyncio.gather()` call should be awaited. Failing to await it causes the tasks to run after the method exits, which can cause unexpected behavior, including failure if the event loop no longer exists.

Fixes RAE-564