### PR TITLE
Support Redis 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,11 @@ jobs:
 
       - name: Set Redis image name
         run: |
-          if [[ ${{ matrix.redis-stack-version }} == '8.0-M03']]; then
+          if [[ "${{ matrix.redis-stack-version }}" == "8.0-M03" ]]; then
             echo "REDIS_IMAGE=redis:${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
           else
             echo "REDIS_IMAGE=redis/redis-stack-server:${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
+          fi
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
       matrix:
         python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
         connection: ['hiredis', 'plain']
-        redis-stack-version: ['6.2.6-v9', 'latest', 'edge']
+        redis-stack-version: ['6.2.6-v9', 'latest', 'edge', '8.0-M03']
 
-    services:
-      redis:
-        image: redis/redis-stack-server:${{matrix.redis-stack-version}}
-        ports:
-          - 6379:6379
+    # services:
+    #   redis:
+    #     image: ${{ env.REDIS_IMAGE }}
+    #     ports:
+    #       - 6379:6379
 
     steps:
       - name: Check out repository
@@ -58,9 +58,12 @@ jobs:
         run: |
           poetry add hiredis
 
-      - name: Set Redis version
+      - name: Set Redis image name
         run: |
-          echo "REDIS_VERSION=${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
+          if [[ ${{ matrix.redis-stack-version }} == '8.0-M03']]; then
+            echo "REDIS_IMAGE=redis:${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
+          else
+            echo "REDIS_IMAGE=redis/redis-stack-server:${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,21 @@ env:
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} [redis-stack ${{matrix.redis-stack-version}}]
+    name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} [redis ${{matrix.redis-version}}]
     runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis/redis-stack-server:${{matrix.redis-version}}
+        ports:
+          - 6379:6379
 
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
         connection: ['hiredis', 'plain']
-        redis-stack-version: ['6.2.6-v9', 'latest', 'edge', '8.0-M03']
-
-    # services:
-    #   redis:
-    #     image: ${{ env.REDIS_IMAGE }}
-    #     ports:
-    #       - 6379:6379
+        redis-version: ['6.2.6-v9', 'latest', '8.0-M03']
 
     steps:
       - name: Check out repository
@@ -60,10 +60,10 @@ jobs:
 
       - name: Set Redis image name
         run: |
-          if [[ "${{ matrix.redis-stack-version }}" == "8.0-M03" ]]; then
-            echo "REDIS_IMAGE=redis:${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
+          if [[ "${{ matrix.redis-version }}" == "8.0-M03" ]]; then
+            echo "REDIS_IMAGE=redis:${{ matrix.redis-version }}" >> $GITHUB_ENV
           else
-            echo "REDIS_IMAGE=redis/redis-stack-server:${{ matrix.redis-stack-version }}" >> $GITHUB_ENV
+            echo "REDIS_IMAGE=redis/redis-stack-server:${{ matrix.redis-version }}" >> $GITHUB_ENV
           fi
 
       - name: Authenticate to Google Cloud
@@ -72,7 +72,7 @@ jobs:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
       - name: Run tests
-        if: matrix.connection == 'plain' && matrix.redis-stack-version == 'latest'
+        if: matrix.connection == 'plain' && matrix.redis-version == 'latest'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
@@ -90,12 +90,12 @@ jobs:
           make test-all
 
       - name: Run tests
-        if: matrix.connection != 'plain' || matrix.redis-stack-version != 'latest'
+        if: matrix.connection != 'plain' || matrix.redis-version != 'latest'
         run: |
           make test
 
       - name: Run notebooks
-        if: matrix.connection == 'plain' && matrix.redis-stack-version == 'latest'
+        if: matrix.connection == 'plain' && matrix.redis-version == 'latest'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,8 @@ env:
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} [redis ${{matrix.redis-version}}]
+    name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} [redis ${{ matrix.redis-version }}]
     runs-on: ubuntu-latest
-
-    services:
-      redis:
-        image: redis/redis-stack-server:${{matrix.redis-version}}
-        ports:
-          - 6379:6379
 
     strategy:
       fail-fast: false
@@ -110,6 +104,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          docker run -d --name redis -p 6379:6379 redis/redis-stack-server:latest
           make test-notebooks 
 
   docs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,7 @@ def redis_container(request):
 
     # Set the Compose project name so containers do not clash across workers
     os.environ["COMPOSE_PROJECT_NAME"] = f"redis_test_{worker_id}"
-    os.environ.setdefault(
-        "REDIS_IMAGE", "redis:8.0-M03"
-    )  # "redis/redis-stack-server:edge")
+    os.environ.setdefault("REDIS_IMAGE", "redis/redis-stack-server:latest")
 
     compose = DockerCompose(
         context="tests",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,9 @@ def redis_container(request):
 
     # Set the Compose project name so containers do not clash across workers
     os.environ["COMPOSE_PROJECT_NAME"] = f"redis_test_{worker_id}"
-    os.environ.setdefault("REDIS_VERSION", "edge")
+    os.environ.setdefault(
+        "REDIS_IMAGE", "redis:8.0-M03"
+    )  # "redis/redis-stack-server:edge")
 
     compose = DockerCompose(
         context="tests",

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   redis:
-    image: "redis/redis-stack:${REDIS_VERSION}"
+    image: "${REDIS_IMAGE}"
     ports:
       - "6379"
     environment:

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -770,7 +770,7 @@ def test_complex_filters(cache_with_filters):
     assert len(results) == 1
 
 
-def test_index_updating(redis_url):
+def test_cache_index_overwrite(redis_url):
     cache_no_tags = SemanticCache(
         name="test_cache",
         redis_url=redis_url,
@@ -785,15 +785,22 @@ def test_index_updating(redis_url):
     # filterable_fields not defined in schema, so no tags will match
     tag_filter = Tag("some_tag") == "abc"
 
-    response = cache_no_tags.check(
-        prompt="this prompt has a tag",
-        filter_expression=tag_filter,
-    )
-    assert response == []
+    try:
+        response = cache_no_tags.check(
+            prompt="this prompt has a tag",
+            filter_expression=tag_filter,
+        )
+    except Exception as e:
+        # This will fail in Redis 8+ on query dialect 2
+        if "Unknown field" in str(e):
+            pytest.skip("Skipping test due to unknown field error: " + str(e))
+        else:
+            raise
+    else:
+        assert response == []
 
     with pytest.raises((RedisModuleVersionError, ValueError)):
-
-        cache_with_tags = SemanticCache(
+        SemanticCache(
             name="test_cache",
             redis_url=redis_url,
             filterable_fields=[{"name": "some_tag", "type": "tag"}],

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -793,11 +793,11 @@ def test_cache_index_overwrite(redis_url):
     except Exception as e:
         # This will fail in Redis 8+ on query dialect 2
         if "Unknown field" in str(e):
-            pytest.skip("Skipping test due to unknown field error: " + str(e))
+            response = []
         else:
             raise
-    else:
-        assert response == []
+
+    assert response == []
 
     with pytest.raises((RedisModuleVersionError, ValueError)):
         SemanticCache(


### PR DESCRIPTION
This PR adds testing support for Redis 8 (currently `redis:8.0-M03` from Docker) to our GitHub Actions pipeline. Overall, our entire test suite passed against Redis 8 with one notable exception:

**Breaking Change in Redis 8, Dialect 2 Only**
When a search query references a field that is not present in the index schema, Redis 8 now raises:
```
redis.exceptions.ResponseError: Unknown field at offset NN near <unknown-field-name>
```
Previously (and in other dialects), Redis would allow such queries but return empty results. This new behavior is arguably more correct, but it breaks a test that expects an empty result when searching on a non-indexed field.

## Context and Discussion
A single test failed where our code intentionally queries a field not in the index, expecting empty results. With Redis 8, Dialect 2, this now raises an error.
The team discussed whether to:
- Adjust the test to skip or otherwise handle this new behavior (since querying a non-indexed field arguably should be an error).
- Catch and raise a more user-friendly message in our library. The Redis error text can be cryptic, so providing a clearer explanation to users might be beneficial.
## Decision
- Testing: We will proceed with adding Redis 8 to our CI matrix.
- The Failing Test: We will update this test to either skip on Redis 8 or handle the error more gracefully.
- Error Messaging: We may consider adding a better exception message so that developers get a more understandable error when they inadvertently query non-indexed fields. But this will go in a different PR.
