### PR TITLE
Add option to normalize vector distances on query

### DIFF
--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -238,9 +238,9 @@ class SemanticCache(BaseLLMCache):
         Raises:
             ValueError: If the threshold is not between 0 and 1.
         """
-        if not 0 <= float(distance_threshold) <= 1:
+        if not 0 <= float(distance_threshold) <= 2:
             raise ValueError(
-                f"Distance must be between 0 and 1, got {distance_threshold}"
+                f"Distance must be between 0 and 2, got {distance_threshold}"
             )
         self._distance_threshold = float(distance_threshold)
 

--- a/redisvl/extensions/llmcache/semantic.py
+++ b/redisvl/extensions/llmcache/semantic.py
@@ -22,7 +22,7 @@ from redisvl.extensions.llmcache.schema import (
     SemanticCacheIndexSchema,
 )
 from redisvl.index import AsyncSearchIndex, SearchIndex
-from redisvl.query import RangeQuery
+from redisvl.query import VectorRangeQuery
 from redisvl.query.filter import FilterExpression
 from redisvl.query.query import BaseQuery
 from redisvl.redis.connection import RedisConnectionFactory
@@ -390,7 +390,7 @@ class SemanticCache(BaseLLMCache):
         vector = vector or self._vectorize_prompt(prompt)
         self._check_vector_dims(vector)
 
-        query = RangeQuery(
+        query = VectorRangeQuery(
             vector=vector,
             vector_field_name=CACHE_VECTOR_FIELD_NAME,
             return_fields=self.return_fields,
@@ -473,7 +473,7 @@ class SemanticCache(BaseLLMCache):
         vector = vector or await self._avectorize_prompt(prompt)
         self._check_vector_dims(vector)
 
-        query = RangeQuery(
+        query = VectorRangeQuery(
             vector=vector,
             vector_field_name=CACHE_VECTOR_FIELD_NAME,
             return_fields=self.return_fields,
@@ -481,6 +481,7 @@ class SemanticCache(BaseLLMCache):
             num_results=num_results,
             return_score=True,
             filter_expression=filter_expression,
+            normalize_vector_distance=True,
         )
 
         # Search the cache!

--- a/redisvl/extensions/router/schema.py
+++ b/redisvl/extensions/router/schema.py
@@ -18,7 +18,7 @@ class Route(BaseModel):
     """List of reference phrases for the route."""
     metadata: Dict[str, Any] = Field(default={})
     """Metadata associated with the route."""
-    distance_threshold: Annotated[float, Field(strict=True, gt=0, le=1)] = 0.5
+    distance_threshold: Annotated[float, Field(strict=True, gt=0, le=2)] = 0.5
     """Distance threshold for matching the route."""
 
     @field_validator("name")

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -17,7 +17,7 @@ from redisvl.extensions.router.schema import (
     SemanticRouterIndexSchema,
 )
 from redisvl.index import SearchIndex
-from redisvl.query import RangeQuery
+from redisvl.query import VectorRangeQuery
 from redisvl.redis.utils import convert_bytes, hashify, make_dict
 from redisvl.utils.log import get_logger
 from redisvl.utils.utils import deprecated_argument, model_to_dict
@@ -237,7 +237,7 @@ class SemanticRouter(BaseModel):
 
     def _build_aggregate_request(
         self,
-        vector_range_query: RangeQuery,
+        vector_range_query: VectorRangeQuery,
         aggregation_method: DistanceAggregationMethod,
         max_k: int,
     ) -> AggregateRequest:
@@ -279,7 +279,7 @@ class SemanticRouter(BaseModel):
         # therefore you might take the max_threshold and further refine from there.
         distance_threshold = max(route.distance_threshold for route in self.routes)
 
-        vector_range_query = RangeQuery(
+        vector_range_query = VectorRangeQuery(
             vector=vector,
             vector_field_name=ROUTE_VECTOR_FIELD_NAME,
             distance_threshold=float(distance_threshold),

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -777,11 +777,7 @@ class SearchIndex(BaseSearchIndex):
         )
         all_parsed = []
         for query, batch_results in zip(queries, results):
-            parsed = process_results(
-                batch_results,
-                query=query,
-                storage_type=self.schema.index.storage_type,
-            )
+            parsed = process_results(batch_results, query=query, schema=self.schema)
             # Create separate lists of parsed results for each query
             # passed in to the batch_search method, so that callers can
             # access the results for each query individually
@@ -1421,7 +1417,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             parsed = process_results(
                 batch_results,
                 query=query,
-                storage_type=self.schema.index.storage_type,
+                schema=self.schema,
             )
             # Create separate lists of parsed results for each query
             # passed in to the batch_search method, so that callers can

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -18,12 +18,7 @@ from typing import (
     Union,
 )
 
-from redisvl.utils.utils import (
-    deprecated_argument,
-    deprecated_function,
-    norm_cosine_distance,
-    sync_wrapper,
-)
+from redisvl.utils.utils import deprecated_argument, deprecated_function, sync_wrapper
 
 if TYPE_CHECKING:
     from redis.commands.search.aggregation import AggregateResult
@@ -39,13 +34,7 @@ from redis.commands.search.indexDefinition import IndexDefinition
 
 from redisvl.exceptions import RedisModuleVersionError, RedisSearchError
 from redisvl.index.storage import BaseStorage, HashStorage, JsonStorage
-from redisvl.query import (
-    BaseQuery,
-    CountQuery,
-    FilterQuery,
-    VectorQuery,
-    VectorRangeQuery,
-)
+from redisvl.query import BaseQuery, BaseVectorQuery, CountQuery, FilterQuery
 from redisvl.query.filter import FilterExpression
 from redisvl.redis.connection import (
     RedisConnectionFactory,
@@ -104,9 +93,7 @@ def process_results(
         and not query._return_fields  # type: ignore
     )
 
-    if (
-        isinstance(query, VectorQuery) or isinstance(query, VectorRangeQuery)
-    ) and query._normalize_vector_distance:
+    if (isinstance(query, BaseVectorQuery)) and query._normalize_vector_distance:
         dist_metric = VectorDistanceMetric(
             schema.fields[query._vector_field_name].attrs.distance_metric.upper()  # type: ignore
         )

--- a/redisvl/query/__init__.py
+++ b/redisvl/query/__init__.py
@@ -1,5 +1,6 @@
 from redisvl.query.query import (
     BaseQuery,
+    BaseVectorQuery,
     CountQuery,
     FilterQuery,
     RangeQuery,
@@ -9,6 +10,7 @@ from redisvl.query.query import (
 
 __all__ = [
     "BaseQuery",
+    "BaseVectorQuery",
     "VectorQuery",
     "FilterQuery",
     "RangeQuery",

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -198,6 +198,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         in_order: bool = False,
         hybrid_policy: Optional[str] = None,
         batch_size: Optional[int] = None,
+        normalize_cosine_distance: bool = False,
     ):
         """A query for running a vector search along with an optional filter
         expression.
@@ -233,6 +234,9 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
                 of vectors to fetch in each batch. Larger values may improve performance
                 at the cost of memory usage. Only applies when hybrid_policy="BATCHES".
                 Defaults to None, which lets Redis auto-select an appropriate batch size.
+            normalize_cosine_distance (bool): by default Redis returns cosine distance as a value
+                between 0 and 2 where 0 is the best match. If set to True, the cosine distance will be
+                converted to cosine similarity with a value between 0 and 1 where 1 is the best match.
 
         Raises:
             TypeError: If filter_expression is not of type redisvl.query.FilterExpression
@@ -246,6 +250,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         self._num_results = num_results
         self._hybrid_policy: Optional[HybridPolicy] = None
         self._batch_size: Optional[int] = None
+        self._normalize_cosine_distance = normalize_cosine_distance
         self.set_filter(filter_expression)
         query_string = self._build_query_string()
 
@@ -394,6 +399,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         in_order: bool = False,
         hybrid_policy: Optional[str] = None,
         batch_size: Optional[int] = None,
+        normalize_cosine_distance: bool = False,
     ):
         """A query for running a filtered vector search based on semantic
         distance threshold.
@@ -437,6 +443,16 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
                 of vectors to fetch in each batch. Larger values may improve performance
                 at the cost of memory usage. Only applies when hybrid_policy="BATCHES".
                 Defaults to None, which lets Redis auto-select an appropriate batch size.
+            normalize_cosine_distance (bool): by default Redis returns cosine distance as a value
+                between 0 and 2 where 0 is the best match. If set to True, the cosine distance will be
+                converted to cosine similarity with a value between 0 and 1 where 1 is the best match.
+
+        Raises:
+            TypeError: If filter_expression is not of type redisvl.query.FilterExpression
+
+        Note:
+            Learn more about vector range queries: https://redis.io/docs/interact/search-and-query/search/vectors/#range-query
+
         """
         self._vector = vector
         self._vector_field_name = vector_field_name
@@ -456,6 +472,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         if batch_size is not None:
             self.set_batch_size(batch_size)
 
+        self._normalize_cosine_distance = normalize_cosine_distance
         self.set_distance_threshold(distance_threshold)
         self.set_filter(filter_expression)
         query_string = self._build_query_string()

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -198,7 +198,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         in_order: bool = False,
         hybrid_policy: Optional[str] = None,
         batch_size: Optional[int] = None,
-        normalize_cosine_distance: bool = False,
+        normalize_vector_distance: bool = False,
     ):
         """A query for running a vector search along with an optional filter
         expression.
@@ -234,9 +234,12 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
                 of vectors to fetch in each batch. Larger values may improve performance
                 at the cost of memory usage. Only applies when hybrid_policy="BATCHES".
                 Defaults to None, which lets Redis auto-select an appropriate batch size.
-            normalize_cosine_distance (bool): by default Redis returns cosine distance as a value
-                between 0 and 2 where 0 is the best match. If set to True, the cosine distance will be
-                converted to cosine similarity with a value between 0 and 1 where 1 is the best match.
+            normalize_vector_distance (bool): Redis supports 3 distance metrics: L2 (euclidean),
+                IP (inner product), and COSINE. By default, L2 distance returns an unbounded value.
+                COSINE distance returns a value between 0 and 2. IP returns a value determined by
+                the magnitude of the vector. Setting this flag to true converts COSINE and L2 distance
+                to a similarity score between 0 and 1. Note: setting this flag to true for IP will
+                throw a warning since by definition COSINE similarity is normalized IP.
 
         Raises:
             TypeError: If filter_expression is not of type redisvl.query.FilterExpression
@@ -250,7 +253,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         self._num_results = num_results
         self._hybrid_policy: Optional[HybridPolicy] = None
         self._batch_size: Optional[int] = None
-        self._normalize_cosine_distance = normalize_cosine_distance
+        self._normalize_vector_distance = normalize_vector_distance
         self.set_filter(filter_expression)
         query_string = self._build_query_string()
 
@@ -399,7 +402,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         in_order: bool = False,
         hybrid_policy: Optional[str] = None,
         batch_size: Optional[int] = None,
-        normalize_cosine_distance: bool = False,
+        normalize_vector_distance: bool = False,
     ):
         """A query for running a filtered vector search based on semantic
         distance threshold.
@@ -443,9 +446,12 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
                 of vectors to fetch in each batch. Larger values may improve performance
                 at the cost of memory usage. Only applies when hybrid_policy="BATCHES".
                 Defaults to None, which lets Redis auto-select an appropriate batch size.
-            normalize_cosine_distance (bool): by default Redis returns cosine distance as a value
-                between 0 and 2 where 0 is the best match. If set to True, the cosine distance will be
-                converted to cosine similarity with a value between 0 and 1 where 1 is the best match.
+            normalize_vector_distance (bool): Redis supports 3 distance metrics: L2 (euclidean),
+                IP (inner product), and COSINE. By default, L2 distance returns an unbounded value.
+                COSINE distance returns a value between 0 and 2. IP returns a value determined by
+                the magnitude of the vector. Setting this flag to true converts COSINE and L2 distance
+                to a similarity score between 0 and 1. Note: setting this flag to true for IP will
+                throw a warning since by definition COSINE similarity is normalized IP.
 
         Raises:
             TypeError: If filter_expression is not of type redisvl.query.FilterExpression
@@ -472,7 +478,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         if batch_size is not None:
             self.set_batch_size(batch_size)
 
-        self._normalize_cosine_distance = normalize_cosine_distance
+        self._normalize_vector_distance = normalize_vector_distance
         self.set_distance_threshold(distance_threshold)
         self.set_filter(filter_expression)
         query_string = self._build_query_string()

--- a/redisvl/schema/fields.py
+++ b/redisvl/schema/fields.py
@@ -16,6 +16,14 @@ from redis.commands.search.field import TagField as RedisTagField
 from redis.commands.search.field import TextField as RedisTextField
 from redis.commands.search.field import VectorField as RedisVectorField
 
+from redisvl.utils.utils import norm_cosine_distance, norm_l2_distance
+
+VECTOR_NORM_MAP = {
+    "COSINE": norm_cosine_distance,
+    "L2": norm_l2_distance,
+    "IP": None,  # normalized inner product is cosine similarity by definition
+}
+
 
 class FieldTypes(str, Enum):
     TAG = "tag"

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -198,3 +198,10 @@ def norm_cosine_distance(value: float) -> float:
     Normalize the cosine distance to a similarity score between 0 and 1.
     """
     return (2 - value) / 2
+
+
+def norm_l2_distance(value: float) -> float:
+    """
+    Normalize the L2 distance.
+    """
+    return 1 / (1 + value)

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -191,3 +191,10 @@ def sync_wrapper(fn: Callable[[], Coroutine[Any, Any, Any]]) -> Callable[[], Non
             return
 
     return wrapper
+
+
+def norm_cosine_distance(value: float) -> float:
+    """
+    Normalize the cosine distance to a similarity score between 0 and 1.
+    """
+    return (2 - value) / 2

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -197,7 +197,12 @@ def norm_cosine_distance(value: float) -> float:
     """
     Normalize the cosine distance to a similarity score between 0 and 1.
     """
-    return (2 - value) / 2
+    return max((2 - value) / 2, 0)
+
+
+def denorm_cosine_distance(value: float) -> float:
+    """Denormalize the distance threshold from [0, 1] to [0, 1] for our db."""
+    return max(2 - 2 * value, 0)
 
 
 def norm_l2_distance(value: float) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def sample_data(sample_datetimes):
             "last_updated": sample_datetimes["high"].timestamp(),
             "credit_score": "medium",
             "location": "-110.0839,37.3861",
-            "user_embedding": [0.9, 0.9, 0.1],
+            "user_embedding": [-0.1, -0.1, -0.5],
         },
     ]
 

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -25,6 +25,7 @@ def vector_query():
     return VectorQuery(
         vector=[0.1, 0.1, 0.5],
         vector_field_name="user_embedding",
+        return_score=True,
         return_fields=[
             "user",
             "credit_score",
@@ -58,7 +59,7 @@ def normalized_vector_query():
     return VectorQuery(
         vector=[0.1, 0.1, 0.5],
         vector_field_name="user_embedding",
-        normalize_cosine_distance=True,
+        normalize_vector_distance=True,
         return_score=True,
         return_fields=[
             "user",
@@ -107,7 +108,7 @@ def normalized_range_query():
     return RangeQuery(
         vector=[0.1, 0.1, 0.5],
         vector_field_name="user_embedding",
-        normalize_cosine_distance=True,
+        normalize_vector_distance=True,
         return_score=True,
         return_fields=["user", "credit_score", "age", "job", "location"],
         distance_threshold=0.2,
@@ -749,11 +750,26 @@ def test_query_normalize_cosine_distance(index, normalized_vector_query):
         assert 0 <= float(r["vector_distance"]) <= 1
 
 
-def test_query_normalize_cosine_distance_lp_distance(L2_index, normalized_vector_query):
+def test_query_cosine_distance_un_normalized(index, vector_query):
+
+    res = index.query(vector_query)
+
+    assert any(float(r["vector_distance"]) > 1 for r in res)
+
+
+def test_query_l2_distance_un_normalized(L2_index, vector_query):
+
+    res = L2_index.query(vector_query)
+
+    assert any(float(r["vector_distance"]) > 1 for r in res)
+
+
+def test_query_l2_distance_normalized(L2_index, normalized_vector_query):
 
     res = L2_index.query(normalized_vector_query)
 
-    assert any(float(r["vector_distance"]) > 1 for r in res)
+    for r in res:
+        assert 0 <= float(r["vector_distance"]) <= 1
 
 
 def test_range_query_normalize_cosine_distance(index, normalized_range_query):

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -749,7 +749,7 @@ def test_query_normalize_cosine_distance(index, normalized_vector_query):
         assert 0 <= float(r["vector_distance"]) <= 1
 
 
-def test_query_normalize_cosine_distance_ip_distance(L2_index, normalized_vector_query):
+def test_query_normalize_cosine_distance_lp_distance(L2_index, normalized_vector_query):
 
     res = L2_index.query(normalized_vector_query)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,6 +16,7 @@ from redisvl.redis.utils import (
 )
 from redisvl.utils.utils import (
     assert_no_warnings,
+    denorm_cosine_distance,
     deprecated_argument,
     deprecated_function,
     norm_cosine_distance,
@@ -26,6 +27,17 @@ def test_norm_cosine_distance():
     input = 2
     expected = 0
     assert norm_cosine_distance(input) == expected
+
+
+def test_denorm_cosine_distance():
+    input = 0
+    expected = 2
+    assert denorm_cosine_distance(input) == expected
+
+
+def test_norm_denorm_cosine():
+    input = 0.6
+    assert input == round(denorm_cosine_distance(norm_cosine_distance(input)), 6)
 
 
 def test_even_number_of_elements():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,7 +18,14 @@ from redisvl.utils.utils import (
     assert_no_warnings,
     deprecated_argument,
     deprecated_function,
+    norm_cosine_distance,
 )
+
+
+def test_norm_cosine_distance():
+    input = 2
+    expected = 0
+    assert norm_cosine_distance(input) == expected
 
 
 def test_even_number_of_elements():


### PR DESCRIPTION
This pr accomplishes 2 goals:
1. Add an option for users to easily get back a similarity value between 0 and 1 that they might expect to compare against other vector dbs. 
2. Fix the current bug that `distance_threshold` is validated to be between 0 and 1 when in reality it can take values between 0 and 2. 

> Note: after much careful thought I believe it is best that for `0.5.0` we do **not** start enforcing all distance_thresholds between 0 and 1 and move to this option as default behavior. Ideally this metric would be consistent throughout our code and I don't love supporting this flag but I think it provides the value that is scoped for this ticket while inflicting the least amount of pain and confusion. 

Changes:

1. Adds the `normalize_vector_distance` flag to VectorQuery and VectorRangeQuery. 

Behavior:
- If set to `True` it normalizes values returned from redis to a value between 0 and 1. 
- For cosine similarity, it applies `(2 - value)/2`.
- For L2 distance, it applies normalization `(1/(1+value))`.
- For IP, it does nothing and throws a warning since normalized IP is cosine by definition.
- For VectorRangeQuery, if `normalize_vector_distance=True` the distance threshold is now validated to be between 0 and 1 and denormalized for execution against the database to make consistent. 

2. Relaxes validation for semantic caching and routing to be between 0 and 2 fixing the current bug and aligning with how the database actually functions. 

