### PR TITLE
Fix: RedisVL breaks existing logging configurations

### DIFF
--- a/redisvl/utils/log.py
+++ b/redisvl/utils/log.py
@@ -3,7 +3,6 @@ import sys
 
 import coloredlogs
 
-# constants for logging
 coloredlogs.DEFAULT_DATE_FORMAT = "%H:%M:%S"
 coloredlogs.DEFAULT_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s   %(message)s"
 
@@ -15,5 +14,16 @@ def get_logger(name, log_level="info", fmt=None):
     name = "RedisVL" if log_level == "debug" else name
 
     logger = logging.getLogger(name)
-    coloredlogs.install(level=log_level, logger=logger, fmt=fmt, stream=sys.stdout)
+
+    # Only configure this specific logger, not the root logger
+    # Check if the logger already has handlers to respect existing configuration
+    if not logger.handlers:
+        coloredlogs.install(
+            level=log_level,
+            logger=logger,  # Pass the specific logger
+            fmt=fmt,
+            stream=sys.stdout,
+            isatty=True,  # Only use colors when supported
+            reconfigure=False,  # Don't reconfigure existing loggers
+        )
     return logger

--- a/tests/unit/logger_interference_checker.py
+++ b/tests/unit/logger_interference_checker.py
@@ -1,0 +1,25 @@
+import logging
+import sys
+
+# Set up custom logging
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(
+    logging.Formatter(
+        "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)s] %(message)s"
+    )
+)
+
+# Configure root logger
+root_logger = logging.getLogger()
+root_logger.handlers = [handler]
+root_logger.setLevel(logging.INFO)
+
+# Log before import
+app_logger = logging.getLogger("app")
+app_logger.info("PRE_IMPORT_FORMAT")
+
+# Import RedisVL
+from redisvl.query.filter import Text  # noqa: E402, F401
+
+# Log after import
+app_logger.info("POST_IMPORT_FORMAT")


### PR DESCRIPTION
Fix: Prevent RedisVL from overriding existing logging configurations

## Issue
When importing any RedisVL component, the library currently overrides existing user-defined logging configurations silently. This happens because `coloredlogs.install()` is called during module import in `redisvl/utils/log.py`, which affects the root logger without the user's knowledge or consent.

## Changes
- Modified the `get_logger` function in `log.py` to respect existing logging configurations
- Added `reconfigure=False` to prevent modifying existing loggers
- Added `isatty=True` to only use colors in supported terminals
- Added a check to only configure loggers that don't already have handlers

## Testing
Replicates the before RedisVL is loaded scenario by using an external (to the test) py file that's run on it's own process

Fixes #293 