### PR TITLE
fix url pass

### DIFF
--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -79,7 +79,7 @@ class Index:
             rvl index listall
         """
         redis_url = create_redis_url(args)
-        conn = RedisConnectionFactory.get_redis_connection(redis_url)
+        conn = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
         indices = convert_bytes(conn.execute_command("FT._LIST"))
         logger.info("Indices:")
         for i, index in enumerate(indices):
@@ -107,7 +107,7 @@ class Index:
         # connect to redis
         try:
             redis_url = create_redis_url(args)
-            conn = RedisConnectionFactory.get_redis_connection(url=redis_url)
+            conn = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
         except ValueError:
             logger.error(
                 "Must set REDIS_URL environment variable or provide host and port"

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -358,7 +358,7 @@ class SearchIndex(BaseSearchIndex):
             with self._lock:
                 if self.__redis_client is None:
                     self.__redis_client = RedisConnectionFactory.get_redis_connection(
-                        url=self._redis_url,
+                        redis_url=self._redis_url,
                         **self._connection_kwargs,
                     )
         return self.__redis_client

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -223,7 +223,7 @@ class RedisConnectionFactory:
 
     @staticmethod
     def get_redis_connection(
-        url: Optional[str] = None,
+        redis_url: Optional[str] = None,
         required_modules: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> Redis:
@@ -245,7 +245,7 @@ class RedisConnectionFactory:
                 variable is not set.
             RedisModuleVersionError: If required Redis modules are not installed.
         """
-        url = url or get_address_from_env()
+        url = redis_url or get_address_from_env()
         client = Redis.from_url(url, **kwargs)
 
         RedisConnectionFactory.validate_sync_redis(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def client(redis_url):
     """
     A sync Redis client that uses the dynamic `redis_url`.
     """
-    conn = RedisConnectionFactory.get_redis_connection(redis_url)
+    conn = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
     yield conn
 
 

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -84,6 +84,17 @@ def test_search_index_from_existing(client, index):
     assert index2.schema == index.schema
 
 
+def test_search_index_from_existing_url(redis_url, index):
+    index.create(overwrite=True)
+
+    try:
+        index2 = SearchIndex.from_existing(index.name, redis_url=redis_url)
+    except Exception as e:
+        pytest.skip(str(e))
+
+    assert index2.schema == index.schema
+
+
 def test_search_index_from_existing_complex(client):
     schema = {
         "index": {


### PR DESCRIPTION
There was a bug in from_existing where it was not passing the redis_url correctly because the var is named `url`
![image](https://github.com/user-attachments/assets/f350264f-debb-4382-ad40-be38a3609cb3)
