### PR TITLE
update search step on recall and precision

### DIFF
--- a/tests/integration/test_threshold_optimizer.py
+++ b/tests/integration/test_threshold_optimizer.py
@@ -150,7 +150,7 @@ def test_routes_different_distance_thresholds_optimizer_precision(
     router_optimizer = RouterThresholdOptimizer(
         router, test_data_optimization, eval_metric="precision"
     )
-    router_optimizer.optimize(max_iterations=10)
+    router_optimizer.optimize(max_iterations=10, search_step=0.5)
 
     # test that it updated thresholds beyond the null case
     for route in routes:
@@ -186,7 +186,7 @@ def test_routes_different_distance_thresholds_optimizer_recall(
     router_optimizer = RouterThresholdOptimizer(
         router, test_data_optimization, eval_metric="recall"
     )
-    router_optimizer.optimize(max_iterations=10)
+    router_optimizer.optimize(max_iterations=10, search_step=0.5)
 
     # test that it updated thresholds beyond the null case
     for route in routes:


### PR DESCRIPTION
We were experiencing flakiness with a similar test before and haven't had an issue (as far as I know) with that test since updating the search_step. 

Error occurs for this step when after 10 tries the random search hasn't made the threshold large enough to show improvement which is why it failed sometimes. 