### PR TITLE
Validate passed-in Redis clients

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -272,11 +272,6 @@ class SearchIndex(BaseSearchIndex):
         if not isinstance(schema, IndexSchema):
             raise ValueError("Must provide a valid IndexSchema object")
 
-        if redis_client:
-            RedisConnectionFactory.validate_sync_redis(
-                redis_client, required_modules=REQUIRED_MODULES_FOR_INTROSPECTION
-            )
-
         self.schema = schema
 
         self._lib_name: Optional[str] = kwargs.pop("lib_name", None)

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -858,7 +858,6 @@ class AsyncSearchIndex(BaseSearchIndex):
         self.schema = schema
 
         self._lib_name: Optional[str] = kwargs.pop("lib_name", None)
-        self._validated_client = False
 
         # Store connection parameters
         self._redis_client = redis_client
@@ -866,6 +865,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         self._connection_kwargs = connection_kwargs or {}
         self._lock = asyncio.Lock()
 
+        self._validated_client = False
         self._owns_redis_client = redis_client is None
         if self._owns_redis_client:
             weakref.finalize(self, sync_wrapper(self.disconnect))

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -159,7 +159,7 @@ def validate_modules(
         required_modules: List of required modules.
 
     Raises:
-        ValueError: If required Redis modules are not installed.
+        RedisModuleVersionError: If required Redis modules are not installed.
     """
     required_modules = required_modules or DEFAULT_REQUIRED_MODULES
 

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -1,8 +1,10 @@
 import warnings
+from unittest import mock
 
 import pytest
+from redis import Redis
 
-from redisvl.exceptions import RedisSearchError
+from redisvl.exceptions import RedisModuleVersionError, RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.query import VectorQuery
 from redisvl.redis.utils import convert_bytes
@@ -363,3 +365,25 @@ def test_search_index_that_owns_client_disconnect(index_schema, redis_url):
     index.create(overwrite=True, drop=True)
     index.disconnect()
     assert index.client is None
+
+
+def test_search_index_validates_redis_modules(redis_url):
+    """
+    A regression test for RAAE-694: we should validate that a passed-in
+    Redis client has the correct modules installed.
+    """
+    client = Redis.from_url(redis_url)
+    with mock.patch(
+        "redisvl.index.index.RedisConnectionFactory.validate_sync_redis"
+    ) as mock_validate_sync_redis:
+        mock_validate_sync_redis.side_effect = RedisModuleVersionError(
+            "Required modules not installed"
+        )
+        with pytest.raises(RedisModuleVersionError):
+            SearchIndex(
+                schema=IndexSchema.from_dict(
+                    {"index": {"name": "my_index"}, "fields": fields}
+                ),
+                redis_client=client,
+            )
+        mock_validate_sync_redis.assert_called_once()

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -380,10 +380,12 @@ def test_search_index_validates_redis_modules(redis_url):
             "Required modules not installed"
         )
         with pytest.raises(RedisModuleVersionError):
-            SearchIndex(
+            index = SearchIndex(
                 schema=IndexSchema.from_dict(
                     {"index": {"name": "my_index"}, "fields": fields}
                 ),
                 redis_client=client,
             )
+            index.create(overwrite=True, drop=True)
+
         mock_validate_sync_redis.assert_called_once()


### PR DESCRIPTION
Prior to RedisVL 0.4.0, we validated passed-in Redis clients when the user called `set_client()`. This PR reintroduces similar behavior by validating all clients, whether we created them or not, on first access through the lazy-client mechanism.

Closes RAAE-694.