### PR TITLE
Add batch_search to sync Index

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,18 @@ jobs:
       - name: Run full test suite to prime cache
         env:
           HF_HOME: ${{ github.workspace }}/hf_cache
+          OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
+          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT_NAME: ${{ secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
+          OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           make test-all
 
@@ -113,6 +125,7 @@ jobs:
       - name: Run tests
         if: matrix.connection == 'plain' && matrix.redis-version == 'latest'
         env:
+          HF_HOME: ${{ github.workspace }}/hf_cache
           OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -136,6 +149,7 @@ jobs:
       - name: Run notebooks
         if: matrix.connection == 'plain' && matrix.redis-version == 'latest'
         env:
+          HF_HOME: ${{ github.workspace }}/hf_cache
           OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,11 @@ jobs:
           path: hf_cache
           key: ${{ runner.os }}-hf-cache
 
+      - name: Set HuggingFace token
+        run: |
+          mkdir -p ~/.huggingface
+          echo '{"token":"${{ secrets.HF_TOKEN }}"}' > ~/.huggingface/token
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -48,8 +53,14 @@ jobs:
         run: |
           poetry install --all-extras
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
       - name: Run full test suite to prime cache
         env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HOME: ${{ github.workspace }}/hf_cache
           OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,53 @@ env:
   POETRY_VERSION: "1.8.3"
 
 jobs:
+  prime-cache:
+    name: Prime HuggingFace Model Cache
+    runs-on: ubuntu-latest
+    env:
+      HF_HOME: ${{ github.workspace }}/hf_cache
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Cache HuggingFace Models
+        id: hf-cache
+        uses: actions/cache@v3
+        with:
+          path: hf_cache
+          key: ${{ runner.os }}-hf-cache
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          cache: pip
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          poetry install --all-extras
+
+      - name: Run full test suite to prime cache
+        env:
+          HF_HOME: ${{ github.workspace }}/hf_cache
+        run: |
+          make test-all
+
   test:
     name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} [redis ${{ matrix.redis-version }}]
     runs-on: ubuntu-latest
-
+    needs: prime-cache
+    env:
+      HF_HOME: ${{ github.workspace }}/hf_cache
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: ['3.10', '3.11', 3.12, 3.13]
         connection: ['hiredis', 'plain']
         redis-version: ['6.2.6-v9', 'latest', '8.0-M03']
 
@@ -32,11 +71,17 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+      - name: Cache HuggingFace Models
+        uses: actions/cache@v3
+        with:
+          path: hf_cache
+          key: ${{ runner.os }}-hf-cache
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: pip
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -74,16 +119,16 @@ jobs:
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
-          AZURE_OPENAI_API_KEY: ${{secrets.AZURE_OPENAI_API_KEY}}
-          AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
-          AZURE_OPENAI_DEPLOYMENT_NAME: ${{secrets.AZURE_OPENAI_DEPLOYMENT_NAME}}
-          OPENAI_API_VERSION: ${{secrets.OPENAI_API_VERSION}}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT_NAME: ${{ secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
+          OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           make test-all
 
-      - name: Run tests
+      - name: Run tests (alternate)
         if: matrix.connection != 'plain' || matrix.redis-version != 'latest'
         run: |
           make test
@@ -97,15 +142,15 @@ jobs:
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
-          AZURE_OPENAI_API_KEY: ${{secrets.AZURE_OPENAI_API_KEY}}
-          AZURE_OPENAI_ENDPOINT: ${{secrets.AZURE_OPENAI_ENDPOINT}}
-          AZURE_OPENAI_DEPLOYMENT_NAME: ${{secrets.AZURE_OPENAI_DEPLOYMENT_NAME}}
-          OPENAI_API_VERSION: ${{secrets.OPENAI_API_VERSION}}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT_NAME: ${{ secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
+          OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           docker run -d --name redis -p 6379:6379 redis/redis-stack-server:latest
-          make test-notebooks 
+          make test-notebooks
 
   docs:
     runs-on: ubuntu-latest
@@ -117,17 +162,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
+          cache: pip
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           version: ${{ env.POETRY_VERSION }}
-  
+
       - name: Install dependencies
         run: |
           poetry install --all-extras
 
       - name: Build docs
         run: |
-          make docs-build 
+          make docs-build

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -681,7 +681,6 @@ class SearchIndex(BaseSearchIndex):
 
         for i in range(0, len(queries), batch_size):
             batch_queries = queries[i : i + batch_size]
-            print("batch queries", batch_queries)
 
             # redis-py doesn't support calling `search` in a pipeline,
             # so we need to manually execute each command in a pipeline
@@ -693,7 +692,6 @@ class SearchIndex(BaseSearchIndex):
                         query, query_params=query_params
                     )
                     batch_built_queries.append(q)
-                    print("query", query_args, options)
                     pipe.execute_command(
                         "FT.SEARCH",
                         *query_args,
@@ -701,10 +699,7 @@ class SearchIndex(BaseSearchIndex):
                     )
 
                 st = time.time()
-                # One list of results per query
-                print("query stack", pipe.command_stack)
                 results = pipe.execute()
-                print("SUCCESS")
 
                 # We don't know how long each query took, so we'll use the total time
                 # for all queries in the batch as the duration for each query

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -447,47 +447,81 @@ async def test_batch_search(async_index):
 
     results = await async_index.batch_search(["@test:{foo}", "@test:{bar}"])
     assert len(results) == 2
-    assert results[0][0]["id"] == "rvl:1"
-    assert results[1][0]["id"] == "rvl:2"
+    assert results[0].total == 1
+    assert results[0].docs[0]["id"] == "rvl:1"
+    assert results[1].total == 1
+    assert results[1].docs[0]["id"] == "rvl:2"
 
 
+@pytest.mark.parametrize(
+    "queries",
+    [
+        [
+            [
+                FilterQuery(filter_expression="@test:{foo}"),
+                FilterQuery(filter_expression="@test:{bar}"),
+            ],
+            [
+                FilterQuery(filter_expression="@test:{foo}"),
+                FilterQuery(filter_expression="@test:{bar}"),
+                FilterQuery(filter_expression="@test:{baz}"),
+                FilterQuery(filter_expression="@test:{foo}"),
+                FilterQuery(filter_expression="@test:{bar}"),
+                FilterQuery(filter_expression="@test:{baz}"),
+            ],
+        ],
+        [
+            [
+                "@test:{foo}",
+                "@test:{bar}",
+            ],
+            [
+                "@test:{foo}",
+                "@test:{bar}",
+                "@test:{baz}",
+                "@test:{foo}",
+                "@test:{bar}",
+                "@test:{baz}",
+            ],
+        ],
+    ],
+)
 @pytest.mark.asyncio
-async def test_batch_search_with_multiple_batches(async_index):
+async def test_batch_search_with_multiple_batches(async_index, queries):
     await async_index.create(overwrite=True, drop=True)
     data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
     await async_index.load(data, id_field="id")
 
-    results = await async_index.batch_search(["@test:{foo}", "@test:{bar}"])
+    results = await async_index.batch_search(queries[0])
     assert len(results) == 2
-    assert len(results[0]) == 1
-    assert len(results[1]) == 1
+    assert results[0].total == 1
+    assert results[0].docs[0]["id"] == "rvl:1"
+    assert results[1].total == 1
+    assert results[1].docs[0]["id"] == "rvl:2"
 
     results = await async_index.batch_search(
-        [
-            "@test:{foo}",
-            "@test:{bar}",
-            "@test:{baz}",
-            "@test:{foo}",
-            "@test:{bar}",
-            "@test:{baz}",
-        ],
+        queries[1],
         batch_size=2,
     )
     assert len(results) == 6
 
     # First (and only) result for the first query
-    assert results[0][0]["id"] == "rvl:1"
+    assert results[0].total == 1
+    assert results[0].docs[0]["id"] == "rvl:1"
 
     # Second (and only) result for the second query
-    assert results[1][0]["id"] == "rvl:2"
+    assert results[1].total == 1
+    assert results[1].docs[0]["id"] == "rvl:2"
 
     # Third query should have zero results because there is no baz
-    assert len(results[2]) == 0
+    assert results[2].total == 0
 
     # Then the pattern repeats
-    assert results[3][0]["id"] == "rvl:1"
-    assert results[4][0]["id"] == "rvl:2"
-    assert len(results[5]) == 0
+    assert results[3].total == 1
+    assert results[3].docs[0]["id"] == "rvl:1"
+    assert results[4].total == 1
+    assert results[4].docs[0]["id"] == "rvl:2"
+    assert results[5].total == 0
 
 
 @pytest.mark.asyncio
@@ -500,3 +534,20 @@ async def test_batch_query(async_index):
     results = await async_index.batch_query([query])
 
     assert len(results) == 1
+    assert results[0][0]["id"] == "rvl:1"
+
+
+@pytest.mark.asyncio
+async def test_batch_query_with_multiple_batches(async_index):
+    await async_index.create(overwrite=True, drop=True)
+    data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
+    await async_index.load(data, id_field="id")
+
+    queries = [
+        FilterQuery(filter_expression="@test:{foo}"),
+        FilterQuery(filter_expression="@test:{bar}"),
+    ]
+    results = await async_index.batch_query(queries, batch_size=1)
+    assert len(results) == 2
+    assert results[0][0]["id"] == "rvl:1"
+    assert results[1][0]["id"] == "rvl:2"

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -8,6 +8,7 @@ from redis.asyncio import Redis as AsyncRedis
 from redisvl.exceptions import RedisModuleVersionError, RedisSearchError
 from redisvl.index import AsyncSearchIndex
 from redisvl.query import VectorQuery
+from redisvl.query.query import FilterQuery
 from redisvl.redis.utils import convert_bytes
 from redisvl.schema import IndexSchema, StorageType
 
@@ -487,3 +488,15 @@ async def test_batch_search_with_multiple_batches(async_index):
     assert results[3][0]["id"] == "rvl:1"
     assert results[4][0]["id"] == "rvl:2"
     assert len(results[5]) == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_query(async_index):
+    await async_index.create(overwrite=True, drop=True)
+    data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
+    await async_index.load(data, id_field="id")
+
+    query = FilterQuery(filter_expression="@test:{foo}")
+    results = await async_index.batch_query([query])
+
+    assert len(results) == 1

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -7,6 +7,7 @@ from redis import Redis
 from redisvl.exceptions import RedisModuleVersionError, RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.query import VectorQuery
+from redisvl.query.query import FilterQuery
 from redisvl.redis.utils import convert_bytes
 from redisvl.schema import IndexSchema, StorageType
 
@@ -398,43 +399,100 @@ def test_batch_search(index):
 
     results = index.batch_search(["@test:{foo}", "@test:{bar}"])
     assert len(results) == 2
-    assert results[0][0]["id"] == "rvl:1"
-    assert results[1][0]["id"] == "rvl:2"
+    assert results[0].total == 1
+    assert results[0].docs[0]["id"] == "rvl:1"
+    assert results[1].total == 1
+    assert results[1].docs[0]["id"] == "rvl:2"
 
 
-def test_batch_search_with_multiple_batches(index):
+@pytest.mark.parametrize(
+    "queries",
+    [
+        [
+            [
+                FilterQuery(filter_expression="@test:{foo}"),
+                FilterQuery(filter_expression="@test:{bar}"),
+            ],
+            [
+                FilterQuery(filter_expression="@test:{foo}"),
+                FilterQuery(filter_expression="@test:{bar}"),
+                FilterQuery(filter_expression="@test:{baz}"),
+                FilterQuery(filter_expression="@test:{foo}"),
+                FilterQuery(filter_expression="@test:{bar}"),
+                FilterQuery(filter_expression="@test:{baz}"),
+            ],
+        ],
+        [
+            [
+                "@test:{foo}",
+                "@test:{bar}",
+            ],
+            [
+                "@test:{foo}",
+                "@test:{bar}",
+                "@test:{baz}",
+                "@test:{foo}",
+                "@test:{bar}",
+                "@test:{baz}",
+            ],
+        ],
+    ],
+)
+def test_batch_search_with_multiple_batches(index, queries):
     index.create(overwrite=True, drop=True)
     data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
     index.load(data, id_field="id")
 
-    results = index.batch_search(["@test:{foo}", "@test:{bar}"])
+    results = index.batch_search(queries[0])
     assert len(results) == 2
-    assert len(results[0]) == 1
-    assert len(results[1]) == 1
+    assert results[0].total == 1
+    assert results[0].docs[0]["id"] == "rvl:1"
+    assert results[1].total == 1
+    assert results[1].docs[0]["id"] == "rvl:2"
 
     results = index.batch_search(
-        [
-            "@test:{foo}",
-            "@test:{bar}",
-            "@test:{baz}",
-            "@test:{foo}",
-            "@test:{bar}",
-            "@test:{baz}",
-        ],
+        queries[1],
         batch_size=2,
     )
     assert len(results) == 6
 
     # First (and only) result for the first query
-    assert results[0][0]["id"] == "rvl:1"
+    assert results[0].docs[0]["id"] == "rvl:1"
 
     # Second (and only) result for the second query
-    assert results[1][0]["id"] == "rvl:2"
+    assert results[1].docs[0]["id"] == "rvl:2"
 
     # Third query should have zero results because there is no baz
-    assert len(results[2]) == 0
+    assert results[2].total == 0
 
     # Then the pattern repeats
-    assert results[3][0]["id"] == "rvl:1"
-    assert results[4][0]["id"] == "rvl:2"
-    assert len(results[5]) == 0
+    assert results[3].docs[0]["id"] == "rvl:1"
+    assert results[4].docs[0]["id"] == "rvl:2"
+    assert results[5].total == 0
+
+
+def test_batch_query(index):
+    index.create(overwrite=True, drop=True)
+    data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
+    index.load(data, id_field="id")
+
+    query = FilterQuery(filter_expression="@test:{foo}")
+    results = index.batch_query([query])
+
+    assert len(results) == 1
+    assert results[0][0]["id"] == "rvl:1"
+
+
+def test_batch_query_with_multiple_batches(index):
+    index.create(overwrite=True, drop=True)
+    data = [{"id": "1", "test": "foo"}, {"id": "2", "test": "bar"}]
+    index.load(data, id_field="id")
+
+    queries = [
+        FilterQuery(filter_expression="@test:{foo}"),
+        FilterQuery(filter_expression="@test:{bar}"),
+    ]
+    results = index.batch_query(queries, batch_size=1)
+    assert len(results) == 2
+    assert results[0][0]["id"] == "rvl:1"
+    assert results[1][0]["id"] == "rvl:2"

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -431,7 +431,7 @@ def test_batch_search_with_multiple_batches(index):
     # Second (and only) result for the second query
     assert results[1][0]["id"] == "rvl:2"
 
-    # Third query has no results
+    # Third query should have zero results because there is no baz
     assert len(results[2]) == 0
 
     # Then the pattern repeats


### PR DESCRIPTION
Add a `batch_search` method to `SearchIndex` and `AsyncSearchIndex`. These methods run search commands in a pipeline and return correctly-parsed and post-processed results.

TODO:
- [x] Async version
- [x] `batch_query`