### PR TITLE
Enable embedding caching on all vectorizers

### DIFF
--- a/docs/user_guide/10_embeddings_cache.ipynb
+++ b/docs/user_guide/10_embeddings_cache.ipynb
@@ -51,13 +51,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tyler.hutcherson/Library/Caches/pypoetry/virtualenvs/redisvl-VnTEShF2-py3.13/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Compiling the model with `torch.compile` and using a `torch.mps` device is not supported. Falling back to non-compiled mode.\n"
+     ]
+    }
+   ],
    "source": [
     "# Initialize the vectorizer\n",
     "vectorizer = HFTextVectorizer(\n",
-    "    model=\"sentence-transformers/all-mpnet-base-v2\",\n",
+    "    model=\"redis/langcache-embed-v1\",\n",
     "    cache_folder=os.getenv(\"SENTENCE_TRANSFORMERS_HOME\")\n",
     ")"
    ]
@@ -103,21 +113,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Stored with key: embedcache:059d...\n"
+      "Stored with key: embedcache:909f...\n"
      ]
     }
    ],
    "source": [
     "# Text to embed\n",
     "text = \"What is machine learning?\"\n",
-    "model_name = \"sentence-transformers/all-mpnet-base-v2\"\n",
+    "model_name = \"redis/langcache-embed-v1\"\n",
     "\n",
     "# Generate the embedding\n",
     "embedding = vectorizer.embed(text)\n",
@@ -147,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -155,7 +165,7 @@
      "output_type": "stream",
      "text": [
       "Found in cache: What is machine learning?\n",
-      "Model: sentence-transformers/all-mpnet-base-v2\n",
+      "Model: redis/langcache-embed-v1\n",
       "Metadata: {'category': 'ai', 'source': 'user_query'}\n",
       "Embedding shape: (768,)\n"
      ]
@@ -184,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -218,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -251,14 +261,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Stored with key: embedcache:059d...\n",
+      "Stored with key: embedcache:909f...\n",
       "Exists by key: True\n",
       "Retrieved by key: What is machine learning?\n"
      ]
@@ -297,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -382,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -430,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -484,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -533,18 +543,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Computing embedding for: What is artificial intelligence?\n",
-      "Computing embedding for: How does machine learning work?\n",
-      "Found in cache: What is artificial intelligence?\n",
-      "Computing embedding for: What are neural networks?\n",
-      "Found in cache: How does machine learning work?\n",
       "\n",
       "Statistics:\n",
       "Total queries: 5\n",
@@ -562,25 +567,11 @@
     "    ttl=3600  # 1 hour TTL\n",
     ")\n",
     "\n",
-    "# Function to get embedding with caching\n",
-    "def get_cached_embedding(text, model_name):\n",
-    "    # Check if it's in the cache first\n",
-    "    if cached_result := example_cache.get(text=text, model_name=model_name):\n",
-    "        print(f\"Found in cache: {text}\")\n",
-    "        return cached_result[\"embedding\"]\n",
-    "    \n",
-    "    # Not in cache, compute the embedding\n",
-    "    print(f\"Computing embedding for: {text}\")\n",
-    "    embedding = vectorizer.embed(text)\n",
-    "    \n",
-    "    # Store in cache\n",
-    "    example_cache.set(\n",
-    "        text=text,\n",
-    "        model_name=model_name,\n",
-    "        embedding=embedding,\n",
-    "    )\n",
-    "    \n",
-    "    return embedding\n",
+    "vectorizer = HFTextVectorizer(\n",
+    "    model=model_name,\n",
+    "    cache=example_cache,\n",
+    "    cache_folder=os.getenv(\"SENTENCE_TRANSFORMERS_HOME\")\n",
+    ")\n",
     "\n",
     "# Simulate processing a stream of queries\n",
     "queries = [\n",
@@ -604,7 +595,7 @@
     "        cache_hits += 1\n",
     "    \n",
     "    # Get embedding (will compute or use cache)\n",
-    "    embedding = get_cached_embedding(query, model_name)\n",
+    "    embedding = vectorizer.embed(query)\n",
     "\n",
     "# Report statistics\n",
     "cache_misses = total_queries - cache_hits\n",
@@ -632,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -640,24 +631,23 @@
      "output_type": "stream",
      "text": [
       "Benchmarking without caching:\n",
-      "Time taken without caching: 0.0940 seconds\n",
-      "Average time per embedding: 0.0094 seconds\n",
+      "Time taken without caching: 0.4735 seconds\n",
+      "Average time per embedding: 0.0474 seconds\n",
       "\n",
       "Benchmarking with caching:\n",
-      "Time taken with caching: 0.0237 seconds\n",
-      "Average time per embedding: 0.0024 seconds\n",
+      "Time taken with caching: 0.0663 seconds\n",
+      "Average time per embedding: 0.0066 seconds\n",
       "\n",
       "Performance comparison:\n",
-      "Speedup with caching: 3.96x faster\n",
-      "Time saved: 0.0703 seconds (74.8%)\n",
-      "Latency reduction: 0.0070 seconds per query\n"
+      "Speedup with caching: 7.14x faster\n",
+      "Time saved: 0.4073 seconds (86.0%)\n",
+      "Latency reduction: 0.0407 seconds per query\n"
      ]
     }
    ],
    "source": [
     "# Text to use for benchmarking\n",
     "benchmark_text = \"This is a benchmark text to measure the performance of embedding caching.\"\n",
-    "benchmark_model = \"sentence-transformers/all-mpnet-base-v2\"\n",
     "\n",
     "# Create a fresh cache for benchmarking\n",
     "benchmark_cache = EmbeddingsCache(\n",
@@ -665,23 +655,7 @@
     "    redis_url=\"redis://localhost:6379\",\n",
     "    ttl=3600  # 1 hour TTL\n",
     ")\n",
-    "\n",
-    "# Function to get embeddings without caching\n",
-    "def get_embedding_without_cache(text, model_name):\n",
-    "    return vectorizer.embed(text)\n",
-    "\n",
-    "# Function to get embeddings with caching\n",
-    "def get_embedding_with_cache(text, model_name):\n",
-    "    if cached_result := benchmark_cache.get(text=text, model_name=model_name):\n",
-    "        return cached_result[\"embedding\"]\n",
-    "    \n",
-    "    embedding = vectorizer.embed(text)\n",
-    "    benchmark_cache.set(\n",
-    "        text=text,\n",
-    "        model_name=model_name,\n",
-    "        embedding=embedding\n",
-    "    )\n",
-    "    return embedding\n",
+    "vectorizer.cache = benchmark_cache\n",
     "\n",
     "# Number of iterations for the benchmark\n",
     "n_iterations = 10\n",
@@ -689,7 +663,8 @@
     "# Benchmark without caching\n",
     "print(\"Benchmarking without caching:\")\n",
     "start_time = time.time()\n",
-    "get_embedding_without_cache(benchmark_text, benchmark_model)\n",
+    "for _ in range(n_iterations):\n",
+    "    embedding = vectorizer.embed(text, skip_cache=True)\n",
     "no_cache_time = time.time() - start_time\n",
     "print(f\"Time taken without caching: {no_cache_time:.4f} seconds\")\n",
     "print(f\"Average time per embedding: {no_cache_time/n_iterations:.4f} seconds\")\n",
@@ -697,7 +672,8 @@
     "# Benchmark with caching\n",
     "print(\"\\nBenchmarking with caching:\")\n",
     "start_time = time.time()\n",
-    "get_embedding_with_cache(benchmark_text, benchmark_model)\n",
+    "for _ in range(n_iterations):\n",
+    "    embedding = vectorizer.embed(text)\n",
     "cache_time = time.time() - start_time\n",
     "print(f\"Time taken with caching: {cache_time:.4f} seconds\")\n",
     "print(f\"Average time per embedding: {cache_time/n_iterations:.4f} seconds\")\n",
@@ -785,7 +761,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/poetry.lock
+++ b/poetry.lock
@@ -763,15 +763,15 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cohere"
-version = "5.13.12"
+version = "5.15.0"
 description = ""
 optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"cohere\""
 files = [
-    {file = "cohere-5.13.12-py3-none-any.whl", hash = "sha256:2a043591a3e5280b47716a6b311e4c7f58e799364113a9cb81b50cd4f6c95f7e"},
-    {file = "cohere-5.13.12.tar.gz", hash = "sha256:97bb9ac107e580780b941acbabd3aa5e71960e6835398292c46aaa8a0a4cab88"},
+    {file = "cohere-5.15.0-py3-none-any.whl", hash = "sha256:22ff867c2a6f2fc2b585360c6072f584f11f275ef6d9242bac24e0fa2df1dfb5"},
+    {file = "cohere-5.15.0.tar.gz", hash = "sha256:e802d4718ddb0bb655654382ebbce002756a3800faac30296cde7f1bdc6ff2cc"},
 ]
 
 [package.dependencies]
@@ -3627,8 +3627,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.21", markers = "python_version < \"3.10\""},
-    {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\" and python_version < \"3.13\""},
 ]

--- a/redisvl/extensions/cache/__init__.py
+++ b/redisvl/extensions/cache/__init__.py
@@ -6,7 +6,5 @@ including both embedding caches and LLM response caches.
 """
 
 from redisvl.extensions.cache.base import BaseCache
-from redisvl.extensions.cache.embeddings import EmbeddingsCache
-from redisvl.extensions.cache.llm import SemanticCache
 
-__all__ = ["BaseCache", "EmbeddingsCache", "SemanticCache"]
+__all__ = ["BaseCache"]

--- a/redisvl/extensions/router/schema.py
+++ b/redisvl/extensions/router/schema.py
@@ -62,7 +62,7 @@ class RoutingConfig(BaseModel):
     """Configuration for routing behavior."""
 
     """The maximum number of top matches to return."""
-    max_k: Annotated[int, Field(strict=True, default=1, gt=0)] = 1
+    max_k: Annotated[int, Field(strict=True, gt=0)] = 1
     """Aggregation method to use to classify queries."""
     aggregation_method: DistanceAggregationMethod = Field(
         default=DistanceAggregationMethod.avg

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -21,11 +21,8 @@ from redisvl.query import VectorRangeQuery
 from redisvl.redis.utils import convert_bytes, hashify, make_dict
 from redisvl.utils.log import get_logger
 from redisvl.utils.utils import deprecated_argument, model_to_dict
-from redisvl.utils.vectorize import (
-    BaseVectorizer,
-    HFTextVectorizer,
-    vectorizer_from_dict,
-)
+from redisvl.utils.vectorize.base import BaseVectorizer
+from redisvl.utils.vectorize.text.huggingface import HFTextVectorizer
 
 logger = get_logger(__name__)
 
@@ -483,6 +480,8 @@ class SemanticRouter(BaseModel):
             }
             router = SemanticRouter.from_dict(router_data)
         """
+        from redisvl.utils.vectorize import vectorizer_from_dict
+
         try:
             name = data["name"]
             routes_data = data["routes"]

--- a/redisvl/extensions/session_manager/semantic_session.py
+++ b/redisvl/extensions/session_manager/semantic_session.py
@@ -20,7 +20,7 @@ from redisvl.index import SearchIndex
 from redisvl.query import FilterQuery, RangeQuery
 from redisvl.query.filter import Tag
 from redisvl.utils.utils import deprecated_argument, validate_vector_dims
-from redisvl.utils.vectorize import BaseVectorizer, HFTextVectorizer
+from redisvl.utils.vectorize.base import BaseVectorizer
 
 
 class SemanticSessionManager(BaseSessionManager):
@@ -82,6 +82,8 @@ class SemanticSessionManager(BaseSessionManager):
                     f"Provided dtype {dtype} does not match vectorizer dtype {vectorizer.dtype}"
                 )
         else:
+            from redisvl.utils.vectorize.text.huggingface import HFTextVectorizer
+
             vectorizer_kwargs = kwargs
 
             if dtype:

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -306,12 +306,18 @@ class BaseVectorizer(BaseModel):
 
     async def _aembed(self, text: str, **kwargs) -> List[float]:
         """Asynchronously generate a vector embedding for a single text."""
+        logger.warning(
+            "This vectorizer has no async embed method. Falling back to sync."
+        )
         return self._embed(text, **kwargs)
 
     async def _aembed_many(
         self, texts: List[str], batch_size: int = 10, **kwargs
     ) -> List[List[float]]:
         """Asynchronously generate vector embeddings for a batch of texts."""
+        logger.warning(
+            "This vectorizer has no async embed_many method. Falling back to sync."
+        )
         return self._embed_many(texts, batch_size, **kwargs)
 
     def _get_from_cache_batch(

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -1,10 +1,15 @@
+import logging
 from enum import Enum
-from typing import Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing_extensions import Annotated
 
+from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.redis.utils import array_to_buffer
 from redisvl.schema.fields import VectorDataType
+
+logger = logging.getLogger(__name__)
 
 
 class Vectorizers(Enum):
@@ -18,19 +23,33 @@ class Vectorizers(Enum):
 
 
 class BaseVectorizer(BaseModel):
-    """Base vectorizer interface."""
+    """Base RedisVL vectorizer interface.
+
+    This class defines the interface for text vectorization with an optional
+    caching layer to improve performance by avoiding redundant API calls.
+
+    Attributes:
+        model: The name of the embedding model.
+        dtype: The data type of the embeddings, defaults to "float32".
+        dims: The dimensionality of the vectors.
+        cache: Optional embedding cache to store and retrieve embeddings.
+    """
 
     model: str
     dtype: str = "float32"
-    dims: Optional[int] = None
+    dims: Annotated[Optional[int], Field(strict=True, gt=0)] = None
+    cache: Optional[EmbeddingsCache] = Field(default=None)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def type(self) -> str:
+        """Return the type of vectorizer."""
         return "base"
 
     @field_validator("dtype")
     @classmethod
     def check_dtype(cls, dtype):
+        """Validate the data type is supported."""
         try:
             VectorDataType(dtype.upper())
         except ValueError:
@@ -39,33 +58,63 @@ class BaseVectorizer(BaseModel):
             )
         return dtype
 
-    @field_validator("dims")
-    @classmethod
-    def check_dims(cls, value):
-        """Ensures the dims are a positive integer."""
-        if value <= 0:
-            raise ValueError("Dims must be a positive integer.")
-        return value
-
     def embed(
         self,
         text: str,
         preprocess: Optional[Callable] = None,
         as_buffer: bool = False,
+        skip_cache: bool = False,
         **kwargs,
     ) -> Union[List[float], bytes]:
-        """Embed a chunk of text.
+        """Generate a vector embedding for a text string.
 
         Args:
-            text: Text to embed
-            preprocess: Optional function to preprocess text
-            as_buffer: If True, returns a bytes object instead of a list
+            text: The text to convert to a vector embedding
+            preprocess: Function to apply to the text before embedding
+            as_buffer: Return the embedding as a binary buffer instead of a list
+            skip_cache: Bypass the cache for this request
+            **kwargs: Additional model-specific parameters
 
         Returns:
-            Union[List[float], bytes]: Embedding as a list of floats, or as a bytes
-            object if as_buffer=True
+            The vector embedding as either a list of floats or binary buffer
+
+        Examples:
+            >>> embedding = vectorizer.embed("Hello world")
         """
-        raise NotImplementedError
+        # Apply preprocessing if provided
+        if preprocess is not None:
+            text = preprocess(text)
+
+        # Check cache if available and not skipped
+        if self.cache is not None and not skip_cache:
+            try:
+                cache_result = self.cache.get(text=text, model_name=self.model)
+                if cache_result:
+                    logger.debug(f"Cache hit for text with model {self.model}")
+                    return self._process_embedding(
+                        cache_result["embedding"], as_buffer, self.dtype
+                    )
+            except Exception as e:
+                logger.warning(f"Error accessing embedding cache: {str(e)}")
+
+        # Generate embedding using provider-specific implementation
+        cache_metadata = kwargs.pop("metadata", {})
+        embedding = self._embed(text, **kwargs)
+
+        # Store in cache if available and not skipped
+        if self.cache is not None and not skip_cache:
+            try:
+                self.cache.set(
+                    text=text,
+                    model_name=self.model,
+                    embedding=embedding,
+                    metadata=cache_metadata,
+                )
+            except Exception as e:
+                logger.warning(f"Error storing in embedding cache: {str(e)}")
+
+        # Process and return result
+        return self._process_embedding(embedding, as_buffer, self.dtype)
 
     def embed_many(
         self,
@@ -73,21 +122,119 @@ class BaseVectorizer(BaseModel):
         preprocess: Optional[Callable] = None,
         batch_size: int = 10,
         as_buffer: bool = False,
+        skip_cache: bool = False,
         **kwargs,
     ) -> Union[List[List[float]], List[bytes]]:
-        """Embed multiple chunks of text.
+        """Generate vector embeddings for multiple texts efficiently.
 
         Args:
-            texts: List of texts to embed
-            preprocess: Optional function to preprocess text
-            batch_size: Number of texts to process in each batch
-            as_buffer: If True, returns each embedding as a bytes object
+            texts: List of texts to convert to vector embeddings
+            preprocess: Function to apply to each text before embedding
+            batch_size: Number of texts to process in each API call
+            as_buffer: Return embeddings as binary buffers instead of lists
+            skip_cache: Bypass the cache for this request
+            **kwargs: Additional model-specific parameters
 
         Returns:
-            Union[List[List[float]], List[bytes]]: List of embeddings as lists of floats,
-            or as bytes objects if as_buffer=True
+            List of vector embeddings in the same order as the input texts
+
+        Examples:
+            >>> embeddings = vectorizer.embed_many(["Hello", "World"], batch_size=2)
         """
-        raise NotImplementedError
+        if not texts:
+            return []
+
+        # Apply preprocessing if provided
+        if preprocess is not None:
+            processed_texts = [preprocess(text) for text in texts]
+        else:
+            processed_texts = texts
+
+        # Get cached embeddings and identify misses
+        results, cache_misses, cache_miss_indices = self._get_from_cache_batch(
+            processed_texts, skip_cache
+        )
+
+        # Generate embeddings for cache misses
+        if cache_misses:
+            cache_metadata = kwargs.pop("metadata", {})
+            new_embeddings = self._embed_many(
+                texts=cache_misses, batch_size=batch_size, **kwargs
+            )
+
+            # Store new embeddings in cache
+            self._store_in_cache_batch(
+                cache_misses, new_embeddings, cache_metadata, skip_cache
+            )
+
+            # Insert new embeddings into results array
+            for idx, embedding in zip(cache_miss_indices, new_embeddings):
+                results[idx] = embedding
+
+        # Process and return results
+        return [self._process_embedding(emb, as_buffer, self.dtype) for emb in results]
+
+    async def aembed(
+        self,
+        text: str,
+        preprocess: Optional[Callable] = None,
+        as_buffer: bool = False,
+        skip_cache: bool = False,
+        **kwargs,
+    ) -> Union[List[float], bytes]:
+        """Asynchronously generate a vector embedding for a text string.
+
+        Args:
+            text: The text to convert to a vector embedding
+            preprocess: Function to apply to the text before embedding
+            as_buffer: Return the embedding as a binary buffer instead of a list
+            skip_cache: Bypass the cache for this request
+            **kwargs: Additional model-specific parameters
+
+        Returns:
+            The vector embedding as either a list of floats or binary buffer
+
+        Examples:
+            >>> embedding = await vectorizer.aembed("Hello world")
+        """
+        # Apply preprocessing if provided
+        if preprocess is not None:
+            text = preprocess(text)
+
+        # Check cache if available and not skipped
+        if self.cache is not None and not skip_cache:
+            try:
+                cache_result = await self.cache.aget(text=text, model_name=self.model)
+                if cache_result:
+                    logger.debug(f"Async cache hit for text with model {self.model}")
+                    return self._process_embedding(
+                        cache_result["embedding"], as_buffer, self.dtype
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Error accessing embedding cache asynchronously: {str(e)}"
+                )
+
+        # Generate embedding using provider-specific implementation
+        cache_metadata = kwargs.pop("metadata", {})
+        embedding = await self._aembed(text, **kwargs)
+
+        # Store in cache if available and not skipped
+        if self.cache is not None and not skip_cache:
+            try:
+                await self.cache.aset(
+                    text=text,
+                    model_name=self.model,
+                    embedding=embedding,
+                    metadata=cache_metadata,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Error storing in embedding cache asynchronously: {str(e)}"
+                )
+
+        # Process and return result
+        return self._process_embedding(embedding, as_buffer, self.dtype)
 
     async def aembed_many(
         self,
@@ -95,52 +242,256 @@ class BaseVectorizer(BaseModel):
         preprocess: Optional[Callable] = None,
         batch_size: int = 10,
         as_buffer: bool = False,
+        skip_cache: bool = False,
         **kwargs,
     ) -> Union[List[List[float]], List[bytes]]:
-        """Asynchronously embed multiple chunks of text.
+        """Asynchronously generate vector embeddings for multiple texts efficiently.
 
         Args:
-            texts: List of texts to embed
-            preprocess: Optional function to preprocess text
-            batch_size: Number of texts to process in each batch
-            as_buffer: If True, returns each embedding as a bytes object
+            texts: List of texts to convert to vector embeddings
+            preprocess: Function to apply to each text before embedding
+            batch_size: Number of texts to process in each API call
+            as_buffer: Return embeddings as binary buffers instead of lists
+            skip_cache: Bypass the cache for this request
+            **kwargs: Additional model-specific parameters
 
         Returns:
-            Union[List[List[float]], List[bytes]]: List of embeddings as lists of floats,
-            or as bytes objects if as_buffer=True
-        """
-        # Fallback to standard embedding call if no async support
-        return self.embed_many(texts, preprocess, batch_size, as_buffer, **kwargs)
+            List of vector embeddings in the same order as the input texts
 
-    async def aembed(
+        Examples:
+            >>> embeddings = await vectorizer.aembed_many(["Hello", "World"], batch_size=2)
+        """
+        if not texts:
+            return []
+
+        # Apply preprocessing if provided
+        if preprocess is not None:
+            processed_texts = [preprocess(text) for text in texts]
+        else:
+            processed_texts = texts
+
+        # Get cached embeddings and identify misses
+        results, cache_misses, cache_miss_indices = await self._aget_from_cache_batch(
+            processed_texts, skip_cache
+        )
+
+        # Generate embeddings for cache misses
+        if cache_misses:
+            cache_metadata = kwargs.pop("metadata", {})
+            new_embeddings = await self._aembed_many(
+                texts=cache_misses, batch_size=batch_size, **kwargs
+            )
+
+            # Store new embeddings in cache
+            await self._astore_in_cache_batch(
+                cache_misses, new_embeddings, cache_metadata, skip_cache
+            )
+
+            # Insert new embeddings into results array
+            for idx, embedding in zip(cache_miss_indices, new_embeddings):
+                results[idx] = embedding
+
+        # Process and return results
+        return [self._process_embedding(emb, as_buffer, self.dtype) for emb in results]
+
+    def _embed(self, text: str, **kwargs) -> List[float]:
+        """Generate a vector embedding for a single text."""
+        raise NotImplementedError
+
+    def _embed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """Generate vector embeddings for a batch of texts."""
+        raise NotImplementedError
+
+    async def _aembed(self, text: str, **kwargs) -> List[float]:
+        """Asynchronously generate a vector embedding for a single text."""
+        return self._embed(text, **kwargs)
+
+    async def _aembed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """Asynchronously generate vector embeddings for a batch of texts."""
+        return self._embed_many(texts, batch_size, **kwargs)
+
+    def _get_from_cache_batch(
+        self, texts: List[str], skip_cache: bool
+    ) -> tuple[List[Optional[List[float]]], List[str], List[int]]:
+        """Get vector embeddings from cache and track cache misses.
+
+        Args:
+            texts: List of texts to get from cache
+            skip_cache: Whether to skip cache lookup
+
+        Returns:
+            Tuple of (results, cache_misses, cache_miss_indices)
+        """
+        results = [None] * len(texts)
+        cache_misses = []
+        cache_miss_indices = []
+
+        # Skip cache if requested or no cache available
+        if skip_cache or self.cache is None:
+            return results, texts, list(range(len(texts)))  # type: ignore
+
+        try:
+            # Efficient batch cache lookup
+            cache_results = self.cache.mget(texts=texts, model_name=self.model)
+
+            # Process cache hits and collect misses
+            for i, (text, cache_result) in enumerate(zip(texts, cache_results)):
+                if cache_result:
+                    results[i] = cache_result["embedding"]
+                else:
+                    cache_misses.append(text)
+                    cache_miss_indices.append(i)
+
+            logger.debug(
+                f"Cache hits: {len(texts) - len(cache_misses)}, misses: {len(cache_misses)}"
+            )
+        except Exception as e:
+            logger.warning(f"Error accessing embedding cache in batch: {str(e)}")
+            # On cache error, process all texts
+            cache_misses = texts
+            cache_miss_indices = list(range(len(texts)))
+
+        return results, cache_misses, cache_miss_indices  # type: ignore
+
+    async def _aget_from_cache_batch(
+        self, texts: List[str], skip_cache: bool
+    ) -> tuple[List[Optional[List[float]]], List[str], List[int]]:
+        """Asynchronously get vector embeddings from cache and track cache misses.
+
+        Args:
+            texts: List of texts to get from cache
+            skip_cache: Whether to skip cache lookup
+
+        Returns:
+            Tuple of (results, cache_misses, cache_miss_indices)
+        """
+        results = [None] * len(texts)
+        cache_misses = []
+        cache_miss_indices = []
+
+        # Skip cache if requested or no cache available
+        if skip_cache or self.cache is None:
+            return results, texts, list(range(len(texts)))  # type: ignore
+
+        try:
+            # Efficient batch cache lookup
+            cache_results = await self.cache.amget(texts=texts, model_name=self.model)
+
+            # Process cache hits and collect misses
+            for i, (text, cache_result) in enumerate(zip(texts, cache_results)):
+                if cache_result:
+                    results[i] = cache_result["embedding"]
+                else:
+                    cache_misses.append(text)
+                    cache_miss_indices.append(i)
+
+            logger.debug(
+                f"Async cache hits: {len(texts) - len(cache_misses)}, misses: {len(cache_misses)}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Error accessing embedding cache in batch asynchronously: {str(e)}"
+            )
+            # On cache error, process all texts
+            cache_misses = texts
+            cache_miss_indices = list(range(len(texts)))
+
+        return results, cache_misses, cache_miss_indices  # type: ignore
+
+    def _store_in_cache_batch(
         self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[float], bytes]:
-        """Asynchronously embed a chunk of text.
+        texts: List[str],
+        embeddings: List[List[float]],
+        metadata: Dict,
+        skip_cache: bool,
+    ) -> None:
+        """Store a batch of vector embeddings in the cache.
 
         Args:
-            text: Text to embed
-            preprocess: Optional function to preprocess text
-            as_buffer: If True, returns a bytes object instead of a list
-
-        Returns:
-            Union[List[float], bytes]: Embedding as a list of floats, or as a bytes
-            object if as_buffer=True
+            texts: List of texts that were embedded
+            embeddings: List of vector embeddings
+            metadata: Metadata to store with the embeddings
+            skip_cache: Whether to skip cache storage
         """
-        # Fallback to standard embedding call if no async support
-        return self.embed(text, preprocess, as_buffer, **kwargs)
+        if skip_cache or self.cache is None:
+            return
+
+        try:
+            # Prepare batch cache storage items
+            cache_items = [
+                {
+                    "text": text,
+                    "model_name": self.model,
+                    "embedding": emb,
+                    "metadata": metadata,
+                }
+                for text, emb in zip(texts, embeddings)
+            ]
+            self.cache.mset(items=cache_items)
+        except Exception as e:
+            logger.warning(f"Error storing batch in embedding cache: {str(e)}")
+
+    async def _astore_in_cache_batch(
+        self,
+        texts: List[str],
+        embeddings: List[List[float]],
+        metadata: Dict,
+        skip_cache: bool,
+    ) -> None:
+        """Asynchronously store a batch of vector embeddings in the cache.
+
+        Args:
+            texts: List of texts that were embedded
+            embeddings: List of vector embeddings
+            metadata: Metadata to store with the embeddings
+            skip_cache: Whether to skip cache storage
+        """
+        if skip_cache or self.cache is None:
+            return
+
+        try:
+            # Prepare batch cache storage items
+            cache_items = [
+                {
+                    "text": text,
+                    "model_name": self.model,
+                    "embedding": emb,
+                    "metadata": metadata,
+                }
+                for text, emb in zip(texts, embeddings)
+            ]
+            await self.cache.amset(items=cache_items)
+        except Exception as e:
+            logger.warning(
+                f"Error storing batch in embedding cache asynchronously: {str(e)}"
+            )
 
     def batchify(self, seq: list, size: int, preprocess: Optional[Callable] = None):
+        """Split a sequence into batches of specified size.
+
+        Args:
+            seq: Sequence to split into batches
+            size: Batch size
+            preprocess: Optional function to preprocess each item
+
+        Yields:
+            Batches of the sequence
+        """
         for pos in range(0, len(seq), size):
             if preprocess is not None:
                 yield [preprocess(chunk) for chunk in seq[pos : pos + size]]
             else:
                 yield seq[pos : pos + size]
 
-    def _process_embedding(self, embedding: List[float], as_buffer: bool, dtype: str):
-        if as_buffer:
-            return array_to_buffer(embedding, dtype)
+    def _process_embedding(
+        self, embedding: Optional[List[float]], as_buffer: bool, dtype: str
+    ):
+        """Process the vector embedding format based on the as_buffer flag."""
+        if embedding is not None:
+            if as_buffer:
+                return array_to_buffer(embedding, dtype)
         return embedding

--- a/redisvl/utils/vectorize/text/azureopenai.py
+++ b/redisvl/utils/vectorize/text/azureopenai.py
@@ -1,9 +1,12 @@
 import os
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from pydantic import PrivateAttr
+from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tenacity.retry import retry_if_not_exception_type
+
+if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
 
 from redisvl.utils.utils import deprecated_argument
 from redisvl.utils.vectorize.base import BaseVectorizer
@@ -28,9 +31,12 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
     allowing for batch processing of texts and flexibility in handling
     preprocessing tasks.
 
+    You can optionally enable caching to improve performance when generating
+    embeddings for repeated text inputs.
+
     .. code-block:: python
 
-        # Synchronous embedding of a single text
+        # Basic usage
         vectorizer = AzureOpenAITextVectorizer(
             model="text-embedding-ada-002",
             api_config={
@@ -41,6 +47,26 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         )
         embedding = vectorizer.embed("Hello, world!")
 
+        # With caching enabled
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+        cache = EmbeddingsCache(name="azureopenai_embeddings_cache")
+
+        vectorizer = AzureOpenAITextVectorizer(
+            model="text-embedding-ada-002",
+            api_config={
+                "api_key": "your_api_key",
+                "api_version": "your_api_version",
+                "azure_endpoint": "your_azure_endpoint",
+            },
+            cache=cache
+        )
+
+        # First call will compute and cache the embedding
+        embedding1 = vectorizer.embed("Hello, world!")
+
+        # Second call will retrieve from cache
+        embedding2 = vectorizer.embed("Hello, world!")
+
         # Asynchronous batch embedding of multiple texts
         embeddings = await vectorizer.aembed_many(
             ["Hello, world!", "How are you?"],
@@ -49,14 +75,14 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
 
     """
 
-    _client: Any = PrivateAttr()
-    _aclient: Any = PrivateAttr()
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(
         self,
         model: str = "text-embedding-ada-002",
         api_config: Optional[Dict] = None,
         dtype: str = "float32",
+        cache: Optional["EmbeddingsCache"] = None,
         **kwargs,
     ):
         """Initialize the AzureOpenAI vectorizer.
@@ -71,22 +97,37 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
             dtype (str): the default datatype to use when embedding text as byte arrays.
                 Used when setting `as_buffer=True` in calls to embed() and embed_many().
                 Defaults to 'float32'.
+            cache (Optional[EmbeddingsCache]): Optional EmbeddingsCache instance to cache embeddings for
+                better performance with repeated texts. Defaults to None.
 
         Raises:
             ImportError: If the openai library is not installed.
             ValueError: If the AzureOpenAI API key, version, or endpoint are not provided.
             ValueError: If an invalid dtype is provided.
         """
-        super().__init__(model=model, dtype=dtype)
-        # Init client
+        super().__init__(model=model, dtype=dtype, cache=cache)
+        # Initialize clients and set up the model
+        self._setup(api_config, **kwargs)
+
+    def _setup(self, api_config: Optional[Dict], **kwargs):
+        """Set up the AzureOpenAI clients and determine the embedding dimensions."""
+        # Initialize clients
         self._initialize_clients(api_config, **kwargs)
-        # Set model dimensions
+        # Set model dimensions after client initialization
         self.dims = self._set_model_dims()
 
     def _initialize_clients(self, api_config: Optional[Dict], **kwargs):
         """
-        Setup the OpenAI clients using the provided API key or an
-        environment variable.
+        Setup the AzureOpenAI clients using the provided API key, API version,
+        and Azure endpoint.
+
+        Args:
+            api_config: Dictionary with API configuration options
+            **kwargs: Additional arguments to pass to AzureOpenAI clients
+
+        Raises:
+            ImportError: If the openai library is not installed
+            ValueError: If required parameters are not provided
         """
         if api_config is None:
             api_config = {}
@@ -96,8 +137,8 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
             from openai import AsyncAzureOpenAI, AzureOpenAI
         except ImportError:
             raise ImportError(
-                "AzureOpenAI vectorizer requires the openai library. \
-                    Please install with `pip install openai`"
+                "AzureOpenAI vectorizer requires the openai library. "
+                "Please install with `pip install openai>=1.13.0`"
             )
 
         # Fetch the API key, version and endpoint from api_config or environment variable
@@ -110,8 +151,7 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         if not azure_endpoint:
             raise ValueError(
                 "AzureOpenAI API endpoint is required. "
-                "Provide it in api_config or set the AZURE_OPENAI_ENDPOINT\
-                    environment variable."
+                "Provide it in api_config or set the AZURE_OPENAI_ENDPOINT environment variable."
             )
 
         api_version = (
@@ -123,8 +163,7 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         if not api_version:
             raise ValueError(
                 "AzureOpenAI API version is required. "
-                "Provide it in api_config or set the OPENAI_API_VERSION\
-                    environment variable."
+                "Provide it in api_config or set the OPENAI_API_VERSION environment variable."
             )
 
         api_key = (
@@ -136,10 +175,10 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         if not api_key:
             raise ValueError(
                 "AzureOpenAI API key is required. "
-                "Provide it in api_config or set the AZURE_OPENAI_API_KEY\
-                    environment variable."
+                "Provide it in api_config or set the AZURE_OPENAI_API_KEY environment variable."
             )
 
+        # Store clients as regular attributes instead of PrivateAttr
         self._client = AzureOpenAI(
             api_key=api_key,
             api_version=api_version,
@@ -156,198 +195,164 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         )
 
     def _set_model_dims(self) -> int:
+        """
+        Determine the dimensionality of the embedding model by making a test call.
+
+        Returns:
+            int: Dimensionality of the embedding model
+
+        Raises:
+            ValueError: If embedding dimensions cannot be determined
+        """
         try:
-            embedding = self.embed("dimension check")
+            # Call the protected _embed method to avoid caching this test embedding
+            embedding = self._embed("dimension check")
+            return len(embedding)
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Unexpected response from the AzureOpenAI API: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except
             # fall back (TODO get more specific)
             raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
-        return len(embedding)
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    @deprecated_argument("dtype")
-    def embed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[List[float]], List[bytes]]:
-        """Embed many chunks of texts using the AzureOpenAI API.
-
-        Args:
-            texts (List[str]): List of text chunks to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing
-                callable to perform before vectorization. Defaults to None.
-            batch_size (int, optional): Batch size of texts to use when creating
-                embeddings. Defaults to 10.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
-
-        Returns:
-            Union[List[List[float]], List[bytes]]: List of embeddings as lists of floats,
-            or as bytes objects if as_buffer=True
-
-        Raises:
-            TypeError: If the wrong input type is passed in for the test.
+    def _embed(self, text: str, **kwargs) -> List[float]:
         """
-        if not isinstance(texts, list):
-            raise TypeError("Must pass in a list of str values to embed.")
-        if len(texts) > 0 and not isinstance(texts[0], str):
-            raise TypeError("Must pass in a list of str values to embed.")
-
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        embeddings: List = []
-        for batch in self.batchify(texts, batch_size, preprocess):
-            response = self._client.embeddings.create(
-                input=batch, model=self.model, **kwargs
-            )
-            embeddings += [
-                self._process_embedding(r.embedding, as_buffer, dtype)
-                for r in response.data
-            ]
-        return embeddings
-
-    @retry(
-        wait=wait_random_exponential(min=1, max=60),
-        stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type(TypeError),
-    )
-    @deprecated_argument("dtype")
-    def embed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[float], bytes]:
-        """Embed a chunk of text using the AzureOpenAI API.
+        Generate a vector embedding for a single text using the AzureOpenAI API.
 
         Args:
-            text (str): Chunk of text to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            text: Text to embed
+            **kwargs: Additional parameters to pass to the AzureOpenAI API
 
         Returns:
-            Union[List[float], bytes]: Embedding as a list of floats, or as a bytes
-            object if as_buffer=True
+            List[float]: Vector embedding as a list of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If text is not a string
+            ValueError: If embedding fails
         """
         if not isinstance(text, str):
             raise TypeError("Must pass in a str value to embed.")
 
-        if preprocess:
-            text = preprocess(text)
-
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        result = self._client.embeddings.create(
-            input=[text], model=self.model, **kwargs
-        )
-        return self._process_embedding(result.data[0].embedding, as_buffer, dtype)
+        try:
+            result = self._client.embeddings.create(
+                input=[text], model=self.model, **kwargs
+            )
+            return result.data[0].embedding
+        except Exception as e:
+            raise ValueError(f"Embedding text failed: {e}")
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    @deprecated_argument("dtype")
-    async def aembed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[List[float]], List[bytes]]:
-        """Asynchronously embed many chunks of texts using the AzureOpenAI API.
+    def _embed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """
+        Generate vector embeddings for a batch of texts using the AzureOpenAI API.
 
         Args:
-            texts (List[str]): List of text chunks to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            batch_size (int, optional): Batch size of texts to use when creating
-                embeddings. Defaults to 10.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the AzureOpenAI API
 
         Returns:
-            Union[List[List[float]], List[bytes]]: List of embeddings as lists of floats,
-            or as bytes objects if as_buffer=True
+            List[List[float]]: List of vector embeddings as lists of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If texts is not a list of strings
+            ValueError: If embedding fails
         """
         if not isinstance(texts, list):
             raise TypeError("Must pass in a list of str values to embed.")
-        if len(texts) > 0 and not isinstance(texts[0], str):
+        if texts and not isinstance(texts[0], str):
             raise TypeError("Must pass in a list of str values to embed.")
 
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        embeddings: List = []
-        for batch in self.batchify(texts, batch_size, preprocess):
-            response = await self._aclient.embeddings.create(
-                input=batch, model=self.model, **kwargs
-            )
-            embeddings += [
-                self._process_embedding(r.embedding, as_buffer, dtype)
-                for r in response.data
-            ]
-        return embeddings
+        try:
+            embeddings: List = []
+            for batch in self.batchify(texts, batch_size):
+                response = self._client.embeddings.create(
+                    input=batch, model=self.model, **kwargs
+                )
+                embeddings.extend([r.embedding for r in response.data])
+            return embeddings
+        except Exception as e:
+            raise ValueError(f"Embedding texts failed: {e}")
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    @deprecated_argument("dtype")
-    async def aembed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[float], bytes]:
-        """Asynchronously embed a chunk of text using the OpenAI API.
+    async def _aembed(self, text: str, **kwargs) -> List[float]:
+        """
+        Asynchronously generate a vector embedding for a single text using the AzureOpenAI API.
 
         Args:
-            text (str): Chunk of text to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            text: Text to embed
+            **kwargs: Additional parameters to pass to the AzureOpenAI API
 
         Returns:
-            Union[List[float], bytes]: Embedding as a list of floats, or as a bytes
-            object if as_buffer=True
+            List[float]: Vector embedding as a list of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If text is not a string
+            ValueError: If embedding fails
         """
         if not isinstance(text, str):
             raise TypeError("Must pass in a str value to embed.")
 
-        if preprocess:
-            text = preprocess(text)
+        try:
+            result = await self._aclient.embeddings.create(
+                input=[text], model=self.model, **kwargs
+            )
+            return result.data[0].embedding
+        except Exception as e:
+            raise ValueError(f"Embedding text failed: {e}")
 
-        dtype = kwargs.pop("dtype", self.dtype)
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+    )
+    async def _aembed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """
+        Asynchronously generate vector embeddings for a batch of texts using the AzureOpenAI API.
 
-        result = await self._aclient.embeddings.create(
-            input=[text], model=self.model, **kwargs
-        )
-        return self._process_embedding(result.data[0].embedding, as_buffer, dtype)
+        Args:
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the AzureOpenAI API
+
+        Returns:
+            List[List[float]]: List of vector embeddings as lists of floats
+
+        Raises:
+            TypeError: If texts is not a list of strings
+            ValueError: If embedding fails
+        """
+        if not isinstance(texts, list):
+            raise TypeError("Must pass in a list of str values to embed.")
+        if texts and not isinstance(texts[0], str):
+            raise TypeError("Must pass in a list of str values to embed.")
+
+        try:
+            embeddings: List = []
+            for batch in self.batchify(texts, batch_size):
+                response = await self._aclient.embeddings.create(
+                    input=batch, model=self.model, **kwargs
+                )
+                embeddings.extend([r.embedding for r in response.data])
+            return embeddings
+        except Exception as e:
+            raise ValueError(f"Embedding texts failed: {e}")
 
     @property
     def type(self) -> str:

--- a/redisvl/utils/vectorize/text/cohere.py
+++ b/redisvl/utils/vectorize/text/cohere.py
@@ -1,10 +1,13 @@
 import os
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from pydantic import PrivateAttr
+from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tenacity.retry import retry_if_not_exception_type
+
+if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
 
 from redisvl.utils.utils import deprecated_argument
 from redisvl.utils.vectorize.base import BaseVectorizer
@@ -27,10 +30,14 @@ class CohereTextVectorizer(BaseVectorizer):
     The vectorizer supports only synchronous operations, allows for batch
     processing of texts and flexibility in handling preprocessing tasks.
 
+    You can optionally enable caching to improve performance when generating
+    embeddings for repeated text inputs.
+
     .. code-block:: python
 
         from redisvl.utils.vectorize import CohereTextVectorizer
 
+        # Basic usage
         vectorizer = CohereTextVectorizer(
             model="embed-english-v3.0",
             api_config={"api_key": "your-cohere-api-key"} # OR set COHERE_API_KEY in your env
@@ -39,20 +46,43 @@ class CohereTextVectorizer(BaseVectorizer):
             text="your input query text here",
             input_type="search_query"
         )
-        doc_embeddings = cohere.embed_many(
+        doc_embeddings = vectorizer.embed_many(
             texts=["your document text", "more document text"],
             input_type="search_document"
         )
 
+        # With caching enabled
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+        cache = EmbeddingsCache(name="cohere_embeddings_cache")
+
+        vectorizer = CohereTextVectorizer(
+            model="embed-english-v3.0",
+            api_config={"api_key": "your-cohere-api-key"},
+            cache=cache
+        )
+
+        # First call will compute and cache the embedding
+        embedding1 = vectorizer.embed(
+            text="your input query text here",
+            input_type="search_query"
+        )
+
+        # Second call will retrieve from cache
+        embedding2 = vectorizer.embed(
+            text="your input query text here",
+            input_type="search_query"
+        )
+
     """
 
-    _client: Any = PrivateAttr()
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(
         self,
         model: str = "embed-english-v3.0",
         api_config: Optional[Dict] = None,
         dtype: str = "float32",
+        cache: Optional["EmbeddingsCache"] = None,
         **kwargs,
     ):
         """Initialize the Cohere vectorizer.
@@ -67,22 +97,37 @@ class CohereTextVectorizer(BaseVectorizer):
                 Used when setting `as_buffer=True` in calls to embed() and embed_many().
                 'float32' will use Cohere's float embeddings, 'int8' and 'uint8' will map
                 to Cohere's corresponding embedding types. Defaults to 'float32'.
+            cache (Optional[EmbeddingsCache]): Optional EmbeddingsCache instance to cache embeddings for
+                better performance with repeated texts. Defaults to None.
 
         Raises:
             ImportError: If the cohere library is not installed.
             ValueError: If the API key is not provided.
             ValueError: If an invalid dtype is provided.
         """
-        super().__init__(model=model, dtype=dtype)
-        # Init client
+        super().__init__(model=model, dtype=dtype, cache=cache)
+        # Initialize client and set up the model
+        self._setup(api_config, **kwargs)
+
+    def _setup(self, api_config: Optional[Dict], **kwargs):
+        """Set up the Cohere client and determine the embedding dimensions."""
+        # Initialize client
         self._initialize_client(api_config, **kwargs)
-        # Set model dimensions after init
+        # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
     def _initialize_client(self, api_config: Optional[Dict], **kwargs):
         """
-        Setup the Cohere clients using the provided API key or an
+        Setup the Cohere client using the provided API key or an
         environment variable.
+
+        Args:
+            api_config: Dictionary with API configuration options
+            **kwargs: Additional arguments to pass to Cohere client
+
+        Raises:
+            ImportError: If the cohere library is not installed
+            ValueError: If no API key is provided
         """
         if api_config is None:
             api_config = {}
@@ -92,8 +137,8 @@ class CohereTextVectorizer(BaseVectorizer):
             from cohere import Client
         except ImportError:
             raise ImportError(
-                "Cohere vectorizer requires the cohere library. \
-                    Please install with `pip install cohere`"
+                "Cohere vectorizer requires the cohere library. "
+                "Please install with `pip install cohere`"
             )
 
         api_key = (
@@ -104,20 +149,39 @@ class CohereTextVectorizer(BaseVectorizer):
                 "Cohere API key is required. "
                 "Provide it in api_config or set the COHERE_API_KEY environment variable."
             )
+
         self._client = Client(api_key=api_key, client_name="redisvl", **kwargs)
 
     def _set_model_dims(self) -> int:
+        """
+        Determine the dimensionality of the embedding model by making a test call.
+
+        Returns:
+            int: Dimensionality of the embedding model
+
+        Raises:
+            ValueError: If embedding dimensions cannot be determined
+        """
         try:
-            embedding = self.embed("dimension check", input_type="search_document")
+            # Call the protected _embed method to avoid caching this test embedding
+            embedding = self._embed("dimension check", input_type="search_document")
+            return len(embedding)
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Unexpected response from the Cohere API: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except
             # fall back (TODO get more specific)
             raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
-        return len(embedding)
 
     def _get_cohere_embedding_type(self, dtype: str) -> List[str]:
-        """Map dtype to appropriate Cohere embedding_types value."""
+        """
+        Map dtype to appropriate Cohere embedding_types value.
+
+        Args:
+            dtype: The data type to map to Cohere embedding types
+
+        Returns:
+            List of embedding type strings compatible with Cohere API
+        """
         if dtype == "int8":
             return ["int8"]
         elif dtype == "uint8":
@@ -125,40 +189,30 @@ class CohereTextVectorizer(BaseVectorizer):
         else:
             return ["float"]
 
-    @deprecated_argument("dtype")
-    def embed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[float], List[int], bytes]:
-        """Embed a chunk of text using the Cohere Embeddings API.
-
-        Must provide the embedding `input_type` as a `kwarg` to this method
-        that specifies the type of input you're giving to the model.
-
-        Supported input types:
-            - ``search_document``: Used for embeddings stored in a vector database for search use-cases.
-            - ``search_query``: Used for embeddings of search queries run against a vector DB to find relevant documents.
-            - ``classification``: Used for embeddings passed through a text classifier
-            - ``clustering``: Used for the embeddings run through a clustering algorithm.
-
-        When hydrating your Redis DB, the documents you want to search over
-        should be embedded with input_type= "search_document" and when you are
-        querying the database, you should set the input_type = "search query".
-        If you want to use the embeddings for a classification or clustering
-        task downstream, you should set input_type= "classification" or
-        "clustering".
+    def _validate_input_type(self, input_type) -> None:
+        """
+        Validate that a proper input_type parameter was provided.
 
         Args:
-            text (str): Chunk of text to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
-            input_type (str): Specifies the type of input passed to the model.
-                Required for embedding models v3 and higher.
+            input_type: The input type parameter to validate
+
+        Raises:
+            TypeError: If input_type is not a string
+        """
+        if not isinstance(input_type, str):
+            raise TypeError(
+                "Must pass in a str value for cohere embedding input_type. "
+                "See https://docs.cohere.com/reference/embed."
+            )
+
+    def _embed(self, text: str, **kwargs) -> List[Union[float, int]]:
+        """
+        Generate a vector embedding for a single text using the Cohere API.
+
+        Args:
+            text: Text to embed
+            **kwargs: Additional parameters to pass to the Cohere API,
+                      must include 'input_type'
 
         Returns:
             Union[List[float], List[int], bytes]:
@@ -168,122 +222,14 @@ class CohereTextVectorizer(BaseVectorizer):
               - For dtype="int8" or "uint8": Returns a list of integers
 
         Raises:
-            TypeError: In an invalid input_type is provided.
-
+            TypeError: If text is not a string or input_type is not provided
+            ValueError: If embedding fails
         """
-        input_type = kwargs.pop("input_type", None)
-
         if not isinstance(text, str):
             raise TypeError("Must pass in a str value to embed.")
-        if not isinstance(input_type, str):
-            raise TypeError(
-                "Must pass in a str value for cohere embedding input_type. \
-                    See https://docs.cohere.com/reference/embed."
-            )
 
-        if preprocess:
-            text = preprocess(text)
-
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        # Check if embedding_types was provided and warn user
-        if "embedding_types" in kwargs:
-            warnings.warn(
-                "The 'embedding_types' parameter is not supported in CohereTextVectorizer. "
-                "Please use the 'dtype' parameter instead. Your 'embedding_types' value will be ignored.",
-                UserWarning,
-                stacklevel=2,
-            )
-            kwargs.pop("embedding_types")
-
-        # Map dtype to appropriate embedding_type
-        embedding_types = self._get_cohere_embedding_type(dtype)
-
-        response = self._client.embed(
-            texts=[text],
-            model=self.model,
-            input_type=input_type,
-            embedding_types=embedding_types,
-            **kwargs,
-        )
-
-        # Extract the appropriate embedding based on embedding_types
-        embed_type = embedding_types[0]
-        if hasattr(response.embeddings, embed_type):
-            embedding = getattr(response.embeddings, embed_type)[0]
-        else:
-            embedding = response.embeddings[0]  # Fallback for older API versions
-
-        return self._process_embedding(embedding, as_buffer, dtype)
-
-    @retry(
-        wait=wait_random_exponential(min=1, max=60),
-        stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type(TypeError),
-    )
-    @deprecated_argument("dtype")
-    def embed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[List[float]], List[List[int]], List[bytes]]:
-        """Embed many chunks of text using the Cohere Embeddings API.
-
-        Must provide the embedding `input_type` as a `kwarg` to this method
-        that specifies the type of input you're giving to the model.
-
-        Supported input types:
-            - ``search_document``: Used for embeddings stored in a vector database for search use-cases.
-            - ``search_query``: Used for embeddings of search queries run against a vector DB to find relevant documents.
-            - ``classification``: Used for embeddings passed through a text classifier
-            - ``clustering``: Used for the embeddings run through a clustering algorithm.
-
-
-        When hydrating your Redis DB, the documents you want to search over
-        should be embedded with input_type= "search_document" and when you are
-        querying the database, you should set the input_type = "search query".
-        If you want to use the embeddings for a classification or clustering
-        task downstream, you should set input_type= "classification" or
-        "clustering".
-
-        Args:
-            texts (List[str]): List of text chunks to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            batch_size (int, optional): Batch size of texts to use when creating
-                embeddings. Defaults to 10.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
-            input_type (str): Specifies the type of input passed to the model.
-                Required for embedding models v3 and higher.
-
-        Returns:
-            Union[List[List[float]], List[List[int]], List[bytes]]:
-            - If as_buffer=True: Returns a list of bytes objects
-            - If as_buffer=False:
-              - For dtype="float32": Returns a list of lists of floats
-              - For dtype="int8" or "uint8": Returns a list of lists of integers
-
-        Raises:
-            TypeError: In an invalid input_type is provided.
-
-        """
         input_type = kwargs.pop("input_type", None)
-
-        if not isinstance(texts, list):
-            raise TypeError("Must pass in a list of str values to embed.")
-        if len(texts) > 0 and not isinstance(texts[0], str):
-            raise TypeError("Must pass in a list of str values to embed.")
-        if not isinstance(input_type, str):
-            raise TypeError(
-                "Must pass in a str value for cohere embedding input_type.\
-                    See https://docs.cohere.com/reference/embed."
-            )
-
-        dtype = kwargs.pop("dtype", self.dtype)
+        self._validate_input_type(input_type)
 
         # Check if embedding_types was provided and warn user
         if "embedding_types" in kwargs:
@@ -296,31 +242,96 @@ class CohereTextVectorizer(BaseVectorizer):
             kwargs.pop("embedding_types")
 
         # Map dtype to appropriate embedding_type
-        embedding_types = self._get_cohere_embedding_type(dtype)
+        embedding_types = self._get_cohere_embedding_type(self.dtype)
 
-        embeddings: List = []
-        for batch in self.batchify(texts, batch_size, preprocess):
+        try:
             response = self._client.embed(
-                texts=batch,
+                texts=[text],
                 model=self.model,
                 input_type=input_type,
                 embedding_types=embedding_types,
                 **kwargs,
             )
 
-            # Extract the appropriate embeddings based on embedding_types
+            # Extract the appropriate embedding based on embedding_types
             embed_type = embedding_types[0]
             if hasattr(response.embeddings, embed_type):
-                batch_embeddings = getattr(response.embeddings, embed_type)
+                embedding = getattr(response.embeddings, embed_type)[0]
             else:
-                batch_embeddings = (
-                    response.embeddings
-                )  # Fallback for older API versions
+                embedding = response.embeddings[0]  # type: ignore
 
-            embeddings += [
-                self._process_embedding(embedding, as_buffer, dtype)
-                for embedding in batch_embeddings
-            ]
+            return embedding
+        except Exception as e:
+            raise ValueError(f"Embedding text failed: {e}")
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+    )
+    def _embed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[Union[float, int]]]:
+        """
+        Generate vector embeddings for a batch of texts using the Cohere API.
+
+        Args:
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the Cohere API,
+                      must include 'input_type'
+
+        Returns:
+            List[List[Union[float, int]]]: List of vector embeddings
+
+        Raises:
+            TypeError: If texts is not a list of strings or input_type is not provided
+            ValueError: If embedding fails
+        """
+        if not isinstance(texts, list):
+            raise TypeError("Must pass in a list of str values to embed.")
+        if texts and not isinstance(texts[0], str):
+            raise TypeError("Must pass in a list of str values to embed.")
+
+        input_type = kwargs.pop("input_type", None)
+        self._validate_input_type(input_type)
+
+        # Check if embedding_types was provided and warn user
+        if "embedding_types" in kwargs:
+            warnings.warn(
+                "The 'embedding_types' parameter is not supported in CohereTextVectorizer. "
+                "Please use the 'dtype' parameter instead. Your 'embedding_types' value will be ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+            kwargs.pop("embedding_types")
+
+        # Map dtype to appropriate embedding_type
+        embedding_types = self._get_cohere_embedding_type(self.dtype)
+
+        embeddings: List = []
+        for batch in self.batchify(texts, batch_size):
+            try:
+                response = self._client.embed(
+                    texts=batch,
+                    model=self.model,
+                    input_type=input_type,
+                    embedding_types=embedding_types,
+                    **kwargs,
+                )
+
+                # Extract the appropriate embeddings based on embedding_types
+                embed_type = embedding_types[0]
+                if hasattr(response.embeddings, embed_type):
+                    batch_embeddings = getattr(response.embeddings, embed_type)
+                else:
+                    # Fallback for older API versions
+                    batch_embeddings = response.embeddings
+
+                embeddings.extend(batch_embeddings)
+            except Exception as e:
+                raise ValueError(f"Embedding texts failed: {e}")
+
         return embeddings
 
     @property

--- a/redisvl/utils/vectorize/text/huggingface.py
+++ b/redisvl/utils/vectorize/text/huggingface.py
@@ -1,34 +1,59 @@
-from typing import Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
 from pydantic.v1 import PrivateAttr
+
+if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
 
 from redisvl.utils.utils import deprecated_argument
 from redisvl.utils.vectorize.base import BaseVectorizer
 
 
 class HFTextVectorizer(BaseVectorizer):
-    """The HFTextVectorizer class is designed to leverage the power of Hugging
-    Face's Sentence Transformers for generating text embeddings. This vectorizer
-    is particularly useful in scenarios where advanced natural language
+    """The HFTextVectorizer class leverages Hugging Face's Sentence Transformers
+    for generating vector embeddings from text input.
+
+    This vectorizer is particularly useful in scenarios where advanced natural language
     processing and understanding are required, and ideal for running on your own
-    hardware (for free).
+    hardware without usage fees.
+
+    You can optionally enable caching to improve performance when generating
+    embeddings for repeated text inputs.
 
     Utilizing this vectorizer involves specifying a pre-trained model from
     Hugging Face's vast collection of Sentence Transformers. These models are
     trained on a variety of datasets and tasks, ensuring versatility and
-    robust performance across different text embedding needs. Additionally,
-    make sure the `sentence-transformers` library is installed with
-    `pip install sentence-transformers==2.2.2`.
+    robust performance across different embedding needs.
+
+    Requirements:
+        - The `sentence-transformers` library must be installed with pip.
 
     .. code-block:: python
 
-        # Embedding a single text
+        # Basic usage
         vectorizer = HFTextVectorizer(model="sentence-transformers/all-mpnet-base-v2")
         embedding = vectorizer.embed("Hello, world!")
 
-        # Embedding a batch of texts
-        embeddings = vectorizer.embed_many(["Hello, world!", "How are you?"], batch_size=2)
+        # With caching enabled
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+        cache = EmbeddingsCache(name="my_embeddings_cache")
 
+        vectorizer = HFTextVectorizer(
+            model="sentence-transformers/all-mpnet-base-v2",
+            cache=cache
+        )
+
+        # First call will compute and cache the embedding
+        embedding1 = vectorizer.embed("Hello, world!")
+
+        # Second call will retrieve from cache
+        embedding2 = vectorizer.embed("Hello, world!")
+
+        # Batch processing
+        embeddings = vectorizer.embed_many(
+            ["Hello, world!", "How are you?"],
+            batch_size=2
+        )
     """
 
     _client: Any = PrivateAttr()
@@ -37,6 +62,7 @@ class HFTextVectorizer(BaseVectorizer):
         self,
         model: str = "sentence-transformers/all-mpnet-base-v2",
         dtype: str = "float32",
+        cache: Optional["EmbeddingsCache"] = None,
         **kwargs,
     ):
         """Initialize the Hugging Face text vectorizer.
@@ -48,13 +74,17 @@ class HFTextVectorizer(BaseVectorizer):
             dtype (str): the default datatype to use when embedding text as byte arrays.
                 Used when setting `as_buffer=True` in calls to embed() and embed_many().
                 Defaults to 'float32'.
+            cache (Optional[EmbeddingsCache]): Optional EmbeddingsCache instance to cache embeddings for
+                better performance with repeated texts. Defaults to None.
+            **kwargs: Additional parameters to pass to the SentenceTransformer
+                constructor.
 
         Raises:
             ImportError: If the sentence-transformers library is not installed.
             ValueError: If there is an error setting the embedding model dimensions.
             ValueError: If an invalid dtype is provided.
         """
-        super().__init__(model=model, dtype=dtype)
+        super().__init__(model=model, dtype=dtype, cache=cache)
         # Init client
         self._initialize_client(model, **kwargs)
         # Set model dimensions after init
@@ -74,7 +104,7 @@ class HFTextVectorizer(BaseVectorizer):
 
     def _set_model_dims(self):
         try:
-            embedding = self.embed("dimension check")
+            embedding = self._embed("dimension check")
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Empty response from the embedding model: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except
@@ -82,86 +112,88 @@ class HFTextVectorizer(BaseVectorizer):
             raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
         return len(embedding)
 
-    @deprecated_argument("dtype")
-    def embed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[float], bytes]:
-        """Embed a chunk of text using the Hugging Face sentence transformer.
+    def _embed(self, text: str, **kwargs) -> List[float]:
+        """Generate a vector embedding for a single text using the Hugging Face model.
 
         Args:
-            text (str): Chunk of text to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing
-                callable to perform before vectorization. Defaults to None.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            text: Text to embed
+            **kwargs: Additional model-specific parameters
 
         Returns:
-            Union[List[float], bytes]: Embedding as a list of floats, or as a bytes
-            object if as_buffer=True
+            List[float]: Vector embedding as a list of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the text.
+            TypeError: If the input is not a string
         """
         if not isinstance(text, str):
             raise TypeError("Must pass in a str value to embed.")
 
-        if preprocess:
-            text = preprocess(text)
-
-        dtype = kwargs.pop("dtype", self.dtype)
-
         embedding = self._client.encode([text], **kwargs)[0]
-        return self._process_embedding(embedding.tolist(), as_buffer, dtype)
+        return embedding.tolist()
 
-    @deprecated_argument("dtype")
-    def embed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[List[float]], List[bytes]]:
-        """Asynchronously embed many chunks of texts using the Hugging Face
-        sentence transformer.
+    def _embed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """Generate vector embeddings for a batch of texts using the Hugging Face model.
 
         Args:
-            texts (List[str]): List of text chunks to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing
-                callable to perform before vectorization. Defaults to None.
-            batch_size (int, optional): Batch size of texts to use when creating
-                embeddings. Defaults to 10.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each batch
+            **kwargs: Additional model-specific parameters
 
         Returns:
-            Union[List[List[float]], List[bytes]]: List of embeddings as lists of floats,
-            or as bytes objects if as_buffer=True
+            List[List[float]]: List of vector embeddings as lists of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If the input is not a list of strings
         """
         if not isinstance(texts, list):
             raise TypeError("Must pass in a list of str values to embed.")
         if len(texts) > 0 and not isinstance(texts[0], str):
             raise TypeError("Must pass in a list of str values to embed.")
 
-        dtype = kwargs.pop("dtype", self.dtype)
-
         embeddings: List = []
-        for batch in self.batchify(texts, batch_size, preprocess):
+        for batch in self.batchify(texts, batch_size, None):
             batch_embeddings = self._client.encode(batch, **kwargs)
-            embeddings.extend(
-                [
-                    self._process_embedding(embedding.tolist(), as_buffer, dtype)
-                    for embedding in batch_embeddings
-                ]
-            )
+            embeddings.extend([embedding.tolist() for embedding in batch_embeddings])
         return embeddings
+
+    async def _aembed(self, text: str, **kwargs) -> List[float]:
+        """Asynchronously generate a vector embedding for a single text.
+
+        Note: This implementation falls back to the synchronous version as
+        sentence-transformers does not have native async support.
+
+        Args:
+            text: Text to embed
+            **kwargs: Additional model-specific parameters
+
+        Returns:
+            List[float]: Vector embedding as a list of floats
+        """
+        # HuggingFace Sentence Transformers doesn't have async support,
+        # so we just call the synchronous version
+        return self._embed(text, **kwargs)
+
+    async def _aembed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """Asynchronously generate vector embeddings for a batch of texts.
+
+        Note: This implementation falls back to the synchronous version as
+        sentence-transformers does not have native async support.
+
+        Args:
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each batch
+            **kwargs: Additional model-specific parameters
+
+        Returns:
+            List[List[float]]: List of vector embeddings as lists of floats
+        """
+        # HuggingFace Sentence Transformers doesn't have async support,
+        # so we just call the synchronous version
+        return self._embed_many(texts, batch_size, **kwargs)
 
     @property
     def type(self) -> str:

--- a/redisvl/utils/vectorize/text/huggingface.py
+++ b/redisvl/utils/vectorize/text/huggingface.py
@@ -158,43 +158,6 @@ class HFTextVectorizer(BaseVectorizer):
             embeddings.extend([embedding.tolist() for embedding in batch_embeddings])
         return embeddings
 
-    async def _aembed(self, text: str, **kwargs) -> List[float]:
-        """Asynchronously generate a vector embedding for a single text.
-
-        Note: This implementation falls back to the synchronous version as
-        sentence-transformers does not have native async support.
-
-        Args:
-            text: Text to embed
-            **kwargs: Additional model-specific parameters
-
-        Returns:
-            List[float]: Vector embedding as a list of floats
-        """
-        # HuggingFace Sentence Transformers doesn't have async support,
-        # so we just call the synchronous version
-        return self._embed(text, **kwargs)
-
-    async def _aembed_many(
-        self, texts: List[str], batch_size: int = 10, **kwargs
-    ) -> List[List[float]]:
-        """Asynchronously generate vector embeddings for a batch of texts.
-
-        Note: This implementation falls back to the synchronous version as
-        sentence-transformers does not have native async support.
-
-        Args:
-            texts: List of texts to embed
-            batch_size: Number of texts to process in each batch
-            **kwargs: Additional model-specific parameters
-
-        Returns:
-            List[List[float]]: List of vector embeddings as lists of floats
-        """
-        # HuggingFace Sentence Transformers doesn't have async support,
-        # so we just call the synchronous version
-        return self._embed_many(texts, batch_size, **kwargs)
-
     @property
     def type(self) -> str:
         return "hf"

--- a/redisvl/utils/vectorize/text/mistral.py
+++ b/redisvl/utils/vectorize/text/mistral.py
@@ -1,9 +1,12 @@
 import os
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from pydantic import PrivateAttr
+from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tenacity.retry import retry_if_not_exception_type
+
+if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
 
 from redisvl.utils.utils import deprecated_argument
 from redisvl.utils.vectorize.base import BaseVectorizer
@@ -27,14 +30,33 @@ class MistralAITextVectorizer(BaseVectorizer):
     allowing for batch processing of texts and flexibility in handling
     preprocessing tasks.
 
+    You can optionally enable caching to improve performance when generating
+    embeddings for repeated text inputs.
+
     .. code-block:: python
 
-        # Synchronous embedding of a single text
+        # Basic usage
         vectorizer = MistralAITextVectorizer(
-            model="mistral-embed"
+            model="mistral-embed",
             api_config={"api_key": "your_api_key"} # OR set MISTRAL_API_KEY in your env
         )
         embedding = vectorizer.embed("Hello, world!")
+
+        # With caching enabled
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+        cache = EmbeddingsCache(name="mistral_embeddings_cache")
+
+        vectorizer = MistralAITextVectorizer(
+            model="mistral-embed",
+            api_config={"api_key": "your_api_key"},
+            cache=cache
+        )
+
+        # First call will compute and cache the embedding
+        embedding1 = vectorizer.embed("Hello, world!")
+
+        # Second call will retrieve from cache
+        embedding2 = vectorizer.embed("Hello, world!")
 
         # Asynchronous batch embedding of multiple texts
         embeddings = await vectorizer.aembed_many(
@@ -44,41 +66,57 @@ class MistralAITextVectorizer(BaseVectorizer):
 
     """
 
-    _client: Any = PrivateAttr()
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(
         self,
         model: str = "mistral-embed",
         api_config: Optional[Dict] = None,
         dtype: str = "float32",
+        cache: Optional["EmbeddingsCache"] = None,
         **kwargs,
     ):
         """Initialize the MistralAI vectorizer.
 
         Args:
             model (str): Model to use for embedding. Defaults to
-                'text-embedding-ada-002'.
+                'mistral-embed'.
             api_config (Optional[Dict], optional): Dictionary containing the
                 API key. Defaults to None.
             dtype (str): the default datatype to use when embedding text as byte arrays.
                 Used when setting `as_buffer=True` in calls to embed() and embed_many().
                 Defaults to 'float32'.
+            cache (Optional[EmbeddingsCache]): Optional EmbeddingsCache instance to cache embeddings for
+                better performance with repeated texts. Defaults to None.
 
         Raises:
             ImportError: If the mistralai library is not installed.
             ValueError: If the Mistral API key is not provided.
             ValueError: If an invalid dtype is provided.
         """
-        super().__init__(model=model, dtype=dtype)
-        # Init client
+        super().__init__(model=model, dtype=dtype, cache=cache)
+        # Initialize client and set up the model
+        self._setup(api_config, **kwargs)
+
+    def _setup(self, api_config: Optional[Dict], **kwargs):
+        """Set up the MistralAI client and determine the embedding dimensions."""
+        # Initialize client
         self._initialize_client(api_config, **kwargs)
-        # Set model dimensions after init
+        # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
     def _initialize_client(self, api_config: Optional[Dict], **kwargs):
         """
-        Setup the Mistral clients using the provided API key or an
+        Setup the Mistral client using the provided API key or an
         environment variable.
+
+        Args:
+            api_config: Dictionary with API configuration options
+            **kwargs: Additional arguments to pass to MistralAI client
+
+        Raises:
+            ImportError: If the mistralai library is not installed
+            ValueError: If no API key is provided
         """
         if api_config is None:
             api_config = {}
@@ -88,8 +126,8 @@ class MistralAITextVectorizer(BaseVectorizer):
             from mistralai import Mistral
         except ImportError:
             raise ImportError(
-                "MistralAI vectorizer requires the mistralai library. \
-                    Please install with `pip install mistralai`"
+                "MistralAI vectorizer requires the mistralai library. "
+                "Please install with `pip install mistralai`"
             )
 
         # Fetch the API key from api_config or environment variable
@@ -99,203 +137,171 @@ class MistralAITextVectorizer(BaseVectorizer):
         if not api_key:
             raise ValueError(
                 "MISTRAL API key is required. "
-                "Provide it in api_config or set the MISTRAL_API_KEY\
-                    environment variable."
+                "Provide it in api_config or set the MISTRAL_API_KEY environment variable."
             )
 
+        # Store client as a regular attribute instead of PrivateAttr
         self._client = Mistral(api_key=api_key, **kwargs)
 
     def _set_model_dims(self) -> int:
+        """
+        Determine the dimensionality of the embedding model by making a test call.
+
+        Returns:
+            int: Dimensionality of the embedding model
+
+        Raises:
+            ValueError: If embedding dimensions cannot be determined
+        """
         try:
-            embedding = self.embed("dimension check")
+            # Call the protected _embed method to avoid caching this test embedding
+            embedding = self._embed("dimension check")
+            return len(embedding)
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Unexpected response from the MISTRAL API: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except
             # fall back (TODO get more specific)
             raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
-        return len(embedding)
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    @deprecated_argument("dtype")
-    def embed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[List[float]], List[bytes]]:
-        """Embed many chunks of texts using the Mistral API.
-
-        Args:
-            texts (List[str]): List of text chunks to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing
-                callable to perform before vectorization. Defaults to None.
-            batch_size (int, optional): Batch size of texts to use when creating
-                embeddings. Defaults to 10.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
-
-        Returns:
-            Union[List[List[float]], List[bytes]]: List of embeddings as lists of floats,
-            or as bytes objects if as_buffer=True
-
-        Raises:
-            TypeError: If the wrong input type is passed in for the test.
+    def _embed(self, text: str, **kwargs) -> List[float]:
         """
-        if not isinstance(texts, list):
-            raise TypeError("Must pass in a list of str values to embed.")
-        if len(texts) > 0 and not isinstance(texts[0], str):
-            raise TypeError("Must pass in a list of str values to embed.")
-
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        embeddings: List = []
-        for batch in self.batchify(texts, batch_size, preprocess):
-            response = self._client.embeddings.create(
-                model=self.model, inputs=batch, **kwargs
-            )
-            embeddings += [
-                self._process_embedding(r.embedding, as_buffer, dtype)
-                for r in response.data
-            ]
-        return embeddings
-
-    @retry(
-        wait=wait_random_exponential(min=1, max=60),
-        stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type(TypeError),
-    )
-    @deprecated_argument("dtype")
-    def embed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> Union[List[float], bytes]:
-        """Embed a chunk of text using the Mistral API.
+        Generate a vector embedding for a single text using the MistralAI API.
 
         Args:
-            text (str): Chunk of text to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            text: Text to embed
+            **kwargs: Additional parameters to pass to the MistralAI API
 
         Returns:
-            Union[List[float], bytes]: Embedding as a list of floats, or as a bytes
-            object if as_buffer=True
+            List[float]: Vector embedding as a list of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If text is not a string
+            ValueError: If embedding fails
         """
         if not isinstance(text, str):
             raise TypeError("Must pass in a str value to embed.")
 
-        if preprocess:
-            text = preprocess(text)
-
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        result = self._client.embeddings.create(
-            model=self.model, inputs=[text], **kwargs
-        )
-        return self._process_embedding(result.data[0].embedding, as_buffer, dtype)
+        try:
+            result = self._client.embeddings.create(
+                model=self.model, inputs=[text], **kwargs
+            )
+            return result.data[0].embedding  # type: ignore
+        except Exception as e:
+            raise ValueError(f"Embedding text failed: {e}")
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    @deprecated_argument("dtype")
-    async def aembed_many(
-        self,
-        texts: List[str],
-        preprocess: Optional[Callable] = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        **kwargs,
+    def _embed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
     ) -> List[List[float]]:
-        """Asynchronously embed many chunks of texts using the Mistral API.
+        """
+        Generate vector embeddings for a batch of texts using the MistralAI API.
 
         Args:
-            texts (List[str]): List of text chunks to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            batch_size (int, optional): Batch size of texts to use when creating
-                embeddings. Defaults to 10.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the MistralAI API
 
         Returns:
-            List[List[float]]: List of embeddings.
+            List[List[float]]: List of vector embeddings as lists of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If texts is not a list of strings
+            ValueError: If embedding fails
         """
         if not isinstance(texts, list):
             raise TypeError("Must pass in a list of str values to embed.")
-        if len(texts) > 0 and not isinstance(texts[0], str):
+        if texts and not isinstance(texts[0], str):
             raise TypeError("Must pass in a list of str values to embed.")
 
-        dtype = kwargs.pop("dtype", self.dtype)
-
-        embeddings: List = []
-        for batch in self.batchify(texts, batch_size, preprocess):
-            response = await self._client.embeddings.create_async(
-                model=self.model, inputs=batch, **kwargs
-            )
-            embeddings += [
-                self._process_embedding(r.embedding, as_buffer, dtype)
-                for r in response.data
-            ]
-        return embeddings
+        try:
+            embeddings: List = []
+            for batch in self.batchify(texts, batch_size):
+                response = self._client.embeddings.create(
+                    model=self.model, inputs=batch, **kwargs
+                )
+                embeddings.extend([r.embedding for r in response.data])
+            return embeddings
+        except Exception as e:
+            raise ValueError(f"Embedding texts failed: {e}")
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    @deprecated_argument("dtype")
-    async def aembed(
-        self,
-        text: str,
-        preprocess: Optional[Callable] = None,
-        as_buffer: bool = False,
-        **kwargs,
-    ) -> List[float]:
-        """Asynchronously embed a chunk of text using the MistralAPI.
+    async def _aembed(self, text: str, **kwargs) -> List[float]:
+        """
+        Asynchronously generate a vector embedding for a single text using the MistralAI API.
 
         Args:
-            text (str): Chunk of text to embed.
-            preprocess (Optional[Callable], optional): Optional preprocessing callable to
-                perform before vectorization. Defaults to None.
-            as_buffer (bool, optional): Whether to convert the raw embedding
-                to a byte string. Defaults to False.
+            text: Text to embed
+            **kwargs: Additional parameters to pass to the MistralAI API
 
         Returns:
-            List[float]: Embedding.
+            List[float]: Vector embedding as a list of floats
 
         Raises:
-            TypeError: If the wrong input type is passed in for the test.
+            TypeError: If text is not a string
+            ValueError: If embedding fails
         """
         if not isinstance(text, str):
             raise TypeError("Must pass in a str value to embed.")
 
-        if preprocess:
-            text = preprocess(text)
+        try:
+            result = await self._client.embeddings.create_async(
+                model=self.model, inputs=[text], **kwargs
+            )
+            return result.data[0].embedding  # type: ignore
+        except Exception as e:
+            raise ValueError(f"Embedding text failed: {e}")
 
-        dtype = kwargs.pop("dtype", self.dtype)
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+    )
+    async def _aembed_many(
+        self, texts: List[str], batch_size: int = 10, **kwargs
+    ) -> List[List[float]]:
+        """
+        Asynchronously generate vector embeddings for a batch of texts using the MistralAI API.
 
-        result = await self._client.embeddings.create_async(
-            model=self.model, inputs=[text], **kwargs
-        )
-        return self._process_embedding(result.data[0].embedding, as_buffer, dtype)
+        Args:
+            texts: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the MistralAI API
+
+        Returns:
+            List[List[float]]: List of vector embeddings as lists of floats
+
+        Raises:
+            TypeError: If texts is not a list of strings
+            ValueError: If embedding fails
+        """
+        if not isinstance(texts, list):
+            raise TypeError("Must pass in a list of str values to embed.")
+        if texts and not isinstance(texts[0], str):
+            raise TypeError("Must pass in a list of str values to embed.")
+
+        try:
+            embeddings: List = []
+            for batch in self.batchify(texts, batch_size):
+                response = await self._client.embeddings.create_async(
+                    model=self.model, inputs=batch, **kwargs
+                )
+                embeddings.extend([r.embedding for r in response.data])
+            return embeddings
+        except Exception as e:
+            raise ValueError(f"Embedding texts failed: {e}")
 
     @property
     def type(self) -> str:

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from redis.exceptions import ConnectionError
 
 from redisvl.exceptions import RedisModuleVersionError
-from redisvl.extensions.cache import SemanticCache
+from redisvl.extensions.cache.llm import SemanticCache
 from redisvl.index.index import AsyncSearchIndex, SearchIndex
 from redisvl.query.filter import Num, Tag, Text
 from redisvl.utils.vectorize import HFTextVectorizer

--- a/tests/integration/test_vectorizers.py
+++ b/tests/integration/test_vectorizers.py
@@ -41,11 +41,11 @@ def embeddings_cache(client):
     params=[
         HFTextVectorizer,
         OpenAITextVectorizer,
-        # VertexAITextVectorizer,
+        VertexAITextVectorizer,
         CohereTextVectorizer,
-        # AzureOpenAITextVectorizer,
-        # BedrockTextVectorizer,
-        # MistralAITextVectorizer,
+        AzureOpenAITextVectorizer,
+        BedrockTextVectorizer,
+        MistralAITextVectorizer,
         CustomTextVectorizer,
         VoyageAITextVectorizer,
     ]
@@ -418,14 +418,14 @@ def test_custom_vectorizer_embed_many(custom_embed_class, custom_embed_func):
 @pytest.mark.parametrize(
     "vectorizer_",
     [
-        # AzureOpenAITextVectorizer,
-        # BedrockTextVectorizer,
+        AzureOpenAITextVectorizer,
+        BedrockTextVectorizer,
         CohereTextVectorizer,
         CustomTextVectorizer,
         HFTextVectorizer,
-        # MistralAITextVectorizer,
+        MistralAITextVectorizer,
         OpenAITextVectorizer,
-        # VertexAITextVectorizer,
+        VertexAITextVectorizer,
         VoyageAITextVectorizer,
     ],
 )
@@ -447,14 +447,14 @@ def test_default_dtype(vectorizer_):
 @pytest.mark.parametrize(
     "vectorizer_",
     [
-        # AzureOpenAITextVectorizer,
-        # BedrockTextVectorizer,
+        AzureOpenAITextVectorizer,
+        BedrockTextVectorizer,
         CohereTextVectorizer,
         CustomTextVectorizer,
         HFTextVectorizer,
-        # MistralAITextVectorizer,
+        MistralAITextVectorizer,
         OpenAITextVectorizer,
-        # VertexAITextVectorizer,
+        VertexAITextVectorizer,
         VoyageAITextVectorizer,
     ],
 )
@@ -480,13 +480,13 @@ def test_vectorizer_dtype_assignment(vectorizer_):
 @pytest.mark.parametrize(
     "vectorizer_",
     [
-        # AzureOpenAITextVectorizer,
-        # BedrockTextVectorizer,
+        AzureOpenAITextVectorizer,
+        BedrockTextVectorizer,
         CohereTextVectorizer,
         HFTextVectorizer,
-        # MistralAITextVectorizer,
+        MistralAITextVectorizer,
         OpenAITextVectorizer,
-        # VertexAITextVectorizer,
+        VertexAITextVectorizer,
         VoyageAITextVectorizer,
     ],
 )


### PR DESCRIPTION
Adds support to the `BaseVectorizer` class to have an optional `EmbeddingsCache` attached.

- Refactored the subclass vectorizers to implement private embed methods and then let the base class handle the cache wrapper logic.
- Fixed some circular imports.
- Fixed async client handling in the cache subclasses (caught during testing).
- Handle some typing checks and pydantic stuff related to private attrs and custom attrs.

TODO in a separate PR:
- Add embeddings caching to our testing suite (CI/CD speed up??)
- Add embeddings caching to our SemanticRouter