### PR TITLE
Avoid looking at local variables for deprecation warnings

### DIFF
--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -93,10 +93,13 @@ def deprecated_argument(argument: str, replacement: Optional[str] = None) -> Cal
 
             @wraps(underlying)
             def inner_wrapped(*args, **kwargs):
-                sig = inspect.signature(underlying)
-                bound_args = sig.bind(*args, **kwargs)
-                if argument in bound_args.arguments:
+                if argument in kwargs:
                     warn(message, DeprecationWarning, stacklevel=2)
+                else:
+                    sig = inspect.signature(underlying)
+                    bound_args = sig.bind(*args, **kwargs)
+                    if argument in bound_args.arguments:
+                        warn(message, DeprecationWarning, stacklevel=2)
                 return underlying(*args, **kwargs)
 
             if isinstance(func, classmethod):
@@ -107,10 +110,13 @@ def deprecated_argument(argument: str, replacement: Optional[str] = None) -> Cal
 
             @wraps(func)
             def inner_normal(*args, **kwargs):
-                sig = inspect.signature(func)
-                bound_args = sig.bind(*args, **kwargs)
-                if argument in bound_args.arguments:
+                if argument in kwargs:
                     warn(message, DeprecationWarning, stacklevel=2)
+                else:
+                    sig = inspect.signature(func)
+                    bound_args = sig.bind(*args, **kwargs)
+                    if argument in bound_args.arguments:
+                        warn(message, DeprecationWarning, stacklevel=2)
                 return func(*args, **kwargs)
 
             return inner_normal

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from enum import Enum
 from functools import wraps
@@ -76,7 +77,7 @@ def deprecated_argument(argument: str, replacement: Optional[str] = None) -> Cal
     def wrapper(func):
         @wraps(func)
         def inner(*args, **kwargs):
-            argument_names = func.__code__.co_varnames
+            argument_names = list(inspect.signature(func).parameters.keys())
 
             if argument in argument_names:
                 warn(message, DeprecationWarning, stacklevel=2)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import pytest
 
@@ -237,3 +238,15 @@ class TestDeprecatedArgument:
         with pytest.warns(DeprecationWarning):
             result = await test_func(dtype="float32")
         assert result == 1
+        
+    async def test_ignores_local_variable(self):
+        @deprecated_argument("dtype")
+        async def test_func(vectorizer=None):
+            # The presence of this variable should not trigger a warning
+            dtype = "float32"
+            return 1
+
+        # This will raise an error if any warning is emitted
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            await test_func()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -382,6 +382,18 @@ class TestDeprecatedArgument:
         with assert_no_warnings():
             TestClass(new_arg="float32")
 
+    def test_class_init_keyword_argument_kwargs(self):
+        class TestClass:
+            @deprecated_argument("old_arg", "new_arg")
+            def __init__(self, new_arg=None, **kwargs):
+                pass
+
+        with pytest.warns(DeprecationWarning):
+            TestClass(old_arg="float32")
+
+        with assert_no_warnings():
+            TestClass(new_arg="float32")
+
     async def test_async_function_argument(self):
         @deprecated_argument("old_arg", "new_arg")
         async def test_func(old_arg=None, new_arg=None):


### PR DESCRIPTION
Deprecation warnings should not be looking at local function variables. 😅 