### PR TITLE
Consider vectorizer the owner of dtype

### DIFF
--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -86,11 +86,27 @@ class SemanticCache(BaseLLMCache):
         else:
             prefix = name
 
-        # Set vectorizer default
-        if vectorizer is None:
+        # Validate a provided vectorizer or set the default
+        if vectorizer:
+            if not isinstance(vectorizer, BaseVectorizer):
+                raise TypeError("Must provide a valid redisvl.vectorizer class.")
+        else:
+            dtype = kwargs.get("dtype")
+            vectorizer_kwargs = {"dtype": dtype} if dtype else {}
+
             vectorizer = HFTextVectorizer(
-                model="sentence-transformers/all-mpnet-base-v2"
+                model="sentence-transformers/all-mpnet-base-v2",
+                **vectorizer_kwargs,
             )
+
+        self._vectorizer = vectorizer
+
+        # Create semantic cache schema and index
+        schema = SemanticCacheIndexSchema.from_params(
+            name, prefix, vectorizer.dims, vectorizer.dtype
+        )
+        schema = self._modify_schema(schema, filterable_fields)
+        self._index = SearchIndex(schema=schema)
 
         # Process fields and other settings
         self.set_threshold(distance_threshold)
@@ -102,14 +118,6 @@ class SemanticCache(BaseLLMCache):
             UPDATED_AT_FIELD_NAME,
             METADATA_FIELD_NAME,
         ]
-
-        # Create semantic cache schema and index
-        dtype = kwargs.get("dtype", "float32")
-        schema = SemanticCacheIndexSchema.from_params(
-            name, prefix, vectorizer.dims, dtype
-        )
-        schema = self._modify_schema(schema, filterable_fields)
-        self._index = SearchIndex(schema=schema)
 
         # Handle redis connection
         if redis_client:
@@ -128,19 +136,8 @@ class SemanticCache(BaseLLMCache):
                     "If you wish to overwrite the index schema, set overwrite=True during initialization."
                 )
 
-        # Create the search index
+        # Create the search index in Redis
         self._index.create(overwrite=overwrite, drop=False)
-
-        # Initialize and validate vectorizer
-        if not isinstance(vectorizer, BaseVectorizer):
-            raise TypeError("Must provide a valid redisvl.vectorizer class.")
-
-        validate_vector_dims(
-            vectorizer.dims,
-            self._index.schema.fields[CACHE_VECTOR_FIELD_NAME].attrs.dims,  # type: ignore
-        )
-        self._vectorizer = vectorizer
-        self._dtype = self.index.schema.fields[CACHE_VECTOR_FIELD_NAME].attrs.datatype  # type: ignore[union-attr]
 
     def _modify_schema(
         self,
@@ -290,7 +287,7 @@ class SemanticCache(BaseLLMCache):
         if not isinstance(prompt, str):
             raise TypeError("Prompt must be a string.")
 
-        return self._vectorizer.embed(prompt, dtype=self._dtype)
+        return self._vectorizer.embed(prompt)
 
     async def _avectorize_prompt(self, prompt: Optional[str]) -> List[float]:
         """Converts a text prompt to its vector representation using the
@@ -372,7 +369,7 @@ class SemanticCache(BaseLLMCache):
             num_results=num_results,
             return_score=True,
             filter_expression=filter_expression,
-            dtype=self._dtype,
+            dtype=self._vectorizer.dtype,
         )
 
         # Search the cache!
@@ -543,7 +540,7 @@ class SemanticCache(BaseLLMCache):
         # Load cache entry with TTL
         ttl = ttl or self._ttl
         keys = self._index.load(
-            data=[cache_entry.to_dict(self._dtype)],
+            data=[cache_entry.to_dict(self._vectorizer.dtype)],
             ttl=ttl,
             id_field=ENTRY_ID_FIELD_NAME,
         )
@@ -607,7 +604,7 @@ class SemanticCache(BaseLLMCache):
         # Load cache entry with TTL
         ttl = ttl or self._ttl
         keys = await aindex.load(
-            data=[cache_entry.to_dict(self._dtype)],
+            data=[cache_entry.to_dict(self._vectorizer.dtype)],
             ttl=ttl,
             id_field=ENTRY_ID_FIELD_NAME,
         )

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -86,12 +86,17 @@ class SemanticCache(BaseLLMCache):
         else:
             prefix = name
 
+        dtype = kwargs.get("dtype")
+
         # Validate a provided vectorizer or set the default
         if vectorizer:
             if not isinstance(vectorizer, BaseVectorizer):
                 raise TypeError("Must provide a valid redisvl.vectorizer class.")
+            if dtype and vectorizer.dtype != dtype:
+                raise ValueError(
+                    f"Provided dtype {dtype} does not match vectorizer dtype {vectorizer.dtype}"
+                )
         else:
-            dtype = kwargs.get("dtype")
             vectorizer_kwargs = {"dtype": dtype} if dtype else {}
 
             vectorizer = HFTextVectorizer(

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -22,7 +22,7 @@ from redisvl.extensions.llmcache.schema import (
 from redisvl.index import AsyncSearchIndex, SearchIndex
 from redisvl.query import RangeQuery
 from redisvl.query.filter import FilterExpression
-from redisvl.utils.utils import current_timestamp, serialize, validate_vector_dims
+from redisvl.utils.utils import current_timestamp, deprecated_argument, serialize, validate_vector_dims
 from redisvl.utils.vectorize import BaseVectorizer, HFTextVectorizer
 
 
@@ -32,6 +32,7 @@ class SemanticCache(BaseLLMCache):
     _index: SearchIndex
     _aindex: Optional[AsyncSearchIndex] = None
 
+    @deprecated_argument("dtype", "vectorizer")
     def __init__(
         self,
         name: str = "llmcache",

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -101,13 +101,6 @@ class SemanticCache(BaseLLMCache):
 
         self._vectorizer = vectorizer
 
-        # Create semantic cache schema and index
-        schema = SemanticCacheIndexSchema.from_params(
-            name, prefix, vectorizer.dims, vectorizer.dtype
-        )
-        schema = self._modify_schema(schema, filterable_fields)
-        self._index = SearchIndex(schema=schema)
-
         # Process fields and other settings
         self.set_threshold(distance_threshold)
         self.return_fields = [
@@ -118,6 +111,13 @@ class SemanticCache(BaseLLMCache):
             UPDATED_AT_FIELD_NAME,
             METADATA_FIELD_NAME,
         ]
+
+        # Create semantic cache schema and index
+        schema = SemanticCacheIndexSchema.from_params(
+            name, prefix, vectorizer.dims, vectorizer.dtype
+        )
+        schema = self._modify_schema(schema, filterable_fields)
+        self._index = SearchIndex(schema=schema)
 
         # Handle redis connection
         if redis_client:

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -22,7 +22,12 @@ from redisvl.extensions.llmcache.schema import (
 from redisvl.index import AsyncSearchIndex, SearchIndex
 from redisvl.query import RangeQuery
 from redisvl.query.filter import FilterExpression
-from redisvl.utils.utils import current_timestamp, deprecated_argument, serialize, validate_vector_dims
+from redisvl.utils.utils import (
+    current_timestamp,
+    deprecated_argument,
+    serialize,
+    validate_vector_dims,
+)
 from redisvl.utils.vectorize import BaseVectorizer, HFTextVectorizer
 
 

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -20,7 +20,7 @@ from redisvl.index import SearchIndex
 from redisvl.query import RangeQuery
 from redisvl.redis.utils import convert_bytes, hashify, make_dict
 from redisvl.utils.log import get_logger
-from redisvl.utils.utils import model_to_dict
+from redisvl.utils.utils import deprecated_argument, model_to_dict
 from redisvl.utils.vectorize import (
     BaseVectorizer,
     HFTextVectorizer,
@@ -47,6 +47,7 @@ class SemanticRouter(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
+    @deprecated_argument("dtype", "vectorizer")
     def __init__(
         self,
         name: str,
@@ -72,9 +73,17 @@ class SemanticRouter(BaseModel):
             connection_kwargs (Dict[str, Any]): The connection arguments
                 for the redis client. Defaults to empty {}.
         """
-        # Set vectorizer default
-        if vectorizer is None:
-            dtype = kwargs.get("dtype")
+        dtype = kwargs.get("dtype")
+
+        # Validate a provided vectorizer or set the default
+        if vectorizer:
+            if not isinstance(vectorizer, BaseVectorizer):
+                raise TypeError("Must provide a valid redisvl.vectorizer class.")
+            if dtype and vectorizer.dtype != dtype:
+                raise ValueError(
+                    f"Provided dtype {dtype} does not match vectorizer dtype {vectorizer.dtype}"
+                )
+        else:
             vectorizer_kwargs = {"dtype": dtype} if dtype else {}
             vectorizer = HFTextVectorizer(**vectorizer_kwargs)
 
@@ -87,10 +96,9 @@ class SemanticRouter(BaseModel):
             vectorizer=vectorizer,
             routing_config=routing_config,
         )
-        self._initialize_index(
-            redis_client, redis_url, overwrite, vectorizer.dtype, **connection_kwargs
-        )
+        self._initialize_index(redis_client, redis_url, overwrite, **connection_kwargs)
 
+    @deprecated_argument("dtype")
     def _initialize_index(
         self,
         redis_client: Optional[Redis] = None,
@@ -101,7 +109,7 @@ class SemanticRouter(BaseModel):
     ):
         """Initialize the search index and handle Redis connection."""
         schema = SemanticRouterIndexSchema.from_params(
-            self.name, self.vectorizer.dims, dtype
+            self.name, self.vectorizer.dims, self.vectorizer.dtype
         )
         self._index = SearchIndex(schema=schema)
 
@@ -170,9 +178,7 @@ class SemanticRouter(BaseModel):
         for route in routes:
             # embed route references as a single batch
             reference_vectors = self.vectorizer.embed_many(
-                [reference for reference in route.references],
-                as_buffer=True,
-                dtype=self._index.schema.fields[ROUTE_VECTOR_FIELD_NAME].attrs.datatype,  # type: ignore[union-attr]
+                [reference for reference in route.references], as_buffer=True
             )
             # set route references
             for i, reference in enumerate(route.references):
@@ -249,7 +255,6 @@ class SemanticRouter(BaseModel):
             vector_field_name=ROUTE_VECTOR_FIELD_NAME,
             distance_threshold=distance_threshold,
             return_fields=["route_name"],
-            dtype=self._index.schema.fields[ROUTE_VECTOR_FIELD_NAME].attrs.datatype,  # type: ignore[union-attr]
         )
 
         aggregate_request = self._build_aggregate_request(
@@ -302,7 +307,6 @@ class SemanticRouter(BaseModel):
             vector_field_name=ROUTE_VECTOR_FIELD_NAME,
             distance_threshold=distance_threshold,
             return_fields=["route_name"],
-            dtype=self._index.schema.fields[ROUTE_VECTOR_FIELD_NAME].attrs.datatype,  # type: ignore[union-attr]
         )
         aggregate_request = self._build_aggregate_request(
             vector_range_query, aggregation_method, max_k

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -74,7 +74,9 @@ class SemanticRouter(BaseModel):
         """
         # Set vectorizer default
         if vectorizer is None:
-            vectorizer = HFTextVectorizer()
+            dtype = kwargs.get("dtype")
+            vectorizer_kwargs = {"dtype": dtype} if dtype else {}
+            vectorizer = HFTextVectorizer(**vectorizer_kwargs)
 
         if routing_config is None:
             routing_config = RoutingConfig()
@@ -85,9 +87,8 @@ class SemanticRouter(BaseModel):
             vectorizer=vectorizer,
             routing_config=routing_config,
         )
-        dtype = kwargs.get("dtype", "float32")
         self._initialize_index(
-            redis_client, redis_url, overwrite, dtype, **connection_kwargs
+            redis_client, redis_url, overwrite, vectorizer.dtype, **connection_kwargs
         )
 
     def _initialize_index(

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -1,8 +1,10 @@
+from functools import wraps
 import json
 from enum import Enum
 from time import time
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Optional
 from uuid import uuid4
+from warnings import warn
 
 from pydantic.v1 import BaseModel
 
@@ -57,3 +59,32 @@ def serialize(data: Dict[str, Any]) -> str:
 def deserialize(data: str) -> Dict[str, Any]:
     """Deserialize the input from a string."""
     return json.loads(data)
+
+
+def deprecated_argument(argument: str, replacement: Optional[str] = None) -> Callable:
+    """
+    Decorator to warn if a deprecated argument is passed.
+
+    When the wrapped function is called, the decorator will warn if the
+    deprecated argument is passed as an argument or keyword argument.
+    """
+
+    message = f"Argument {argument} is deprecated and will be removed in the next major release."
+    if replacement:
+        message += f" Use {replacement} instead."
+
+    def wrapper(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            argument_names = func.__code__.co_varnames
+
+            if argument in argument_names:
+                warn(message, DeprecationWarning, stacklevel=2)
+            elif argument in kwargs:
+                warn(message, DeprecationWarning, stacklevel=2)
+
+            return func(*args, **kwargs)
+
+        return inner
+
+    return wrapper

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -1,6 +1,6 @@
-from functools import wraps
 import json
 from enum import Enum
+from functools import wraps
 from time import time
 from typing import Any, Callable, Dict, Optional
 from uuid import uuid4

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -884,3 +884,26 @@ def test_bad_dtype_connecting_to_existing_cache(redis_url):
         bad_type = SemanticCache(
             name="float64_cache", dtype="float16", redis_url=redis_url
         )
+
+
+def test_vectorizer_dtype_mismatch():
+    with pytest.raises(ValueError):
+        SemanticCache(
+            name="test_cache",
+            dtype="float32",
+            vectorizer=HFTextVectorizer(dtype="float16"),
+        )
+
+
+def test_invalid_vectorizer():
+    with pytest.raises(TypeError):
+        SemanticCache(
+            name="test_cache",
+            vectorizer="invalid_vectorizer",  # type: ignore
+        )
+
+
+def test_passes_through_dtype_to_default_vectorizer():
+    # The default is float32, so we should see float64 if we pass it in.
+    cache = SemanticCache(name="test_cache", dtype="float64")
+    assert cache._vectorizer.dtype == "float64"

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -885,11 +885,10 @@ def test_bad_dtype_connecting_to_existing_cache(redis_url):
             name="float64_cache", dtype="float16", redis_url=redis_url
         )
 
-
 def test_vectorizer_dtype_mismatch():
     with pytest.raises(ValueError):
         SemanticCache(
-            name="test_cache",
+            name="test_dtype_mismatch",
             dtype="float32",
             vectorizer=HFTextVectorizer(dtype="float16"),
         )
@@ -898,12 +897,17 @@ def test_vectorizer_dtype_mismatch():
 def test_invalid_vectorizer():
     with pytest.raises(TypeError):
         SemanticCache(
-            name="test_cache",
+            name="test_invalid_vectorizer",
             vectorizer="invalid_vectorizer",  # type: ignore
         )
 
 
 def test_passes_through_dtype_to_default_vectorizer():
     # The default is float32, so we should see float64 if we pass it in.
-    cache = SemanticCache(name="test_cache", dtype="float64")
+    cache = SemanticCache(name="test_pass_through_dtype)", dtype="float64")
     assert cache._vectorizer.dtype == "float64"
+
+
+def test_deprecated_dtype_argument():
+    with pytest.warns(DeprecationWarning):
+        SemanticCache(name="test_deprecated_dtype", dtype="float32")

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from collections import namedtuple
 from time import sleep, time
+import warnings
 
 import pytest
 from pydantic.v1 import ValidationError
@@ -69,6 +70,13 @@ def cache_with_redis_client(vectorizer, client):
     yield cache_instance
     cache_instance.clear()  # Clear cache after each test
     cache_instance._index.delete(True)  # Clean up index
+
+
+@pytest.fixture(autouse=True)
+def disable_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        yield
 
 
 def test_bad_ttl(cache):
@@ -892,6 +900,7 @@ def test_vectorizer_dtype_mismatch():
             name="test_dtype_mismatch",
             dtype="float32",
             vectorizer=HFTextVectorizer(dtype="float16"),
+            overwrite=True,
         )
 
 
@@ -900,15 +909,18 @@ def test_invalid_vectorizer():
         SemanticCache(
             name="test_invalid_vectorizer",
             vectorizer="invalid_vectorizer",  # type: ignore
+            overwrite=True,
         )
 
 
 def test_passes_through_dtype_to_default_vectorizer():
     # The default is float32, so we should see float64 if we pass it in.
-    cache = SemanticCache(name="test_pass_through_dtype)", dtype="float64")
+    cache = SemanticCache(
+        name="test_pass_through_dtype", dtype="float64", overwrite=True
+    )
     assert cache._vectorizer.dtype == "float64"
 
 
 def test_deprecated_dtype_argument():
     with pytest.warns(DeprecationWarning):
-        SemanticCache(name="test_deprecated_dtype", dtype="float32")
+        SemanticCache(name="test_deprecated_dtype", dtype="float32", overwrite=True)

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -885,6 +885,7 @@ def test_bad_dtype_connecting_to_existing_cache(redis_url):
             name="float64_cache", dtype="float16", redis_url=redis_url
         )
 
+
 def test_vectorizer_dtype_mismatch():
     with pytest.raises(ValueError):
         SemanticCache(

--- a/tests/unit/test_base_vectorizer.py
+++ b/tests/unit/test_base_vectorizer.py
@@ -1,28 +1,29 @@
 from typing import List
-from redisvl.utils.vectorize.base import BaseVectorizer
 
+from redisvl.utils.vectorize.base import BaseVectorizer
 
 
 def test_base_vectorizer_defaults():
     """
-    Test that the base vectorizer defaults are set correctly, with 
+    Test that the base vectorizer defaults are set correctly, with
     a default for dtype. Versions before 0.3.8 did not have this field.
 
     A regression test for langchain-redis/#48
     """
+
     class SimpleVectorizer(BaseVectorizer):
         model: str = "simple"
         dims: int = 10
-        
+
         def embed(self, text: str, **kwargs) -> List[float]:
             return [0.0] * self.dims
-        
+
         async def aembed(self, text: str, **kwargs) -> List[float]:
             return [0.0] * self.dims
-        
+
         async def aembed_many(self, texts: List[str], **kwargs) -> List[List[float]]:
             return [[0.0] * self.dims] * len(texts)
-        
+
         def embed_many(self, texts: List[str], **kwargs) -> List[List[float]]:
             return [[0.0] * self.dims] * len(texts)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from ml_dtypes import bfloat16
 
 from redisvl.redis.utils import (
     array_to_buffer,
@@ -8,6 +7,7 @@ from redisvl.redis.utils import (
     convert_bytes,
     make_dict,
 )
+from redisvl.utils.utils import deprecated_argument
 
 
 def test_even_number_of_elements():
@@ -146,3 +146,94 @@ def test_conversion_with_invalid_floats():
     array = [float("inf"), float("-inf"), float("nan")]
     result = array_to_buffer(array, "float16")
     assert len(result) > 0  # Simple check to ensure it returns anything
+
+
+class TestDeprecatedArgument:
+    def test_deprecation_warning_text_with_replacement(self):
+        @deprecated_argument("dtype", "vectorizer")
+        def test_func(dtype=None, vectorizer=None):
+            pass
+
+        with pytest.warns(DeprecationWarning) as record:
+            test_func(dtype="float32")
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "Argument dtype is deprecated and will be removed"
+            " in the next major release. Use vectorizer instead."
+        )
+
+    def test_deprecation_warning_text_without_replacement(self):
+        @deprecated_argument("dtype")
+        def test_func(dtype=None):
+            pass
+
+        with pytest.warns(DeprecationWarning) as record:
+            test_func(dtype="float32")
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "Argument dtype is deprecated and will be removed"
+            " in the next major release."
+        )
+
+    def test_function_argument(self):
+        @deprecated_argument("dtype", "vectorizer")
+        def test_func(dtype=None, vectorizer=None):
+            pass
+
+        with pytest.warns(DeprecationWarning):
+            test_func(dtype="float32")
+
+    def test_function_keyword_argument(self):
+        @deprecated_argument("dtype", "vectorizer")
+        def test_func(dtype=None, vectorizer=None):
+            pass
+
+        with pytest.warns(DeprecationWarning):
+            test_func(vectorizer="float32")
+
+    def test_class_method_argument(self):
+        class TestClass:
+            @deprecated_argument("dtype", "vectorizer")
+            def test_method(self, dtype=None, vectorizer=None):
+                pass
+
+        with pytest.warns(DeprecationWarning):
+            TestClass().test_method(dtype="float32")
+
+    def test_class_method_keyword_argument(self):
+        class TestClass:
+            @deprecated_argument("dtype", "vectorizer")
+            def test_method(self, dtype=None, vectorizer=None):
+                pass
+
+        with pytest.warns(DeprecationWarning):
+            TestClass().test_method(vectorizer="float32")
+
+    def test_class_init_argument(self):
+        class TestClass:
+            @deprecated_argument("dtype", "vectorizer")
+            def __init__(self, dtype=None, vectorizer=None):
+                pass
+
+        with pytest.warns(DeprecationWarning):
+            TestClass(dtype="float32")
+
+    def test_class_init_keyword_argument(self):
+        class TestClass:
+            @deprecated_argument("dtype", "vectorizer")
+            def __init__(self, dtype=None, vectorizer=None):
+                pass
+
+        with pytest.warns(DeprecationWarning):
+            TestClass(dtype="float32")
+
+    async def test_async_function_argument(self):
+        @deprecated_argument("dtype", "vectorizer")
+        async def test_func(dtype=None, vectorizer=None):
+            return 1
+
+        with pytest.warns(DeprecationWarning):
+            result = await test_func(dtype="float32")
+        assert result == 1


### PR DESCRIPTION
The `dtype` argument to `SemanticCache`, `SemanticRouter`, and `SemanticSessionManager` is intended to specify the vectorizer's data type. However, the constructors for these classes allow passing in both a vectorizer instance (with dtype already set) and `dtype`, in which case, the vectorizer may have a different `dtype` than the `dtype` used in the index schema.

This PR works on eliminating this possibility by adding validation and treating the vectorizer as the true "owner" of `dtype`. We also begin the deprecation process for standalone `dtype` arguments, guiding users to pass in vectorizer instances instead if they require customizing the vectorizer's dtype. Finally, we make vectorizer validation consistent across these classes.