### PR TITLE
Add nightly CI run and optional manual workflow dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+  schedule:
+    - cron: "0 2 * * *"  # 2 AM UTC nightly
+  
+  workflow_dispatch:
+
 env:
   POETRY_VERSION: "1.8.3"
 


### PR DESCRIPTION
This PR introduces a nightly run of our test suite on `main` and exposes a path for a manual test run in case of emergency.