### PR TITLE
Fix various commands to work with Redis Cluster

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,27 +36,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Define which tools Claude can use
-          allowed_tools: |
-            Bash(git status)
-            Bash(git log)
-            Bash(git show)
-            Bash(git blame)
-            Bash(git reflog)
-            Bash(git stash list)
-            Bash(git ls-files)
-            Bash(git branch)
-            Bash(git tag)
-            Bash(git diff)
-            Bash(make:*)
-            Bash(pytest:*)
-            Bash(cd:*)
-            Bash(ls:*)
-            Bash(make)
-            Bash(make:*)
-            View
-            GlobTool
-            GrepTool
-            BatchTool
-
-          # Your Anthropic API key (stored as a GitHub secret)
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash(git status),Bash(git log),Bash(git show),Bash(git blame),Bash(git reflog),Bash(git stash list),Bash(git ls-files),Bash(git branch),Bash(git tag),Bash(git diff),Bash(make:*),Bash(pytest:*),Bash(cd:*),Bash(ls:*),Bash(make),Bash(make:*),View,GlobTool,GrepTool,BatchTool"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         python-version: ["3.9", "3.10", 3.12, 3.13] 
         connection: ["hiredis", "plain"]
         redis-py-version: ["5.x", "6.x"]
-        redis-version: ["6.2.6-v9", "latest", "8.0-M03"]
+        redis-version: ["6.2.6-v9", "latest", "8.0.1"]
 
     steps:
       - name: Check out repository
@@ -132,7 +132,7 @@ jobs:
 
       - name: Set Redis image name
         run: |
-          if [[ "${{ matrix.redis-version }}" == "8.0-M03" ]]; then
+          if [[ "${{ matrix.redis-version }}" == "8.0.1" ]]; then
             echo "REDIS_IMAGE=redis:${{ matrix.redis-version }}" >> $GITHUB_ENV
           else
             echo "REDIS_IMAGE=redis/redis-stack-server:${{ matrix.redis-version }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           make test-all
 
   test:
-    name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} [redis ${{ matrix.redis-version }}]
+    name: Python ${{ matrix.python-version }} - ${{ matrix.connection }} - redis-py ${{ matrix.redis-py-version }} [redis ${{ matrix.redis-version }}]
     runs-on: ubuntu-latest
     needs: service-tests
     env:
@@ -89,6 +89,7 @@ jobs:
         # 3.11 tests are run in the service-tests job
         python-version: ["3.9", "3.10", 3.12, 3.13] 
         connection: ["hiredis", "plain"]
+        redis-py-version: ["5.x", "6.x"]
         redis-version: ["6.2.6-v9", "latest", "8.0-M03"]
 
     steps:
@@ -116,6 +117,14 @@ jobs:
         run: |
           poetry install --all-extras
 
+      - name: Install specific redis-py version
+        run: |
+          if [[ "${{ matrix.redis-py-version }}" == "5.x" ]]; then
+            poetry add "redis>=5.0.0,<6.0.0"
+          else
+            poetry add "redis>=6.0.0,<7.0.0"
+          fi
+
       - name: Install hiredis if needed
         if: matrix.connection == 'hiredis'
         run: |
@@ -135,7 +144,7 @@ jobs:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
       - name: Run tests
-        if: matrix.connection == 'plain' && matrix.redis-version == 'latest'
+        if: matrix.connection == 'plain' && matrix.redis-py-version == '6.x' && matrix.redis-version == 'latest'
         env:
           HF_HOME: ${{ github.workspace }}/hf_cache
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
@@ -144,12 +153,12 @@ jobs:
           make test
 
       - name: Run tests (alternate)
-        if: matrix.connection != 'plain' || matrix.redis-version != 'latest'
+        if: matrix.connection != 'plain' || matrix.redis-py-version != '6.x' || matrix.redis-version != 'latest'
         run: |
           make test
 
       - name: Run notebooks
-        if: matrix.connection == 'plain' && matrix.redis-version == 'latest'
+        if: matrix.connection == 'plain' && matrix.redis-py-version == '6.x' && matrix.redis-version == 'latest'
         env:
           HF_HOME: ${{ github.workspace }}/hf_cache
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,4 @@ libs/redis/docs/.Trash*
 .idea/*
 .vscode/settings.json
 .python-version
+tests/data

--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,9 @@ pyrightconfig.json
 [Ll]ocal
 pyvenv.cfg
 pip-selfcheck.json
+env
+venv
+.venv
 
 libs/redis/docs/.Trash*
 .python-version
@@ -223,3 +226,7 @@ libs/redis/docs/.Trash*
 .vscode/settings.json
 .python-version
 tests/data
+.git
+.cursor
+.junie
+.undodir

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ make docs-build       # Build documentation
 make docs-serve       # Serve docs locally
 ```
 
+Pre-commit hooks are also configured, which you should
+run before you commit:
+```bash
+uv run pre-commit run --all-files
+```
+
 ## Important Architectural Patterns
 
 ### Async/Sync Dual Interfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md - RedisVL Project Context
+
+## Frequently Used Commands
+
+```bash
+# Development workflow
+make install          # Install dependencies
+make format           # Format code (black + isort)
+make check-types      # Run mypy type checking
+make lint             # Run all linting (format + types)
+make test             # Run tests (no external APIs)
+make test-all         # Run all tests (includes API tests)
+make check            # Full check (lint + test)
+
+# Redis setup
+make redis-start      # Start Redis Stack container
+make redis-stop       # Stop Redis Stack container
+
+# Documentation
+make docs-build       # Build documentation
+make docs-serve       # Serve docs locally
+```
+
+## Important Architectural Patterns
+
+### Async/Sync Dual Interfaces
+- Most core classes have both sync and async versions (e.g., `SearchIndex` / `AsyncSearchIndex`)
+- Follow existing patterns when adding new functionality
+
+### Schema-Driven Design
+```python
+# Index schemas define structure
+schema = IndexSchema.from_yaml("schema.yaml")
+index = SearchIndex(schema, redis_url="redis://localhost:6379")
+```
+
+## Critical Rules
+
+### Do Not Modify
+- **CRITICAL**: Do not change this line unless explicitly asked:
+  ```python
+  token.strip().strip(",").replace(""", "").replace(""", "").lower()
+  ```
+
+### README.md Maintenance
+**IMPORTANT**: DO NOT modify README.md unless explicitly requested.
+
+**If you need to document something, use these alternatives:**
+- Development info → CONTRIBUTING.md
+- API details → docs/ directory
+- Examples → docs/examples/
+- Project memory (explicit preferences, directives, etc.) → CLAUDE.md
+
+## Testing Notes
+RedisVL uses `pytest` with `testcontainers` for testing.
+
+- `make test` - unit tests only (no external APIs)
+- `make test-all` - includes integration tests requiring API keys
+
+## Project Structure
+
+```
+redisvl/
+├── cli/              # Command-line interface (rvl command)
+├── extensions/       # AI extensions (cache, memory, routing)
+│   ├── cache/        # Semantic caching for LLMs
+│   ├── llmcache/     # LLM-specific caching
+│   ├── message_history/  # Chat history management
+│   ├── router/       # Semantic routing
+│   └── session_manager/  # Session management
+├── index/            # SearchIndex classes (sync/async)
+├── query/            # Query builders (Vector, Range, Filter, Count)
+├── redis/            # Redis client utilities
+├── schema/           # Index schema definitions
+└── utils/            # Utilities (vectorizers, rerankers, optimization)
+    ├── optimize/     # Threshold optimization
+    ├── rerank/       # Result reranking
+    └── vectorize/    # Embedding providers integration
+```
+
+## Core Components
+
+### 1. Index Management
+- `SearchIndex` / `AsyncSearchIndex` - Main interface for Redis vector indices
+- `IndexSchema` - Define index structure with fields (text, tags, vectors, etc.)
+- Support for JSON and Hash storage types
+
+### 2. Query System
+- `VectorQuery` - Semantic similarity search
+- `RangeQuery` - Vector search within distance range
+- `FilterQuery` - Metadata filtering and full-text search
+- `CountQuery` - Count matching records
+- Etc.
+
+### 3. AI Extensions
+- `SemanticCache` - LLM response caching with semantic similarity
+- `EmbeddingsCache` - Cache for vector embeddings
+- `MessageHistory` - Chat history with recency/relevancy retrieval
+- `SemanticRouter` - Route queries to topics/intents
+
+### 4. Vectorizers (Optional Dependencies)
+- OpenAI, Azure OpenAI, Cohere, HuggingFace, Mistral, VoyageAI
+- Custom vectorizer support
+- Batch processing capabilities
+
+## Documentation
+- Main docs: https://docs.redisvl.com
+- Built with Sphinx from `docs/` directory
+- Includes API reference and user guides
+- Example notebooks in documentation `docs/user_guide/...`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ make docs-serve       # Serve docs locally
 Pre-commit hooks are also configured, which you should
 run before you commit:
 ```bash
-uv run pre-commit run --all-files
+pre-commit run --all-files
 ```
 
 ## Important Architectural Patterns

--- a/poetry.lock
+++ b/poetry.lock
@@ -7655,4 +7655,4 @@ voyageai = ["voyageai"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "0f2d5eb340a201832661cda4b1ed42caf506b0ca2066ccfcc9ed319e28653dec"
+content-hash = "8ea19be9a1ad40e1ad2bdabb367bf49832fb0319f8c463ae433230956d94f723"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5615,14 +5615,14 @@ tqdm = "*"
 
 [[package]]
 name = "redis"
-version = "5.2.1"
+version = "6.1.0"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4"},
-    {file = "redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f"},
+    {file = "redis-6.1.0-py3-none-any.whl", hash = "sha256:3b72622f3d3a89df2a6041e82acd896b0e67d9f54e9bcd906d091d23ba5219f6"},
+    {file = "redis-6.1.0.tar.gz", hash = "sha256:c928e267ad69d3069af28a9823a07726edf72c7e37764f43dc0123f37928c075"},
 ]
 
 [package.dependencies]
@@ -5630,7 +5630,8 @@ async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\
 
 [package.extras]
 hiredis = ["hiredis (>=3.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
+jwt = ["pyjwt (>=2.9.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "referencing"
@@ -6206,14 +6207,14 @@ train = ["accelerate (>=0.20.3)", "datasets"]
 name = "setuptools"
 version = "75.8.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"sentence-transformers\" and python_version >= \"3.12\""
+groups = ["main", "dev"]
 files = [
     {file = "setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"},
     {file = "setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2"},
 ]
+markers = {main = "extra == \"sentence-transformers\" and python_version >= \"3.12\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
@@ -7106,14 +7107,14 @@ tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
 name = "types-cffi"
-version = "1.16.0.20241221"
+version = "1.17.0.20250326"
 description = "Typing stubs for cffi"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "types_cffi-1.16.0.20241221-py3-none-any.whl", hash = "sha256:e5b76b4211d7a9185f6ab8d06a106d56c7eb80af7cdb8bfcb4186ade10fb112f"},
-    {file = "types_cffi-1.16.0.20241221.tar.gz", hash = "sha256:1c96649618f4b6145f58231acb976e0b448be6b847f7ab733dabe62dfbff6591"},
+    {file = "types_cffi-1.17.0.20250326-py3-none-any.whl", hash = "sha256:5af4ecd7374ae0d5fa9e80864e8d4b31088cc32c51c544e3af7ed5b5ed681447"},
+    {file = "types_cffi-1.17.0.20250326.tar.gz", hash = "sha256:6c8fea2c2f34b55e5fb77b1184c8ad849d57cf0ddccbc67a62121ac4b8b32254"},
 ]
 
 [package.dependencies]
@@ -7146,22 +7147,6 @@ files = [
     {file = "types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"},
     {file = "types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c"},
 ]
-
-[[package]]
-name = "types-redis"
-version = "4.6.0.20241004"
-description = "Typing stubs for redis"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "types-redis-4.6.0.20241004.tar.gz", hash = "sha256:5f17d2b3f9091ab75384153bfa276619ffa1cf6a38da60e10d5e6749cc5b902e"},
-    {file = "types_redis-4.6.0.20241004-py3-none-any.whl", hash = "sha256:ef5da68cb827e5f606c8f9c0b49eeee4c2669d6d97122f301d3a55dc6a63f6ed"},
-]
-
-[package.dependencies]
-cryptography = ">=35.0.0"
-types-pyOpenSSL = "*"
 
 [[package]]
 name = "types-requests"
@@ -7197,15 +7182,18 @@ urllib3 = ">=2"
 
 [[package]]
 name = "types-setuptools"
-version = "75.8.0.20250225"
+version = "80.3.0.20250505"
 description = "Typing stubs for setuptools"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "types_setuptools-75.8.0.20250225-py3-none-any.whl", hash = "sha256:94c86b439cc60bcc68c1cda3fd2c301f007f8f9502f4fbb54c66cb5ce9b875af"},
-    {file = "types_setuptools-75.8.0.20250225.tar.gz", hash = "sha256:6038f7e983d55792a5f90d8fdbf5d4c186026214a16bb65dd6ae83c624ae9636"},
+    {file = "types_setuptools-80.3.0.20250505-py3-none-any.whl", hash = "sha256:117c86a82367306388b55310d04da807ff4c3ecdf769656a5fdc0fdd06a2c1b6"},
+    {file = "types_setuptools-80.3.0.20250505.tar.gz", hash = "sha256:5fd3d34b8fa3441d68d010fef95e232d1e48f3f5cb578f3477b7aae4f8374502"},
 ]
+
+[package.dependencies]
+setuptools = "*"
 
 [[package]]
 name = "types-urllib3"
@@ -7667,4 +7655,4 @@ voyageai = ["voyageai"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "f68c5ee8aebfc273918a13adc848cc7fc868e2a4ba0a35b59266a30471328cd3"
+content-hash = "0f2d5eb340a201832661cda4b1ed42caf506b0ca2066ccfcc9ed319e28653dec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ numpy = [
   { version = ">=1.26.0,<3", python = ">=3.12" },
 ]
 pyyaml = ">=5.4,<7.0"
-redis = "^6.0"
+redis = ">=5.0,<7.0"
 pydantic = "^2"
 tenacity = ">=8.2.2"
 ml-dtypes = ">=0.4.0,<1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ numpy = [
   { version = ">=1.26.0,<3", python = ">=3.12" },
 ]
 pyyaml = ">=5.4,<7.0"
-redis = "^5.0"
+redis = "^6.0"
 pydantic = "^2"
 tenacity = ">=8.2.2"
 ml-dtypes = ">=0.4.0,<1.0.0"
@@ -68,8 +68,8 @@ pytest-xdist = {extras = ["psutil"], version = "^3.6.1"}
 pre-commit = "^4.1.0"
 mypy = "1.9.0"
 nbval = "^0.11.0"
-types-redis = "*"
 types-pyyaml = "*"
+types-pyopenssl = "*"
 testcontainers = "^4.3.1"
 cryptography = { version = ">=44.0.1", markers = "python_version > '3.9.1'" }
 

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -135,8 +135,9 @@ class BaseCache:
                 url = str(self.redis_kwargs["redis_url"])
                 kwargs = self.redis_kwargs.get("connection_kwargs", {})
                 if not isinstance(kwargs, Mapping):
-                    raise ValueError(
-                        f"connection_kwargs must be a mapping, got {type(kwargs)}"
+                    raise TypeError(
+                        "Expected `connection_kwargs` to be a dictionary (e.g. {'decode_responses': True}), "
+                        f"but got type: {type(kwargs).__name__}"
                     )
                 self._async_redis_client = (
                     RedisConnectionFactory.get_async_redis_connection(url, **kwargs)

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -216,7 +216,14 @@ class BaseCache:
                 await client.delete(*keys)
             if cursor_int == 0:  # Redis returns 0 when scan is complete
                 break
-            cursor = cursor_int  # Update cursor for next iteration
+            # Cluster returns a dict of cursor values. We need to stop if these all
+            # come back as 0.
+            elif isinstance(cursor_int, Mapping):
+                cursor_values = list(cursor_int.values())
+                if all(v == 0 for v in cursor_values):
+                    break
+            else:
+                cursor = cursor_int  # Update cursor for next iteration
 
     def disconnect(self) -> None:
         """Disconnect from Redis."""

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -4,12 +4,14 @@ This module defines the abstract base cache interface that is implemented by
 specific cache types such as LLM caches and embedding caches.
 """
 
-from typing import Any, Dict, Optional
+from collections.abc import Mapping
+from typing import Any, Dict, Optional, Union
 
-from redis import Redis
-from redis.asyncio import Redis as AsyncRedis
+from redis import Redis  # For backwards compatibility in type checking
+from redis.cluster import RedisCluster
 
 from redisvl.redis.connection import RedisConnectionFactory
+from redisvl.types import AsyncRedisClient, SyncRedisClient, SyncRedisCluster
 
 
 class BaseCache:
@@ -19,14 +21,15 @@ class BaseCache:
     including TTL management, connection handling, and basic cache operations.
     """
 
-    _redis_client: Optional[Redis]
-    _async_redis_client: Optional[AsyncRedis]
+    _redis_client: Optional[SyncRedisClient]
+    _async_redis_client: Optional[AsyncRedisClient]
 
     def __init__(
         self,
         name: str,
         ttl: Optional[int] = None,
-        redis_client: Optional[Redis] = None,
+        redis_client: Optional[SyncRedisClient] = None,
+        async_redis_client: Optional[AsyncRedisClient] = None,
         redis_url: str = "redis://localhost:6379",
         connection_kwargs: Dict[str, Any] = {},
     ):
@@ -36,7 +39,7 @@ class BaseCache:
             name (str): The name of the cache.
             ttl (Optional[int], optional): The time-to-live for records cached
                 in Redis. Defaults to None.
-            redis_client (Optional[Redis], optional): A redis client connection instance.
+            redis_client (Optional[SyncRedisClient], optional): A redis client connection instance.
                 Defaults to None.
             redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
             connection_kwargs (Dict[str, Any]): The connection arguments
@@ -53,14 +56,13 @@ class BaseCache:
         }
 
         # Initialize Redis clients
-        self._async_redis_client = None
+        self._async_redis_client = async_redis_client
+        self._redis_client = redis_client
 
-        if redis_client:
+        if redis_client or async_redis_client:
             self._owns_redis_client = False
-            self._redis_client = redis_client
         else:
             self._owns_redis_client = True
-            self._redis_client = None  # type: ignore
 
     def _get_prefix(self) -> str:
         """Get the key prefix for Redis keys.
@@ -103,11 +105,11 @@ class BaseCache:
         else:
             self._ttl = None
 
-    def _get_redis_client(self) -> Redis:
+    def _get_redis_client(self) -> SyncRedisClient:
         """Get or create a Redis client.
 
         Returns:
-            Redis: A Redis client instance.
+            SyncRedisClient: A Redis client instance.
         """
         if self._redis_client is None:
             # Create new Redis client
@@ -116,22 +118,29 @@ class BaseCache:
             self._redis_client = Redis.from_url(url, **kwargs)  # type: ignore
         return self._redis_client
 
-    async def _get_async_redis_client(self) -> AsyncRedis:
+    async def _get_async_redis_client(self) -> AsyncRedisClient:
         """Get or create an async Redis client.
 
         Returns:
-            AsyncRedis: An async Redis client instance.
+            AsyncRedisClient: An async Redis client instance.
         """
         if not hasattr(self, "_async_redis_client") or self._async_redis_client is None:
             client = self.redis_kwargs.get("redis_client")
-            if isinstance(client, Redis):
+
+            if client and isinstance(client, (Redis, RedisCluster)):
                 self._async_redis_client = RedisConnectionFactory.sync_to_async_redis(
                     client
                 )
             else:
-                url = self.redis_kwargs["redis_url"]
-                kwargs = self.redis_kwargs["connection_kwargs"]
-                self._async_redis_client = RedisConnectionFactory.get_async_redis_connection(url, **kwargs)  # type: ignore
+                url = str(self.redis_kwargs["redis_url"])
+                kwargs = self.redis_kwargs.get("connection_kwargs", {})
+                if not isinstance(kwargs, Mapping):
+                    raise ValueError(
+                        f"connection_kwargs must be a mapping, got {type(kwargs)}"
+                    )
+                self._async_redis_client = (
+                    RedisConnectionFactory.get_async_redis_connection(url, **kwargs)
+                )
         return self._async_redis_client
 
     def expire(self, key: str, ttl: Optional[int] = None) -> None:
@@ -183,7 +192,14 @@ class BaseCache:
                 client.delete(*keys)
             if cursor_int == 0:  # Redis returns 0 when scan is complete
                 break
-            cursor = cursor_int  # Update cursor for next iteration
+            # Cluster returns a dict of cursor values. We need to stop if these all
+            # come back as 0.
+            elif isinstance(cursor_int, Mapping):
+                cursor_values = list(cursor_int.values())
+                if all(v == 0 for v in cursor_values):
+                    break
+            else:
+                cursor = cursor_int  # Update cursor for next iteration
 
     async def aclear(self) -> None:
         """Async clear the cache of all keys."""
@@ -193,7 +209,9 @@ class BaseCache:
         # Scan for all keys with our prefix
         cursor = 0  # Start with cursor 0
         while True:
-            cursor_int, keys = await client.scan(cursor=cursor, match=f"{prefix}*", count=100)  # type: ignore
+            cursor_int, keys = await client.scan(
+                cursor=cursor, match=f"{prefix}*", count=100
+            )  # type: ignore
             if keys:
                 await client.delete(*keys)
             if cursor_int == 0:  # Redis returns 0 when scan is complete
@@ -207,12 +225,10 @@ class BaseCache:
 
         if self._redis_client:
             self._redis_client.close()
-            self._redis_client = None  # type: ignore
-
-        if hasattr(self, "_async_redis_client") and self._async_redis_client:
-            # Use synchronous close for async client in synchronous context
-            self._async_redis_client.close()  # type: ignore
-            self._async_redis_client = None  # type: ignore
+            self._redis_client = None
+            # Async clients don't have a sync close method, so we just
+            # zero them out to allow garbage collection.
+            self._async_redis_client = None
 
     async def adisconnect(self) -> None:
         """Async disconnect from Redis."""
@@ -221,9 +237,9 @@ class BaseCache:
 
         if self._redis_client:
             self._redis_client.close()
-            self._redis_client = None  # type: ignore
+            self._redis_client = None
 
         if hasattr(self, "_async_redis_client") and self._async_redis_client:
             # Use proper async close method
-            await self._async_redis_client.aclose()  # type: ignore
-            self._async_redis_client = None  # type: ignore
+            await self._async_redis_client.aclose()
+            self._async_redis_client = None

--- a/redisvl/extensions/cache/embeddings/embeddings.py
+++ b/redisvl/extensions/cache/embeddings/embeddings.py
@@ -47,6 +47,7 @@ class EmbeddingsCache(BaseCache):
             name=name,
             ttl=ttl,
             redis_client=redis_client,
+            async_redis_client=async_redis_client,
             redis_url=redis_url,
             connection_kwargs=connection_kwargs,
         )

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -137,7 +137,9 @@ class SemanticRouter(BaseModel):
 
         router_dict = redis_client.json().get(f"{name}:route_config")
         if not isinstance(router_dict, dict):
-            raise ValueError(f"No valid router config found for {name}")
+            raise ValueError(
+                f"No valid router config found for {name}. Received: {router_dict!r}"
+            )
         return cls.from_dict(
             router_dict, redis_url=redis_url, redis_client=redis_client
         )

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -45,7 +45,14 @@ if TYPE_CHECKING:
 
 from redis.client import NEVER_DECODE
 from redis.commands.helpers import get_protocol_version  # type: ignore
-from redis.commands.search.index_definition import IndexDefinition
+
+# Redis 5.x compatibility (6 fixed the import path)
+try:
+    from redis.commands.search.index_definition import (  # type: ignore[import-untyped]
+        IndexDefinition,
+    )
+except ModuleNotFoundError:
+    from redis.commands.search.indexDefinition import IndexDefinition
 
 # Need Result outside TYPE_CHECKING for cast
 from redis.commands.search.result import Result

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -43,16 +43,17 @@ if TYPE_CHECKING:
     from redis.commands.search.result import Result
     from redisvl.query.query import BaseQuery
 
+from redis import __version__ as redis_version
 from redis.client import NEVER_DECODE
 from redis.commands.helpers import get_protocol_version  # type: ignore
 
 # Redis 5.x compatibility (6 fixed the import path)
-try:
-    from redis.commands.search.index_definition import (  # type: ignore[import-untyped]
+if redis_version.startswith("5"):
+    from redis.commands.search.index_definition import IndexDefinition
+else:
+    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped, no-redef]
         IndexDefinition,
     )
-except ModuleNotFoundError:
-    from redis.commands.search.indexDefinition import IndexDefinition
 
 # Need Result outside TYPE_CHECKING for cast
 from redis.commands.search.result import Result

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -49,9 +49,11 @@ from redis.commands.helpers import get_protocol_version  # type: ignore
 
 # Redis 5.x compatibility (6 fixed the import path)
 if redis_version.startswith("5"):
-    from redis.commands.search.index_definition import IndexDefinition
+    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped]
+        IndexDefinition,
+    )
 else:
-    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped, no-redef]
+    from redis.commands.search.index_definition import (  # type: ignore[no-redef]
         IndexDefinition,
     )
 

--- a/redisvl/index/storage.py
+++ b/redisvl/index/storage.py
@@ -21,9 +21,13 @@ from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
 
 # Redis 5.x compatibility (6 fixed the import path)
 if redis_version.startswith("5"):
-    from redis.commands.search.index_definition import IndexType
+    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped]
+        IndexType,
+    )
 else:
-    from redis.commands.search.indexDefinition import IndexType  # type: ignore[import-untyped, no-redef]
+    from redis.commands.search.index_definition import (  # type: ignore[no-redef]
+        IndexType,
+    )
 
 from redisvl.exceptions import SchemaValidationError
 from redisvl.redis.utils import convert_bytes

--- a/redisvl/index/storage.py
+++ b/redisvl/index/storage.py
@@ -13,18 +13,17 @@ from typing import (
 )
 
 from pydantic import BaseModel, ValidationError
+from redis import __version__ as redis_version
 
 # Add imports for Pipeline types
 from redis.asyncio.client import Pipeline as AsyncPipeline
 from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
 
 # Redis 5.x compatibility (6 fixed the import path)
-try:
-    from redis.commands.search.index_definition import (  # type: ignore[import-untyped]
-        IndexType,
-    )
-except ModuleNotFoundError:
-    from redis.commands.search.indexDefinition import IndexType
+if redis_version.startswith("5"):
+    from redis.commands.search.index_definition import IndexType
+else:
+    from redis.commands.search.indexDefinition import IndexType  # type: ignore[import-untyped, no-redef]
 
 from redisvl.exceptions import SchemaValidationError
 from redisvl.redis.utils import convert_bytes

--- a/redisvl/index/storage.py
+++ b/redisvl/index/storage.py
@@ -17,7 +17,14 @@ from pydantic import BaseModel, ValidationError
 # Add imports for Pipeline types
 from redis.asyncio.client import Pipeline as AsyncPipeline
 from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
-from redis.commands.search.index_definition import IndexType
+
+# Redis 5.x compatibility (6 fixed the import path)
+try:
+    from redis.commands.search.index_definition import (  # type: ignore[import-untyped]
+        IndexType,
+    )
+except ModuleNotFoundError:
+    from redis.commands.search.indexDefinition import IndexType
 
 from redisvl.exceptions import SchemaValidationError
 from redisvl.redis.utils import convert_bytes

--- a/redisvl/index/storage.py
+++ b/redisvl/index/storage.py
@@ -1,14 +1,36 @@
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from collections.abc import Collection
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from pydantic import BaseModel, ValidationError
-from redis import Redis
-from redis.asyncio import Redis as AsyncRedis
-from redis.commands.search.indexDefinition import IndexType
+
+# Add imports for Pipeline types
+from redis.asyncio.client import Pipeline as AsyncPipeline
+from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
+from redis.commands.search.index_definition import IndexType
 
 from redisvl.exceptions import SchemaValidationError
 from redisvl.redis.utils import convert_bytes
 from redisvl.schema import IndexSchema
 from redisvl.schema.validation import validate_object
+from redisvl.types import (
+    AsyncRedisClient,
+    AsyncRedisClientOrPipeline,
+    AsyncRedisPipeline,
+    RedisClientOrPipeline,
+    SyncRedisClient,
+    SyncRedisPipeline,
+)
 from redisvl.utils.log import get_logger
 from redisvl.utils.utils import create_ulid
 
@@ -96,51 +118,37 @@ class BaseStorage(BaseModel):
         return obj
 
     @staticmethod
-    def _set(client: Redis, key: str, obj: Dict[str, Any]):
+    def _set(
+        client: RedisClientOrPipeline, key: str, obj: Dict[str, Any]
+    ) -> Union[SyncRedisPipeline, Dict[str, Any]]:
         """Synchronously set the value in Redis for the given key.
 
         Args:
-            client (Redis): The Redis client instance.
+            client (RedisClientOrPipeline): The Redis client instance.
             key (str): The key under which to store the object.
             obj (Dict[str, Any]): The object to store in Redis.
         """
         raise NotImplementedError
 
     @staticmethod
-    async def _aset(client: AsyncRedis, key: str, obj: Dict[str, Any]):
-        """Asynchronously set the value in Redis for the given key.
-
-        Args:
-            client (AsyncRedis): The Redis client instance.
-            key (str): The key under which to store the object.
-            obj (Dict[str, Any]): The object to store in Redis.
-        """
+    async def _aset(
+        client: AsyncRedisClientOrPipeline, key: str, obj: Dict[str, Any]
+    ) -> Union[AsyncRedisPipeline, Dict[str, Any]]:
+        """Asynchronously set data in Redis using the provided client or pipeline."""
         raise NotImplementedError
 
     @staticmethod
-    def _get(client: Redis, key: str) -> Dict[str, Any]:
-        """Synchronously get the value from Redis for the given key.
-
-        Args:
-            client (Redis): The Redis client instance.
-            key (str): The key for which to retrieve the object.
-
-        Returns:
-            Dict[str, Any]: The retrieved object from Redis.
-        """
+    def _get(
+        client: RedisClientOrPipeline, key: str
+    ) -> Union[SyncRedisPipeline, Dict[str, Any]]:
+        """Synchronously get data from Redis using the provided client or pipeline."""
         raise NotImplementedError
 
     @staticmethod
-    async def _aget(client: AsyncRedis, key: str) -> Dict[str, Any]:
-        """Asynchronously get the value from Redis for the given key.
-
-        Args:
-            client (AsyncRedis): The Redis client instance.
-            key (str): The key for which to retrieve the object.
-
-        Returns:
-            Dict[str, Any]: The retrieved object from Redis.
-        """
+    async def _aget(
+        client: AsyncRedisClientOrPipeline, key: str
+    ) -> Union[AsyncRedisPipeline, Dict[str, Any]]:
+        """Asynchronously get data from Redis using the provided client or pipeline."""
         raise NotImplementedError
 
     def _validate(self, obj: Dict[str, Any]) -> Dict[str, Any]:
@@ -158,6 +166,29 @@ class BaseStorage(BaseModel):
         """
         # Pass directly to validation function and let any errors propagate
         return validate_object(self.index_schema, obj)
+
+    def _get_keys(
+        self,
+        objects: List[Any],
+        keys: Optional[Iterable[str]] = None,
+        id_field: Optional[str] = None,
+    ) -> List[str]:
+        """Generate Redis keys for a list of objects."""
+        generated_keys: List[str] = []
+        keys_iterator = iter(keys) if keys else None
+
+        if keys and len(list(keys)) != len(objects):
+            raise ValueError(
+                "Length of provided keys does not match the length of objects."
+            )
+
+        for obj in objects:
+            if keys_iterator:
+                key = next(keys_iterator)
+            else:
+                key = self._create_key(obj, id_field)
+            generated_keys.append(key)
+        return generated_keys
 
     def _preprocess_and_validate_objects(
         self,
@@ -220,7 +251,7 @@ class BaseStorage(BaseModel):
 
     def write(
         self,
-        redis_client: Redis,
+        redis_client: SyncRedisClient,
         objects: Iterable[Any],
         id_field: Optional[str] = None,
         keys: Optional[Iterable[str]] = None,
@@ -233,7 +264,7 @@ class BaseStorage(BaseModel):
         returns a list of Redis keys written to the database.
 
         Args:
-            redis_client (Redis): A Redis client used for writing data.
+            redis_client (RedisClient): A Redis client used for writing data.
             objects (Iterable[Any]): An iterable of objects to store.
             id_field (Optional[str], optional): Field used as the key for
                 each object. Defaults to None.
@@ -295,7 +326,7 @@ class BaseStorage(BaseModel):
 
     async def awrite(
         self,
-        redis_client: AsyncRedis,
+        redis_client: AsyncRedisClient,
         objects: Iterable[Any],
         id_field: Optional[str] = None,
         keys: Optional[Iterable[str]] = None,
@@ -308,7 +339,7 @@ class BaseStorage(BaseModel):
         The method returns a list of keys written to the database.
 
         Args:
-            redis_client (AsyncRedis): An asynchronous Redis client used
+            redis_client (AsyncRedisClient): An asynchronous Redis client used
                 for writing data.
             objects (Iterable[Any]): An iterable of objects to store.
             id_field (Optional[str], optional): Field used as the key for each
@@ -373,13 +404,16 @@ class BaseStorage(BaseModel):
         return added_keys
 
     def get(
-        self, redis_client: Redis, keys: Iterable[str], batch_size: Optional[int] = None
+        self,
+        redis_client: SyncRedisClient,
+        keys: Collection[str],
+        batch_size: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Retrieve objects from Redis by keys.
 
         Args:
-            redis_client (Redis): Synchronous Redis client.
-            keys (Iterable[str]): Keys to retrieve from Redis.
+            redis_client (SyncRedisClient): Synchronous Redis client.
+            keys (Collection[str]): Keys to retrieve from Redis.
             batch_size (Optional[int], optional): Number of objects to write
                 in a single Redis pipeline execution. Defaults to class's
                 default batch size.
@@ -389,10 +423,10 @@ class BaseStorage(BaseModel):
         """
         results: List = []
 
-        if not isinstance(keys, Iterable):  # type: ignore
-            raise TypeError("Keys must be an iterable of strings")
+        if not isinstance(keys, Collection):
+            raise TypeError("Keys must be a collection of strings")
 
-        if len(keys) == 0:  # type: ignore
+        if len(keys) == 0:
             return []
 
         if batch_size is None:
@@ -412,15 +446,15 @@ class BaseStorage(BaseModel):
 
     async def aget(
         self,
-        redis_client: AsyncRedis,
-        keys: Iterable[str],
+        redis_client: AsyncRedisClient,
+        keys: Collection[str],
         batch_size: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Asynchronously retrieve objects from Redis by keys.
 
         Args:
-            redis_client (AsyncRedis): Asynchronous Redis client.
-            keys (Iterable[str]): Keys to retrieve from Redis.
+            redis_client (AsyncRedisClient): Asynchronous Redis client.
+            keys (Collection[str]): Keys to retrieve from Redis.
             batch_size (Optional[int], optional): Number of objects to write
                 in a single Redis pipeline execution. Defaults to class's
                 default batch size.
@@ -431,10 +465,10 @@ class BaseStorage(BaseModel):
         """
         results: List = []
 
-        if not isinstance(keys, Iterable):  # type: ignore
-            raise TypeError("Keys must be an iterable of strings")
+        if not isinstance(keys, Collection):
+            raise TypeError("Keys must be a collection of strings")
 
-        if len(keys) == 0:  # type: ignore
+        if len(keys) == 0:
             return []
 
         if batch_size is None:
@@ -465,52 +499,60 @@ class HashStorage(BaseStorage):
     """Hash data type for the index"""
 
     @staticmethod
-    def _set(client: Redis, key: str, obj: Dict[str, Any]):
+    def _set(client: RedisClientOrPipeline, key: str, obj: Dict[str, Any]):
         """Synchronously set a hash value in Redis for the given key.
 
         Args:
-            client (Redis): The Redis client instance.
+            client (SyncRedisClient): The Redis client instance.
             key (str): The key under which to store the hash.
             obj (Dict[str, Any]): The hash to store in Redis.
         """
-        client.hset(name=key, mapping=obj)  # type: ignore
+        client.hset(name=key, mapping=obj)
 
     @staticmethod
-    async def _aset(client: AsyncRedis, key: str, obj: Dict[str, Any]):
+    async def _aset(client: AsyncRedisClientOrPipeline, key: str, obj: Dict[str, Any]):
         """Asynchronously set a hash value in Redis for the given key.
 
         Args:
-            client (AsyncRedis): The Redis client instance.
+            client (AsyncClientOrPipeline): The async Redis client or pipeline instance.
             key (str): The key under which to store the hash.
             obj (Dict[str, Any]): The hash to store in Redis.
         """
-        await client.hset(name=key, mapping=obj)  # type: ignore
+        if isinstance(client, (AsyncPipeline, AsyncClusterPipeline)):
+            client.hset(name=key, mapping=obj)  # type: ignore
+        else:
+            await client.hset(name=key, mapping=obj)  # type: ignore
 
     @staticmethod
-    def _get(client: Redis, key: str) -> Dict[str, Any]:
+    def _get(client: SyncRedisClient, key: str) -> Dict[str, Any]:
         """Synchronously retrieve a hash value from Redis for the given key.
 
         Args:
-            client (Redis): The Redis client instance.
+            client (SyncRedisClient): The Redis client instance.
             key (str): The key for which to retrieve the hash.
 
         Returns:
             Dict[str, Any]: The retrieved hash from Redis.
         """
-        return client.hgetall(key)
+        return client.hgetall(key)  # type: ignore
 
     @staticmethod
-    async def _aget(client: AsyncRedis, key: str) -> Dict[str, Any]:
+    async def _aget(
+        client: AsyncRedisClientOrPipeline, key: str
+    ) -> Union[AsyncRedisPipeline, Dict[str, Any]]:
         """Asynchronously retrieve a hash value from Redis for the given key.
 
         Args:
-            client (AsyncRedis): The Redis client instance.
+            client (AsyncRedisClient): The async Redis client or pipeline instance.
             key (str): The key for which to retrieve the hash.
 
         Returns:
             Dict[str, Any]: The retrieved hash from Redis.
         """
-        return await client.hgetall(key)
+        if isinstance(client, (AsyncPipeline, AsyncClusterPipeline)):
+            return client.hgetall(key)  # type: ignore[return-value]
+        else:
+            return await client.hgetall(key)  # type: ignore[return-value, misc]
 
 
 class JsonStorage(BaseStorage):
@@ -525,49 +567,55 @@ class JsonStorage(BaseStorage):
     """JSON data type for the index"""
 
     @staticmethod
-    def _set(client: Redis, key: str, obj: Dict[str, Any]):
+    def _set(client: RedisClientOrPipeline, key: str, obj: Dict[str, Any]):
         """Synchronously set a JSON obj in Redis for the given key.
 
         Args:
-            client (AsyncRedis): The Redis client instance.
+            client (SyncRedisClient): The Redis client instance.
             key (str): The key under which to store the JSON obj.
             obj (Dict[str, Any]): The JSON obj to store in Redis.
         """
         client.json().set(key, "$", obj)
 
     @staticmethod
-    async def _aset(client: AsyncRedis, key: str, obj: Dict[str, Any]):
+    async def _aset(client: AsyncRedisClientOrPipeline, key: str, obj: Dict[str, Any]):
         """Asynchronously set a JSON obj in Redis for the given key.
 
         Args:
-            client (AsyncRedis): The Redis client instance.
+            client (AsyncClientOrPipeline): The async Redis client or pipeline instance.
             key (str): The key under which to store the JSON obj.
             obj (Dict[str, Any]): The JSON obj to store in Redis.
         """
-        await client.json().set(key, "$", obj)
+        if isinstance(client, (AsyncPipeline, AsyncClusterPipeline)):
+            client.json().set(key, "$", obj)  # type: ignore[return-value, misc]
+        else:
+            await client.json().set(key, "$", obj)  # type: ignore[return-value, misc]
 
     @staticmethod
-    def _get(client: Redis, key: str) -> Dict[str, Any]:
+    def _get(client: RedisClientOrPipeline, key: str) -> Dict[str, Any]:
         """Synchronously retrieve a JSON obj from Redis for the given key.
 
         Args:
-            client (AsyncRedis): The Redis client instance.
+            client (SyncRedisClient): The Redis client instance.
             key (str): The key for which to retrieve the JSON obj.
 
         Returns:
             Dict[str, Any]: The retrieved JSON obj from Redis.
         """
-        return client.json().get(key)
+        return client.json().get(key)  # type: ignore[return-value, misc]
 
     @staticmethod
-    async def _aget(client: AsyncRedis, key: str) -> Dict[str, Any]:
-        """Asynchronously retrieve a JSON obj from Redis for the given key.
+    async def _aget(client: AsyncRedisClientOrPipeline, key: str) -> Dict[str, Any]:
+        """Asynchronously retrieve a JSON object from Redis for the given key.
 
         Args:
-            client (AsyncRedis): The Redis client instance.
-            key (str): The key for which to retrieve the JSON obj.
+            client (AsyncRedisClient): The async Redis client or pipeline instance.
+            key (str): The key for which to retrieve the JSON object.
 
         Returns:
-            Dict[str, Any]: The retrieved JSON obj from Redis.
+            Dict[str, Any]: The retrieved JSON object from Redis.
         """
-        return await client.json().get(key)
+        if isinstance(client, (AsyncPipeline, AsyncClusterPipeline)):
+            return client.json().get(key)  # type: ignore[return-value, misc]
+        else:
+            return await client.json().get(key)  # type: ignore[return-value, misc]

--- a/redisvl/query/aggregate.py
+++ b/redisvl/query/aggregate.py
@@ -117,16 +117,16 @@ class HybridQuery(AggregationQuery):
         query_string = self._build_query_string()
         super().__init__(query_string)
 
-        self.scorer(text_scorer)  # type: ignore[attr-defined]
-        self.add_scores()  # type: ignore[attr-defined]
+        self.scorer(text_scorer)
+        self.add_scores()
         self.apply(
             vector_similarity=f"(2 - @{self.DISTANCE_ID})/2", text_score="@__score"
         )
         self.apply(hybrid_score=f"{1-alpha}*@text_score + {alpha}*@vector_similarity")
-        self.sort_by(Desc("@hybrid_score"), max=num_results)
-        self.dialect(dialect)  # type: ignore[attr-defined]
+        self.sort_by(Desc("@hybrid_score"), max=num_results)  # type: ignore
+        self.dialect(dialect)
         if return_fields:
-            self.load(*return_fields)
+            self.load(*return_fields)  # type: ignore[arg-type]
 
     @property
     def params(self) -> Dict[str, Any]:
@@ -135,10 +135,10 @@ class HybridQuery(AggregationQuery):
         Returns:
             Dict[str, Any]: The parameters for the aggregation.
         """
-        if isinstance(self._vector, bytes):
-            vector = self._vector
-        else:
+        if isinstance(self._vector, list):
             vector = array_to_buffer(self._vector, dtype=self._dtype)
+        else:
+            vector = self._vector
 
         params = {self.VECTOR_PARAM: vector}
 

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -1,18 +1,21 @@
 import os
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 from warnings import warn
 
-from redis import Redis
-from redis.asyncio import Connection as AsyncConnection
+from redis import Redis, RedisCluster
 from redis.asyncio import ConnectionPool as AsyncConnectionPool
 from redis.asyncio import Redis as AsyncRedis
-from redis.asyncio import SSLConnection as AsyncSSLConnection
-from redis.connection import AbstractConnection, SSLConnection
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.asyncio.connection import AbstractConnection as AsyncAbstractConnection
+from redis.asyncio.connection import Connection as AsyncConnection
+from redis.asyncio.connection import SSLConnection as AsyncSSLConnection
+from redis.connection import SSLConnection
 from redis.exceptions import ResponseError
 
 from redisvl.exceptions import RedisModuleVersionError
-from redisvl.redis.constants import DEFAULT_REQUIRED_MODULES
-from redisvl.redis.utils import convert_bytes
+from redisvl.redis.constants import DEFAULT_REQUIRED_MODULES, REDIS_URL_ENV_VAR
+from redisvl.redis.utils import convert_bytes, is_cluster_url
+from redisvl.types import AsyncRedisClient, RedisClient, SyncRedisClient
 from redisvl.utils.utils import deprecated_function
 from redisvl.version import __version__
 
@@ -52,14 +55,11 @@ def unpack_redis_modules(module_list: List[Dict[str, Any]]) -> Dict[str, Any]:
 
 
 def get_address_from_env() -> str:
-    """Get a redis connection from environment variables.
-
-    Returns:
-        str: Redis URL
-    """
-    if "REDIS_URL" not in os.environ:
-        raise ValueError("REDIS_URL env var not set")
-    return os.environ["REDIS_URL"]
+    """Get Redis URL from environment variable."""
+    redis_url = os.getenv(REDIS_URL_ENV_VAR)
+    if not redis_url:
+        raise ValueError(f"{REDIS_URL_ENV_VAR} environment variable not set.")
+    return redis_url
 
 
 def make_lib_name(*args) -> str:
@@ -196,7 +196,7 @@ class RedisConnectionFactory:
     )
     def connect(
         cls, redis_url: Optional[str] = None, use_async: bool = False, **kwargs
-    ) -> Union[Redis, AsyncRedis]:
+    ) -> RedisClient:
         """Create a connection to the Redis database based on a URL and some
         connection kwargs.
 
@@ -226,7 +226,7 @@ class RedisConnectionFactory:
         redis_url: Optional[str] = None,
         required_modules: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
-    ) -> Redis:
+    ) -> SyncRedisClient:
         """Creates and returns a synchronous Redis client.
 
         Args:
@@ -246,12 +246,13 @@ class RedisConnectionFactory:
             RedisModuleVersionError: If required Redis modules are not installed.
         """
         url = redis_url or get_address_from_env()
-        client = Redis.from_url(url, **kwargs)
-
+        if is_cluster_url(url, **kwargs):
+            client = RedisCluster.from_url(url, **kwargs)
+        else:
+            client = Redis.from_url(url, **kwargs)
         RedisConnectionFactory.validate_sync_redis(
             client, required_modules=required_modules
         )
-
         return client
 
     @staticmethod
@@ -259,7 +260,7 @@ class RedisConnectionFactory:
         url: Optional[str] = None,
         required_modules: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
-    ) -> AsyncRedis:
+    ) -> AsyncRedisClient:
         """Creates and returns an asynchronous Redis client.
 
         NOTE: This method is the future form of `get_async_redis_connection` but is
@@ -274,7 +275,7 @@ class RedisConnectionFactory:
                 Redis client constructor.
 
         Returns:
-            AsyncRedis: An asynchronous Redis client instance.
+            AsyncRedisClient: An asynchronous Redis client instance (either AsyncRedis or AsyncRedisCluster).
 
         Raises:
             ValueError: If url is not provided and REDIS_URL environment
@@ -282,7 +283,11 @@ class RedisConnectionFactory:
             RedisModuleVersionError: If required Redis modules are not installed.
         """
         url = url or get_address_from_env()
-        client = AsyncRedis.from_url(url, **kwargs)
+
+        if is_cluster_url(url, **kwargs):
+            client = AsyncRedisCluster.from_url(url, **kwargs)
+        else:
+            client = AsyncRedis.from_url(url, **kwargs)
 
         await RedisConnectionFactory.validate_async_redis(
             client, required_modules=required_modules
@@ -293,7 +298,7 @@ class RedisConnectionFactory:
     def get_async_redis_connection(
         url: Optional[str] = None,
         **kwargs,
-    ) -> AsyncRedis:
+    ) -> AsyncRedisClient:
         """Creates and returns an asynchronous Redis client.
 
         Args:
@@ -317,16 +322,41 @@ class RedisConnectionFactory:
         return AsyncRedis.from_url(url, **kwargs)
 
     @staticmethod
-    def sync_to_async_redis(redis_client: Redis) -> AsyncRedis:
+    def get_redis_cluster_connection(
+        redis_url: Optional[str] = None,
+        **kwargs,
+    ) -> RedisCluster:
+        """Creates and returns a synchronous Redis client for a Redis cluster."""
+        url = redis_url or get_address_from_env()
+        return RedisCluster.from_url(url, **kwargs)
+
+    @staticmethod
+    def get_async_redis_cluster_connection(
+        redis_url: Optional[str] = None,
+        **kwargs,
+    ) -> AsyncRedisCluster:
+        """Creates and returns an asynchronous Redis client for a Redis cluster."""
+        url = redis_url or get_address_from_env()
+        return AsyncRedisCluster.from_url(url, **kwargs)
+
+    @staticmethod
+    def sync_to_async_redis(
+        redis_client: SyncRedisClient,
+    ) -> AsyncRedisClient:
         """Convert a synchronous Redis client to an asynchronous one."""
+        if isinstance(redis_client, RedisCluster):
+            raise ValueError(
+                "RedisCluster is not supported for sync-to-async conversion."
+            )
+
         # pick the right connection class
-        connection_class: Type[AbstractConnection] = (
+        connection_class: Type[AsyncAbstractConnection] = (
             AsyncSSLConnection
             if redis_client.connection_pool.connection_class == SSLConnection
             else AsyncConnection
-        )  # type: ignore
+        )
         # make async client
-        return AsyncRedis.from_pool(  # type: ignore
+        return AsyncRedis.from_pool(
             AsyncConnectionPool(
                 connection_class=connection_class,
                 **redis_client.connection_pool.connection_kwargs,
@@ -334,27 +364,29 @@ class RedisConnectionFactory:
         )
 
     @staticmethod
-    def get_modules(client: Redis) -> Dict[str, Any]:
+    def get_modules(client: SyncRedisClient) -> Dict[str, Any]:
         return unpack_redis_modules(convert_bytes(client.module_list()))
 
     @staticmethod
-    async def get_modules_async(client: AsyncRedis) -> Dict[str, Any]:
+    async def get_modules_async(client: AsyncRedisClient) -> Dict[str, Any]:
         return unpack_redis_modules(convert_bytes(await client.module_list()))
 
     @staticmethod
     def validate_sync_redis(
-        redis_client: Redis,
+        redis_client: SyncRedisClient,
         lib_name: Optional[str] = None,
         required_modules: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         """Validates the sync Redis client."""
-        if not isinstance(redis_client, Redis):
-            raise TypeError("Invalid Redis client instance")
+        if not issubclass(type(redis_client), (Redis, RedisCluster)):
+            raise TypeError(
+                "Invalid Redis client instance. Must be Redis or RedisCluster."
+            )
 
         # Set client library name
         _lib_name = make_lib_name(lib_name)
         try:
-            redis_client.client_setinfo("LIB-NAME", _lib_name)  # type: ignore
+            redis_client.client_setinfo("LIB-NAME", _lib_name)
         except ResponseError:
             # Fall back to a simple log echo
             redis_client.echo(_lib_name)
@@ -367,15 +399,19 @@ class RedisConnectionFactory:
 
     @staticmethod
     async def validate_async_redis(
-        redis_client: AsyncRedis,
+        redis_client: AsyncRedisClient,
         lib_name: Optional[str] = None,
         required_modules: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         """Validates the async Redis client."""
+        if not issubclass(type(redis_client), (AsyncRedis, AsyncRedisCluster)):
+            raise TypeError(
+                "Invalid async Redis client instance. Must be async Redis or async RedisCluster."
+            )
         # Set client library name
         _lib_name = make_lib_name(lib_name)
         try:
-            await redis_client.client_setinfo("LIB-NAME", _lib_name)  # type: ignore
+            await redis_client.client_setinfo("LIB-NAME", _lib_name)
         except ResponseError:
             # Fall back to a simple log echo
             await redis_client.echo(_lib_name)

--- a/redisvl/redis/constants.py
+++ b/redisvl/redis/constants.py
@@ -6,3 +6,6 @@ DEFAULT_REQUIRED_MODULES = [
 
 # default tag separator
 REDIS_TAG_SEPARATOR = ","
+
+
+REDIS_URL_ENV_VAR = "REDIS_URL"

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -1,9 +1,10 @@
 import hashlib
 import itertools
 import time
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 
 from redis import RedisCluster
+from redis import __version__ as redis_version
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.client import NEVER_DECODE, Pipeline
 from redis.commands.helpers import get_protocol_version
@@ -23,12 +24,12 @@ from redis.commands.search.commands import (
 from redis.commands.search.field import Field
 
 # Redis 5.x compatibility (6 fixed the import path)
-try:
-    from redis.commands.search.index_definition import (  # type: ignore[import-untyped]
+if redis_version.startswith("5"):
+    from redis.commands.search.index_definition import IndexDefinition
+else:
+    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped, no-redef]
         IndexDefinition,
     )
-except ModuleNotFoundError:
-    from redis.commands.search.indexDefinition import IndexDefinition
 
 from redis.commands.search.query import Query
 from redis.commands.search.result import Result

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -259,7 +259,7 @@ def cluster_search(
     client: Search,
     query: Union[str, Query],
     query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
-) -> Result | Pipeline | ProfileInformation:
+) -> Union[Result, Pipeline, ProfileInformation]:
     args, query = client._mk_query_args(query, query_params=query_params)
     st = time.monotonic()
 
@@ -282,7 +282,7 @@ async def async_cluster_search(
     client: AsyncSearch,
     query: Union[str, Query],
     query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
-) -> Result | Pipeline | ProfileInformation:
+) -> Union[Result, Pipeline, ProfileInformation]:
     args, query = client._mk_query_args(query, query_params=query_params)
     st = time.monotonic()
 

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -25,9 +25,11 @@ from redis.commands.search.field import Field
 
 # Redis 5.x compatibility (6 fixed the import path)
 if redis_version.startswith("5"):
-    from redis.commands.search.index_definition import IndexDefinition
+    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped]
+        IndexDefinition,
+    )
 else:
-    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped, no-redef]
+    from redis.commands.search.index_definition import (  # type: ignore[no-redef]
         IndexDefinition,
     )
 

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -1,5 +1,30 @@
 import hashlib
-from typing import Any, Dict, List, Optional
+import itertools
+import time
+from typing import Any, Dict, List, Optional, Union, cast
+
+from redis import RedisCluster
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.client import NEVER_DECODE, Pipeline
+from redis.commands.helpers import get_protocol_version
+from redis.commands.search import AsyncSearch, Search
+from redis.commands.search.commands import (
+    CREATE_CMD,
+    MAXTEXTFIELDS,
+    NOFIELDS,
+    NOFREQS,
+    NOHL,
+    NOOFFSETS,
+    SEARCH_CMD,
+    SKIPINITIALSCAN,
+    STOPWORDS,
+    TEMPORARY,
+)
+from redis.commands.search.field import Field
+from redis.commands.search.index_definition import IndexDefinition
+from redis.commands.search.profile_information import ProfileInformation
+from redis.commands.search.query import Query
+from redis.commands.search.result import Result
 
 from redisvl.utils.utils import lazy_import
 
@@ -78,3 +103,221 @@ def hashify(content: str, extras: Optional[Dict[str, Any]] = None) -> str:
         extra_string = " ".join([str(k) + str(v) for k, v in sorted(extras.items())])
         content = content + extra_string
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def cluster_create_index(
+    index_name: str,
+    client: RedisCluster,
+    fields: List[Field],
+    no_term_offsets: bool = False,
+    no_field_flags: bool = False,
+    stopwords: Optional[List[str]] = None,
+    definition: Optional[IndexDefinition] = None,
+    max_text_fields=False,
+    temporary=None,
+    no_highlight: bool = False,
+    no_term_frequencies: bool = False,
+    skip_initial_scan: bool = False,
+):
+    """
+    Creates the search index. The index must not already exist.
+
+    For more information, see https://redis.io/commands/ft.create/
+
+    Args:
+        index_name: The name of the index to create.
+        client: The redis client to use.
+        fields: A list of Field objects.
+        no_term_offsets: If `true`, term offsets will not be saved in the index.
+        no_field_flags: If true, field flags that allow searching in specific fields
+                        will not be saved.
+        stopwords: If provided, the index will be created with this custom stopword
+                   list. The list can be empty.
+        definition: If provided, the index will be created with this custom index
+                    definition.
+        max_text_fields: If true, indexes will be encoded as if there were more than
+                         32 text fields, allowing for additional fields beyond 32.
+        temporary: Creates a lightweight temporary index which will expire after the
+                   specified period of inactivity. The internal idle timer is reset
+                   whenever the index is searched or added to.
+        no_highlight: If true, disables highlighting support. Also implied by
+                      `no_term_offsets`.
+        no_term_frequencies: If true, term frequencies will not be saved in the
+                             index.
+        skip_initial_scan: If true, the initial scan and indexing will be skipped.
+
+    """
+    args = [CREATE_CMD, index_name]
+    if definition is not None:
+        args += definition.args
+    if max_text_fields:
+        args.append(MAXTEXTFIELDS)
+    if temporary is not None and isinstance(temporary, int):
+        args.append(TEMPORARY)
+        args.append(temporary)
+    if no_term_offsets:
+        args.append(NOOFFSETS)
+    if no_highlight:
+        args.append(NOHL)
+    if no_field_flags:
+        args.append(NOFIELDS)
+    if no_term_frequencies:
+        args.append(NOFREQS)
+    if skip_initial_scan:
+        args.append(SKIPINITIALSCAN)
+    if stopwords is not None and isinstance(stopwords, (list, tuple, set)):
+        args += [STOPWORDS, str(len(stopwords))]
+        if len(stopwords) > 0:
+            args += list(stopwords)
+
+    args.append("SCHEMA")
+    try:
+        args += list(itertools.chain(*(f.redis_args() for f in fields)))
+    except TypeError:
+        args += fields.redis_args()  # type: ignore
+
+    default_node = client.get_default_node()
+    return client.execute_command(*args, target_nodes=[default_node])
+
+
+async def async_cluster_create_index(
+    index_name: str,
+    client: AsyncRedisCluster,
+    fields: List[Field],
+    no_term_offsets: bool = False,
+    no_field_flags: bool = False,
+    stopwords: Optional[List[str]] = None,
+    definition: Optional[IndexDefinition] = None,
+    max_text_fields=False,
+    temporary=None,
+    no_highlight: bool = False,
+    no_term_frequencies: bool = False,
+    skip_initial_scan: bool = False,
+):
+    """
+    Creates the search index. The index must not already exist.
+
+    For more information, see https://redis.io/commands/ft.create/
+
+    Args:
+        index_name: The name of the index to create.
+        client: The redis client to use.
+        fields: A list of Field objects.
+        no_term_offsets: If `true`, term offsets will not be saved in the index.
+        no_field_flags: If true, field flags that allow searching in specific fields
+                        will not be saved.
+        stopwords: If provided, the index will be created with this custom stopword
+                   list. The list can be empty.
+        definition: If provided, the index will be created with this custom index
+                    definition.
+        max_text_fields: If true, indexes will be encoded as if there were more than
+                         32 text fields, allowing for additional fields beyond 32.
+        temporary: Creates a lightweight temporary index which will expire after the
+                   specified period of inactivity. The internal idle timer is reset
+                   whenever the index is searched or added to.
+        no_highlight: If true, disables highlighting support. Also implied by
+                      `no_term_offsets`.
+        no_term_frequencies: If true, term frequencies will not be saved in the
+                             index.
+        skip_initial_scan: If true, the initial scan and indexing will be skipped.
+
+    """
+    args = [CREATE_CMD, index_name]
+    if definition is not None:
+        args += definition.args
+    if max_text_fields:
+        args.append(MAXTEXTFIELDS)
+    if temporary is not None and isinstance(temporary, int):
+        args.append(TEMPORARY)
+        args.append(temporary)
+    if no_term_offsets:
+        args.append(NOOFFSETS)
+    if no_highlight:
+        args.append(NOHL)
+    if no_field_flags:
+        args.append(NOFIELDS)
+    if no_term_frequencies:
+        args.append(NOFREQS)
+    if skip_initial_scan:
+        args.append(SKIPINITIALSCAN)
+    if stopwords is not None and isinstance(stopwords, (list, tuple, set)):
+        args += [STOPWORDS, str(len(stopwords))]
+        if len(stopwords) > 0:
+            args += list(stopwords)
+
+    args.append("SCHEMA")
+    try:
+        args += list(itertools.chain(*(f.redis_args() for f in fields)))
+    except TypeError:
+        args += fields.redis_args()  # type: ignore
+
+    default_node = client.get_default_node()
+    return await default_node.execute_command(*args)
+
+
+def cluster_search(
+    client: Search,
+    query: Union[str, Query],
+    query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
+) -> Result | Pipeline | ProfileInformation:
+    args, query = client._mk_query_args(query, query_params=query_params)
+    st = time.monotonic()
+
+    options = {}
+    if get_protocol_version(client.client) not in ["3", 3]:
+        options[NEVER_DECODE] = True
+
+    node = client.client.get_default_node()
+    res = client.execute_command(SEARCH_CMD, *args, **options, target_nodes=[node])
+
+    if isinstance(res, Pipeline):
+        return res
+
+    return client._parse_results(
+        SEARCH_CMD, res, query=query, duration=(time.monotonic() - st) * 1000.0
+    )
+
+
+async def async_cluster_search(
+    client: AsyncSearch,
+    query: Union[str, Query],
+    query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
+) -> Result | Pipeline | ProfileInformation:
+    args, query = client._mk_query_args(query, query_params=query_params)
+    st = time.monotonic()
+
+    options = {}
+    if get_protocol_version(client.client) not in ["3", 3]:
+        options[NEVER_DECODE] = True
+
+    node = client.client.get_default_node()
+    res = await client.execute_command(
+        SEARCH_CMD, *args, **options, target_nodes=[node]
+    )
+
+    if isinstance(res, Pipeline):
+        return res
+
+    return client._parse_results(
+        SEARCH_CMD, res, query=query, duration=(time.monotonic() - st) * 1000.0
+    )
+
+
+def is_cluster_url(url: str, **kwargs) -> bool:
+    """
+    Determine if the given URL and/or kwargs indicate a Redis Cluster connection.
+
+    Args:
+        url (str): The Redis connection URL.
+        **kwargs: Additional keyword arguments that may indicate cluster usage.
+
+    Returns:
+        bool: True if the connection should be a cluster, False otherwise.
+    """
+    if "cluster" in kwargs and kwargs["cluster"]:
+        return True
+    if url:
+        # Check if URL contains multiple hosts or has cluster flag
+        if "," in url or "cluster=true" in url.lower():
+            return True
+    return False

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -21,8 +21,15 @@ from redis.commands.search.commands import (
     TEMPORARY,
 )
 from redis.commands.search.field import Field
-from redis.commands.search.index_definition import IndexDefinition
-from redis.commands.search.profile_information import ProfileInformation
+
+# Redis 5.x compatibility (6 fixed the import path)
+try:
+    from redis.commands.search.index_definition import (  # type: ignore[import-untyped]
+        IndexDefinition,
+    )
+except ModuleNotFoundError:
+    from redis.commands.search.indexDefinition import IndexDefinition
+
 from redis.commands.search.query import Query
 from redis.commands.search.result import Result
 
@@ -255,11 +262,12 @@ async def async_cluster_create_index(
     return await default_node.execute_command(*args)
 
 
+# TODO: The return type is incorrect because 5.x doesn't have "ProfileInformation"
 def cluster_search(
     client: Search,
     query: Union[str, Query],
     query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
-) -> Union[Result, Pipeline, ProfileInformation]:
+) -> Union[Result, Pipeline, Any]:  # type: ignore[type-arg]
     args, query = client._mk_query_args(query, query_params=query_params)
     st = time.monotonic()
 
@@ -278,11 +286,12 @@ def cluster_search(
     )
 
 
+# TODO: The return type is incorrect because 5.x doesn't have "ProfileInformation"
 async def async_cluster_search(
     client: AsyncSearch,
     query: Union[str, Query],
     query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
-) -> Union[Result, Pipeline, ProfileInformation]:
+) -> Union[Result, Pipeline, Any]:  # type: ignore[type-arg]
     args, query = client._mk_query_args(query, query_params=query_params)
     st = time.monotonic()
 

--- a/redisvl/types.py
+++ b/redisvl/types.py
@@ -1,0 +1,20 @@
+from typing import Union
+
+from redis import Redis as SyncRedis
+from redis.asyncio import Redis as AsyncRedis
+from redis.asyncio.client import Pipeline as AsyncPipeline
+from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.client import Pipeline as SyncPipeline
+from redis.cluster import ClusterPipeline as SyncClusterPipeline
+from redis.cluster import RedisCluster as SyncRedisCluster
+
+SyncRedisClient = Union[SyncRedis, SyncRedisCluster]
+AsyncRedisClient = Union[AsyncRedis, AsyncRedisCluster]
+RedisClient = Union[SyncRedisClient, AsyncRedisClient]
+
+SyncRedisPipeline = Union[SyncPipeline, SyncClusterPipeline]
+AsyncRedisPipeline = Union[AsyncPipeline, AsyncClusterPipeline]
+
+RedisClientOrPipeline = Union[SyncRedisClient, SyncRedisPipeline]
+AsyncRedisClientOrPipeline = Union[AsyncRedisClient, AsyncRedisPipeline]

--- a/tests/cluster-compose.yml
+++ b/tests/cluster-compose.yml
@@ -1,0 +1,199 @@
+services:
+  redis-node-1:
+    image: "redis:8.0"
+    command:
+      - redis-server
+      - --port 7001
+      - --cluster-enabled yes
+      - --cluster-config-file nodes.conf
+      - --cluster-node-timeout 5000
+      - --appendonly yes
+      - --cluster-announce-ip host.docker.internal
+      - --cluster-announce-port 7001
+      - --cluster-announce-bus-port 17001
+      - --protected-mode no
+    ports:
+      - "7001:7001"
+      - "17001:17001"
+    volumes:
+      - ./data/7001:/data
+
+  redis-node-2:
+    image: "redis:8.0"
+    command:
+      - redis-server
+      - --port 7002
+      - --cluster-enabled yes
+      - --cluster-config-file nodes.conf
+      - --cluster-node-timeout 5000
+      - --appendonly yes
+      - --cluster-announce-ip host.docker.internal
+      - --cluster-announce-port 7002
+      - --cluster-announce-bus-port 17002
+      - --protected-mode no
+    ports:
+      - "7002:7002"
+      - "17002:17002"
+    volumes:
+      - ./data/7002:/data
+
+  redis-node-3:
+    image: "redis:8.0"
+    command:
+      - redis-server
+      - --port 7003
+      - --cluster-enabled yes
+      - --cluster-config-file nodes.conf
+      - --cluster-node-timeout 5000
+      - --appendonly yes
+      - --cluster-announce-ip host.docker.internal
+      - --cluster-announce-port 7003
+      - --cluster-announce-bus-port 17003
+      - --protected-mode no
+    ports:
+      - "7003:7003"
+      - "17003:17003"
+    volumes:
+      - ./data/7003:/data
+
+  redis-node-4:
+    image: "redis:8.0"
+    command:
+      - redis-server
+      - --port 7004
+      - --cluster-enabled yes
+      - --cluster-config-file nodes.conf
+      - --cluster-node-timeout 5000
+      - --appendonly yes
+      - --cluster-announce-ip host.docker.internal
+      - --cluster-announce-port 7004
+      - --cluster-announce-bus-port 17004
+      - --protected-mode no
+    ports:
+      - "7004:7004"
+      - "17004:17004"
+    volumes:
+      - ./data/7004:/data
+
+  redis-node-5:
+    image: "redis:8.0"
+    command:
+      - redis-server
+      - --port 7005
+      - --cluster-enabled yes
+      - --cluster-config-file nodes.conf
+      - --cluster-node-timeout 5000
+      - --appendonly yes
+      - --cluster-announce-ip host.docker.internal
+      - --cluster-announce-port 7005
+      - --cluster-announce-bus-port 17005
+      - --protected-mode no
+    ports:
+      - "7005:7005"
+      - "17005:17005"
+    volumes:
+      - ./data/7005:/data
+
+  redis-node-6:
+    image: "redis:8.0"
+    command:
+      - redis-server
+      - --port 7006
+      - --cluster-enabled yes
+      - --cluster-config-file nodes.conf
+      - --cluster-node-timeout 5000
+      - --appendonly yes
+      - --cluster-announce-ip host.docker.internal
+      - --cluster-announce-port 7006
+      - --cluster-announce-bus-port 17006
+      - --protected-mode no
+    ports:
+      - "7006:7006"
+      - "17006:17006"
+    volumes:
+      - ./data/7006:/data
+
+  redis-cluster-setup:
+    image: "redis:8.0"
+    depends_on:
+      - redis-node-1
+      - redis-node-2
+      - redis-node-3
+      - redis-node-4
+      - redis-node-5
+      - redis-node-6
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for Redis nodes to be available..."
+        sleep 15
+
+        NODES="redis-node-1:7001 redis-node-2:7002 redis-node-3:7003 redis-node-4:7004 redis-node-5:7005 redis-node-6:7006"
+
+        echo "Force resetting all nodes before cluster creation..."
+        for NODE_ADDR_PORT in $NODES; do
+          NODE_HOST=$(echo $NODE_ADDR_PORT | cut -d':' -f1)
+          NODE_PORT=$(echo $NODE_ADDR_PORT | cut -d':' -f2)
+          echo "Resetting node $NODE_HOST:$NODE_PORT"
+          
+          # Wait for node to be responsive
+          retry_count=0
+          max_retries=10
+          until redis-cli -h $NODE_HOST -p $NODE_PORT ping 2>/dev/null | grep -q PONG; do
+            retry_count=$((retry_count+1))
+            if [ "$retry_count" -gt "$max_retries" ]; then
+              echo "Error: Node $NODE_HOST:$NODE_PORT did not respond after $max_retries retries."
+              exit 1 # Exit if a node is unresponsive
+            fi
+            echo "Waiting for $NODE_HOST:$NODE_PORT to respond (attempt $retry_count/$max_retries)..."
+            sleep 3 # Increased sleep between pings
+          done
+          
+          echo "Flushing and hard resetting $NODE_HOST:$NODE_PORT"
+          redis-cli -h $NODE_HOST -p $NODE_PORT FLUSHALL || echo "Warning: FLUSHALL failed on $NODE_HOST:$NODE_PORT, attempting to continue..."
+          # Use CLUSTER RESET HARD
+          redis-cli -h $NODE_HOST -p $NODE_PORT CLUSTER RESET HARD || echo "Warning: CLUSTER RESET HARD failed on $NODE_HOST:$NODE_PORT, attempting to continue..."
+        done
+        echo "Node reset complete."
+        sleep 5 # Give a moment for resets to settle
+
+        MAX_ATTEMPTS=5
+        ATTEMPT=1
+        CLUSTER_CREATED=false
+
+        while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+          echo "Attempting to create Redis cluster (Attempt $ATTEMPT/$MAX_ATTEMPTS)..."
+          output=$(echo yes | redis-cli --cluster create \
+            $NODES \
+            --cluster-replicas 1 2>&1)
+
+          if echo "$output" | grep -q "\[OK\] All 16384 slots covered."; then
+            echo "Cluster created successfully."
+            CLUSTER_CREATED=true
+            break
+          else
+            echo "Failed to create cluster on attempt $ATTEMPT."
+            echo "Output from redis-cli: $output"
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Retrying in 10 seconds..."
+              sleep 10
+            fi
+          fi
+          ATTEMPT=$((ATTEMPT + 1))
+        done
+
+        if [ "$CLUSTER_CREATED" = "false" ]; then
+          echo "Failed to create cluster after $MAX_ATTEMPTS attempts. Exiting."
+          exit 1
+        fi
+
+        echo "Redis cluster setup complete. Container will remain active for health checks."
+        tail -f /dev/null
+    healthcheck:
+      test: >
+        sh -c "redis-cli -h redis-node-1 -p 7001 cluster info | grep -q 'cluster_state:ok'"
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s

--- a/tests/cluster-compose.yml
+++ b/tests/cluster-compose.yml
@@ -132,28 +132,28 @@ services:
         NODES="redis-node-1:7001 redis-node-2:7002 redis-node-3:7003 redis-node-4:7004 redis-node-5:7005 redis-node-6:7006"
 
         echo "Force resetting all nodes before cluster creation..."
-        for NODE_ADDR_PORT in $NODES; do
-          NODE_HOST=$(echo $NODE_ADDR_PORT | cut -d':' -f1)
-          NODE_PORT=$(echo $NODE_ADDR_PORT | cut -d':' -f2)
-          echo "Resetting node $NODE_HOST:$NODE_PORT"
+        for NODE_ADDR_PORT in $$NODES; do
+          NODE_HOST=$$(echo $$NODE_ADDR_PORT | cut -d':' -f1)
+          NODE_PORT=$$(echo $$NODE_ADDR_PORT | cut -d':' -f2)
+          echo "Resetting node $$NODE_HOST:$$NODE_PORT"
           
           # Wait for node to be responsive
           retry_count=0
           max_retries=10
-          until redis-cli -h $NODE_HOST -p $NODE_PORT ping 2>/dev/null | grep -q PONG; do
-            retry_count=$((retry_count+1))
-            if [ "$retry_count" -gt "$max_retries" ]; then
-              echo "Error: Node $NODE_HOST:$NODE_PORT did not respond after $max_retries retries."
+          until redis-cli -h $$NODE_HOST -p $$NODE_PORT ping 2>/dev/null | grep -q PONG; do
+            retry_count=$$((retry_count+1))
+            if [ "$$retry_count" -gt "$$max_retries" ]; then
+              echo "Error: Node $$NODE_HOST:$$NODE_PORT did not respond after $$max_retries retries."
               exit 1 # Exit if a node is unresponsive
             fi
-            echo "Waiting for $NODE_HOST:$NODE_PORT to respond (attempt $retry_count/$max_retries)..."
+            echo "Waiting for $$NODE_HOST:$$NODE_PORT to respond (attempt $$retry_count/$$max_retries)..."
             sleep 3 # Increased sleep between pings
           done
           
-          echo "Flushing and hard resetting $NODE_HOST:$NODE_PORT"
-          redis-cli -h $NODE_HOST -p $NODE_PORT FLUSHALL || echo "Warning: FLUSHALL failed on $NODE_HOST:$NODE_PORT, attempting to continue..."
+          echo "Flushing and hard resetting $$NODE_HOST:$$NODE_PORT"
+          redis-cli -h $$NODE_HOST -p $$NODE_PORT FLUSHALL || echo "Warning: FLUSHALL failed on $$NODE_HOST:$$NODE_PORT, attempting to continue..."
           # Use CLUSTER RESET HARD
-          redis-cli -h $NODE_HOST -p $NODE_PORT CLUSTER RESET HARD || echo "Warning: CLUSTER RESET HARD failed on $NODE_HOST:$NODE_PORT, attempting to continue..."
+          redis-cli -h $$NODE_HOST -p $$NODE_PORT CLUSTER RESET HARD || echo "Warning: CLUSTER RESET HARD failed on $$NODE_HOST:$$NODE_PORT, attempting to continue..."
         done
         echo "Node reset complete."
         sleep 5 # Give a moment for resets to settle
@@ -162,29 +162,29 @@ services:
         ATTEMPT=1
         CLUSTER_CREATED=false
 
-        while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-          echo "Attempting to create Redis cluster (Attempt $ATTEMPT/$MAX_ATTEMPTS)..."
-          output=$(echo yes | redis-cli --cluster create \
-            $NODES \
+        while [ $$ATTEMPT -le $$MAX_ATTEMPTS ]; do
+          echo "Attempting to create Redis cluster (Attempt $$ATTEMPT/$$MAX_ATTEMPTS)..."
+          output=$$(echo yes | redis-cli --cluster create \
+            $$NODES \
             --cluster-replicas 1 2>&1)
 
-          if echo "$output" | grep -q "\[OK\] All 16384 slots covered."; then
+          if echo "$$output" | grep -q "\[OK\] All 16384 slots covered."; then
             echo "Cluster created successfully."
             CLUSTER_CREATED=true
             break
           else
-            echo "Failed to create cluster on attempt $ATTEMPT."
-            echo "Output from redis-cli: $output"
-            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+            echo "Failed to create cluster on attempt $$ATTEMPT."
+            echo "Output from redis-cli: $$output"
+            if [ $$ATTEMPT -lt $$MAX_ATTEMPTS ]; then
               echo "Retrying in 10 seconds..."
               sleep 10
             fi
           fi
-          ATTEMPT=$((ATTEMPT + 1))
+          ATTEMPT=$$((ATTEMPT + 1))
         done
 
-        if [ "$CLUSTER_CREATED" = "false" ]; then
-          echo "Failed to create cluster after $MAX_ATTEMPTS attempts. Exiting."
+        if [ "$$CLUSTER_CREATED" = "false" ]; then
+          echo "Failed to create cluster after $$MAX_ATTEMPTS attempts. Exiting."
           exit 1
         fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,22 +335,23 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    if config.getoption("--run-api-tests"):
-        return
-    if config.getoption("--run-cluster-tests"):
-        return
+    # Check each flag independently
+    run_api_tests = config.getoption("--run-api-tests")
+    run_cluster_tests = config.getoption("--run-cluster-tests")
 
-    # Otherwise skip all tests requiring an API key
+    # Create skip markers
     skip_api = pytest.mark.skip(
         reason="Skipping test because API keys are not provided. Use --run-api-tests to run these tests."
     )
     skip_cluster = pytest.mark.skip(
         reason="Skipping test because Redis cluster is not available. Use --run-cluster-tests to run these tests."
     )
+
+    # Apply skip markers independently based on flags
     for item in items:
-        if item.get_closest_marker("requires_api_keys"):
+        if item.get_closest_marker("requires_api_keys") and not run_api_tests:
             item.add_marker(skip_api)
-        if item.get_closest_marker("requires_cluster"):
+        if item.get_closest_marker("requires_cluster") and not run_cluster_tests:
             item.add_marker(skip_cluster)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,11 +315,20 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Run tests that require API keys",
     )
+    parser.addoption(
+        "--run-cluster-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that require a Redis cluster",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers", "requires_api_keys: mark test as requiring API keys"
+    )
+    config.addinivalue_line(
+        "markers", "requires_cluster: mark test as requiring a Redis cluster"
     )
 
 
@@ -328,14 +337,21 @@ def pytest_collection_modifyitems(
 ) -> None:
     if config.getoption("--run-api-tests"):
         return
+    if config.getoption("--run-cluster-tests"):
+        return
 
     # Otherwise skip all tests requiring an API key
     skip_api = pytest.mark.skip(
         reason="Skipping test because API keys are not provided. Use --run-api-tests to run these tests."
     )
+    skip_cluster = pytest.mark.skip(
+        reason="Skipping test because Redis cluster is not available. Use --run-cluster-tests to run these tests."
+    )
     for item in items:
         if item.get_closest_marker("requires_api_keys"):
             item.add_marker(skip_api)
+        if item.get_closest_marker("requires_cluster"):
+            item.add_marker(skip_cluster)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,9 +122,9 @@ def redis_cluster_container(worker_id):
                     capture_output=True,
                     text=True,
                 )
-                logger.info("Docker Compose logs:\n", logs_result.stdout)
+                logger.info("Docker Compose logs:\n%s", logs_result.stdout)
                 if logs_result.stderr:
-                    logger.error("Docker Compose logs stderr:\n", logs_result.stderr)
+                    logger.error("Docker Compose logs stderr:\n%s", logs_result.stderr)
             except Exception as log_e:
                 logger.error(f"Failed to get Docker Compose logs: {repr(log_e)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,11 @@ def redis_container(worker_id):
 @pytest.fixture(scope="session")
 def redis_cluster_container(worker_id):
     project_name = f"redis_test_cluster_{worker_id}"
-    compose_file = "tests/cluster-compose.yml"
+    # Use cwd if not running in GitHub Actions
+    pwd = os.getcwd()
+    compose_file = os.path.join(
+        os.environ.get("GITHUB_WORKSPACE", pwd), "tests", "cluster-compose.yml"
+    )
     os.environ["COMPOSE_PROJECT_NAME"] = (
         project_name  # For docker compose to pick it up if needed
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def redis_cluster_container(worker_id):
                 )
                 logger.info("Docker Compose logs:\n%s", logs_result.stdout)
                 if logs_result.stderr:
-                    logger.error("Docker Compose logs stderr:\n%s", logs_result.stderr)
+                    logger.error("Docker Compose logs stderr: \n%s", logs_result.stderr)
             except Exception as log_e:
                 logger.error(f"Failed to get Docker Compose logs: {repr(log_e)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import subprocess
-import time
 from datetime import datetime, timezone
 
 import pytest
@@ -10,6 +10,8 @@ from redisvl.index.index import AsyncSearchIndex, SearchIndex
 from redisvl.redis.connection import RedisConnectionFactory
 from redisvl.redis.utils import array_to_buffer
 from redisvl.utils.vectorize import HFTextVectorizer
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
@@ -94,14 +96,18 @@ def redis_cluster_container(worker_id):
         )
 
         if result.returncode != 0:
-            print(f"Docker Compose up failed with exit code {result.returncode}")
+            logger.error(f"Docker Compose up failed with exit code {result.returncode}")
             if result.stdout:
-                print(f"STDOUT: {result.stdout.decode('utf-8', errors='replace')}")
+                logger.error(
+                    f"STDOUT: {result.stdout.decode('utf-8', errors='replace')}"
+                )
             if result.stderr:
-                print(f"STDERR: {result.stderr.decode('utf-8', errors='replace')}")
+                logger.error(
+                    f"STDERR: {result.stderr.decode('utf-8', errors='replace')}"
+                )
 
             # Try to get logs for more details
-            print("Attempting to fetch container logs...")
+            logger.info("Attempting to fetch container logs...")
             try:
                 logs_result = subprocess.run(
                     [
@@ -116,11 +122,11 @@ def redis_cluster_container(worker_id):
                     capture_output=True,
                     text=True,
                 )
-                print("Docker Compose logs:\n", logs_result.stdout)
+                logger.info("Docker Compose logs:\n", logs_result.stdout)
                 if logs_result.stderr:
-                    print("Docker Compose logs stderr:\n", logs_result.stderr)
+                    logger.error("Docker Compose logs stderr:\n", logs_result.stderr)
             except Exception as log_e:
-                print(f"Failed to get Docker Compose logs: {repr(log_e)}")
+                logger.error(f"Failed to get Docker Compose logs: {repr(log_e)}")
 
             # Now raise the exception with the original result
             raise subprocess.CalledProcessError(
@@ -150,7 +156,7 @@ def redis_cluster_container(worker_id):
                 capture_output=True,
             )
         except Exception as e:
-            print(f"Error during cleanup: {repr(e)}")
+            logger.error(f"Error during cleanup: {repr(e)}")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_aggregation.py
+++ b/tests/integration/test_aggregation.py
@@ -1,10 +1,8 @@
 import pytest
-from redis.commands.search.aggregation import AggregateResult
-from redis.commands.search.result import Result
 
 from redisvl.index import SearchIndex
 from redisvl.query import HybridQuery
-from redisvl.query.filter import FilterExpression, Geo, GeoRadius, Num, Tag, Text
+from redisvl.query.filter import Geo, GeoRadius, Num, Tag, Text
 from redisvl.redis.connection import compare_versions
 from redisvl.redis.utils import array_to_buffer
 

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -166,15 +166,18 @@ def test_search_index_no_prefix(index_schema):
 
 @pytest.mark.asyncio
 async def test_search_index_redis_url(redis_url, index_schema):
-    async_index = AsyncSearchIndex(schema=index_schema, redis_url=redis_url)
-    # Client is None until a command is run
-    assert async_index.client is None
+    async with AsyncSearchIndex(
+        schema=index_schema, redis_url=redis_url
+    ) as async_index:
+        # Client is None until a command is run
+        assert async_index.client is None
 
-    # Lazily create the client by running a command
-    await async_index.create(overwrite=True, drop=True)
-    assert async_index.client
+        # Lazily create the client by running a command
+        await async_index.create(overwrite=True, drop=True)
+        assert async_index.client
 
-    await async_index.disconnect()
+    # After exiting async with, if the index owned the client, it should be disconnected
+    # and client attribute should be None again by __aexit__
     assert async_index.client is None
 
 
@@ -186,20 +189,25 @@ async def test_search_index_client(async_client, index_schema):
 
 @pytest.mark.asyncio
 async def test_search_index_set_client(client, redis_url, index_schema):
-    async_index = AsyncSearchIndex(schema=index_schema, redis_url=redis_url)
-    # Ignore deprecation warnings
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        await async_index.create(overwrite=True, drop=True)
-        assert isinstance(async_index.client, AsyncRedis)
+    # Use async with for the index that owns its initial client via redis_url
+    async with AsyncSearchIndex(
+        schema=index_schema, redis_url=redis_url
+    ) as async_index:
+        # Ignore deprecation warnings for set_client
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            await async_index.create(overwrite=True, drop=True)
+            assert isinstance(async_index.client, AsyncRedis)
 
-        # Tests deprecated sync -> async conversion behavior
-        assert isinstance(client, SyncRedis)
-        await async_index.set_client(client)
-        assert isinstance(async_index.client, AsyncRedis)
+            # Tests deprecated sync -> async conversion behavior
+            assert isinstance(client, SyncRedis)
 
-    await async_index.disconnect()
-    assert async_index.client is None
+            await async_index.set_client(client)
+            assert isinstance(async_index.client, AsyncRedis)
+
+            if async_index.client:
+                await async_index.disconnect()
+            assert async_index.client is None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_cross_encoder_reranker.py
+++ b/tests/integration/test_cross_encoder_reranker.py
@@ -1,10 +1,9 @@
 import pytest
-from sentence_transformers import CrossEncoder
 
 from redisvl.utils.rerank.hf_cross_encoder import HFCrossEncoderReranker
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def reranker():
     return HFCrossEncoderReranker()
 

--- a/tests/integration/test_embedcache.py
+++ b/tests/integration/test_embedcache.py
@@ -11,10 +11,10 @@ from redisvl.redis.utils import hashify
 
 
 @pytest.fixture
-def cache(redis_url):
+def cache(redis_url, worker_id):
     """Basic EmbeddingsCache fixture with cleanup."""
     cache_instance = EmbeddingsCache(
-        name="test_embed_cache",
+        name=f"test_embed_cache_{worker_id}",
         redis_url=redis_url,
     )
     yield cache_instance

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import warnings
 from collections import namedtuple
 from time import sleep, time
@@ -15,7 +14,7 @@ from redisvl.query.filter import Num, Tag, Text
 from redisvl.utils.vectorize import HFTextVectorizer
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def vectorizer():
     return HFTextVectorizer("redis/langcache-embed-v1")
 
@@ -820,10 +819,11 @@ def test_complex_filters(cache_with_filters):
     assert len(results) == 1
 
 
-def test_cache_index_overwrite(redis_url, worker_id):
+def test_cache_index_overwrite(redis_url, worker_id, hf_vectorizer):
     cache_no_tags = SemanticCache(
         name=f"test_cache_{worker_id}",
         redis_url=redis_url,
+        vectorizer=hf_vectorizer,
     )
 
     cache_no_tags.store(
@@ -853,12 +853,14 @@ def test_cache_index_overwrite(redis_url, worker_id):
         SemanticCache(
             name=f"test_cache_{worker_id}",
             redis_url=redis_url,
+            vectorizer=hf_vectorizer,
             filterable_fields=[{"name": "some_tag", "type": "tag"}],
         )
 
     cache_overwrite = SemanticCache(
         name=f"test_cache_{worker_id}",
         redis_url=redis_url,
+        vectorizer=hf_vectorizer,
         filterable_fields=[{"name": "some_tag", "type": "tag"}],
         overwrite=True,
     )
@@ -870,10 +872,11 @@ def test_cache_index_overwrite(redis_url, worker_id):
     assert len(response) == 1
 
 
-def test_no_key_collision_on_identical_prompts(redis_url, worker_id):
+def test_no_key_collision_on_identical_prompts(redis_url, worker_id, hf_vectorizer):
     private_cache = SemanticCache(
         name=f"private_cache_{worker_id}",
         redis_url=redis_url,
+        vectorizer=hf_vectorizer,
         filterable_fields=[
             {"name": "user_id", "type": "tag"},
             {"name": "zip_code", "type": "numeric"},
@@ -1000,9 +1003,11 @@ def test_deprecated_dtype_argument(redis_url, worker_id):
 
 
 @pytest.mark.asyncio
-async def test_cache_async_context_manager(redis_url, worker_id):
+async def test_cache_async_context_manager(redis_url, worker_id, hf_vectorizer):
     async with SemanticCache(
-        name=f"test_cache_async_context_manager_{worker_id}", redis_url=redis_url
+        name=f"test_cache_async_context_manager_{worker_id}",
+        redis_url=redis_url,
+        vectorizer=hf_vectorizer,
     ) as cache:
         await cache.astore("test prompt", "test response")
         assert cache._aindex
@@ -1010,11 +1015,14 @@ async def test_cache_async_context_manager(redis_url, worker_id):
 
 
 @pytest.mark.asyncio
-async def test_cache_async_context_manager_with_exception(redis_url, worker_id):
+async def test_cache_async_context_manager_with_exception(
+    redis_url, worker_id, hf_vectorizer
+):
     try:
         async with SemanticCache(
             name=f"test_cache_async_context_manager_with_exception_{worker_id}",
             redis_url=redis_url,
+            vectorizer=hf_vectorizer,
         ) as cache:
             await cache.astore("test prompt", "test response")
             raise ValueError("test")
@@ -1024,18 +1032,22 @@ async def test_cache_async_context_manager_with_exception(redis_url, worker_id):
 
 
 @pytest.mark.asyncio
-async def test_cache_async_disconnect(redis_url, worker_id):
+async def test_cache_async_disconnect(redis_url, worker_id, hf_vectorizer):
     cache = SemanticCache(
-        name=f"test_cache_async_disconnect_{worker_id}", redis_url=redis_url
+        name=f"test_cache_async_disconnect_{worker_id}",
+        redis_url=redis_url,
+        vectorizer=hf_vectorizer,
     )
     await cache.astore("test prompt", "test response")
     await cache.adisconnect()
     assert cache._aindex is None
 
 
-def test_cache_disconnect(redis_url, worker_id):
+def test_cache_disconnect(redis_url, worker_id, hf_vectorizer):
     cache = SemanticCache(
-        name=f"test_cache_disconnect_{worker_id}", redis_url=redis_url
+        name=f"test_cache_disconnect_{worker_id}",
+        redis_url=redis_url,
+        vectorizer=hf_vectorizer,
     )
     cache.store("test prompt", "test response")
     cache.disconnect()

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -149,7 +149,7 @@ def index(sample_data, redis_url, worker_id):
     index = SearchIndex.from_dict(
         {
             "index": {
-                "name": "user_index",
+                "name": f"user_index_{worker_id}",
                 "prefix": f"v1_{worker_id}",
                 "storage_type": "hash",
             },
@@ -201,7 +201,7 @@ def L2_index(sample_data, redis_url, worker_id):
     index = SearchIndex.from_dict(
         {
             "index": {
-                "name": "L2_index",
+                "name": f"L2_index_{worker_id}",
                 "prefix": f"L2_index_{worker_id}",
                 "storage_type": "hash",
             },

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 
 import pytest
@@ -144,13 +145,14 @@ def sorted_range_query():
 
 @pytest.fixture
 def index(sample_data, redis_url, worker_id):
+    unique_id = str(uuid.uuid4())[:8]  # Use first 8 chars of UUID for brevity
 
     # construct a search index from the schema
     index = SearchIndex.from_dict(
         {
             "index": {
-                "name": f"user_index_{worker_id}",
-                "prefix": f"v1_{worker_id}",
+                "name": f"user_index_{worker_id}_{unique_id}",
+                "prefix": f"v1_{worker_id}_{unique_id}",
                 "storage_type": "hash",
             },
             "fields": [
@@ -196,13 +198,14 @@ def index(sample_data, redis_url, worker_id):
 
 @pytest.fixture
 def L2_index(sample_data, redis_url, worker_id):
+    unique_id = str(uuid.uuid4())[:8]  # Use first 8 chars of UUID for brevity
 
     # construct a search index from the schema
     index = SearchIndex.from_dict(
         {
             "index": {
-                "name": f"L2_index_{worker_id}",
-                "prefix": f"L2_index_{worker_id}",
+                "name": f"L2_index_{worker_id}_{unique_id}",
+                "prefix": f"L2_index_{worker_id}_{unique_id}",
                 "storage_type": "hash",
             },
             "fields": [

--- a/tests/integration/test_redis_cluster_support.py
+++ b/tests/integration/test_redis_cluster_support.py
@@ -1,0 +1,174 @@
+"""Tests for Redis Cluster support in RedisVL."""
+
+import pytest
+from redis import Redis
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.cluster import RedisCluster
+
+from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+from redisvl.extensions.router.semantic import Route, SemanticRouter
+from redisvl.index import SearchIndex
+from redisvl.index.index import AsyncSearchIndex
+from redisvl.query.query import TextQuery
+from redisvl.redis.connection import RedisConnectionFactory
+from redisvl.schema import IndexSchema
+
+
+def test_sync_client_validation(redis_url, redis_cluster_url):
+    """Test validation of sync Redis client types."""
+    # Test regular Redis client
+    redis_client = Redis.from_url(redis_url)
+    RedisConnectionFactory.validate_sync_redis(redis_client)
+
+    # Test with RedisCluster client type
+    cluster_client = RedisCluster.from_url(redis_cluster_url)
+    RedisConnectionFactory.validate_sync_redis(cluster_client)
+
+
+@pytest.mark.asyncio
+async def test_async_client_validation(redis_cluster_url):
+    """Test validation of async Redis client types."""
+    async_cluster_client = await RedisConnectionFactory._get_aredis_connection(
+        redis_cluster_url
+    )
+    await RedisConnectionFactory.validate_async_redis(async_cluster_client)
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_conversion_rejects_cluster_client(redis_cluster_url):
+    """Test that sync-to-async conversion rejects RedisCluster clients."""
+    cluster_client = RedisCluster.from_url(redis_cluster_url)
+    with pytest.raises(
+        ValueError, match="RedisCluster is not supported for sync-to-async conversion."
+    ):
+        RedisConnectionFactory.sync_to_async_redis(cluster_client)
+
+
+def test_search_index_cluster_client(redis_cluster_url):
+    """Test that SearchIndex correctly accepts RedisCluster clients."""
+    # Create a simple schema
+    schema = IndexSchema.from_dict(
+        {
+            "index": {"name": "test_cluster_index", "prefix": "test_cluster"},
+            "fields": [
+                {"name": "name", "type": "text"},
+                {"name": "age", "type": "numeric"},
+            ],
+        }
+    )
+
+    cluster_client = RedisCluster.from_url(redis_cluster_url)
+    index = SearchIndex(schema=schema, redis_client=cluster_client)
+    index.create(overwrite=True)
+    index.load([{"name": "test1", "age": 30}])
+    results = index.query(TextQuery("test1", "name"))
+    assert results[0]["name"] == "test1"
+    index.delete(drop=True)
+
+
+@pytest.mark.asyncio
+async def test_async_search_index_client(redis_cluster_url):
+    """Test that AsyncSearchIndex correctly handles AsyncRedis clients."""
+    # Create a simple schema
+    schema = IndexSchema.from_dict(
+        {
+            "index": {"name": "async_test_index", "prefix": "async_test"},
+            "fields": [
+                {"name": "name", "type": "text"},
+                {"name": "age", "type": "numeric"},
+            ],
+        }
+    )
+
+    # Test with AsyncRedis client
+    cluster_client = AsyncRedisCluster.from_url(redis_cluster_url)
+    index = AsyncSearchIndex(schema=schema, redis_client=cluster_client)
+    await index.create(overwrite=True)
+    await index.load([{"name": "async_test", "age": 25}])
+    results = await index.query(TextQuery("async_test", "name"))
+    assert results[0]["name"] == "async_test"
+    await index.delete(drop=True)
+
+
+def test_embeddings_cache_cluster_async(redis_cluster_url):
+    """Test that EmbeddingsCache correctly handles AsyncRedisCluster clients."""
+    cluster_client = RedisConnectionFactory.get_async_redis_cluster_connection(
+        redis_cluster_url
+    )
+    cache = EmbeddingsCache(async_redis_client=cluster_client)
+
+    cache.set(
+        text="hey",
+        model_name="test",
+        embedding=[1, 2, 3],
+    )
+    result = cache.get("hey", "test")
+    assert result is not None
+    assert result["embedding"] == [1, 2, 3]
+    cache.clear()
+
+
+def test_embeddings_cache_cluster_sync(redis_cluster_url):
+    """Test that EmbeddingsCache correctly handles RedisCluster clients."""
+    cluster_client = RedisCluster.from_url(redis_cluster_url)
+    cache = EmbeddingsCache(redis_client=cluster_client)
+
+    for i in range(100):
+        cache.set(
+            text=f"hey_{i}",
+            model_name="test",
+            embedding=[1, 2, 3],
+        )
+    result = cache.get("hey_0", "test")
+    assert result is not None
+    assert result["embedding"] == [1, 2, 3]
+    cache.clear()
+
+    cache.mset(
+        [
+            {"text": "hey_0", "model_name": "test", "embedding": [1, 2, 3]},
+            {"text": "hey_1", "model_name": "test", "embedding": [1, 2, 3]},
+        ]
+    )
+    result = cache.mget(["hey_0", "hey_1"], "test")
+    assert result[0] is not None
+    assert result[1] is not None
+    assert result[0]["embedding"] == [1, 2, 3]
+    assert result[1]["embedding"] == [1, 2, 3]
+    cache.clear()
+
+
+def test_semantic_router_cluster_client(redis_cluster_url, hf_vectorizer):
+    """Test that SemanticRouter works correctly with RedisCluster clients."""
+    routes = [
+        Route(
+            name="General Inquiry",
+            references=["What are your hours?", "Tell me about your services."],
+        ),
+        Route(
+            name="Technical Support",
+            references=[
+                "I have an issue with my account.",
+                "My product is broken.",
+            ],
+        ),
+    ]
+    client = RedisCluster.from_url(redis_cluster_url)
+
+    router_name = "test_cluster_router"
+    router = SemanticRouter(
+        name=router_name,
+        routes=routes,
+        vectorizer=hf_vectorizer,
+        redis_client=client,
+        overwrite=True,
+    )
+
+    query_text = "I need help with my login."
+    matched_route = router(query_text)
+
+    assert matched_route is not None
+    assert matched_route.name == "Technical Support"
+
+    if router._index and router._index.exists():
+        router._index.delete(drop=True)

--- a/tests/integration/test_redis_cluster_support.py
+++ b/tests/integration/test_redis_cluster_support.py
@@ -14,6 +14,7 @@ from redisvl.redis.connection import RedisConnectionFactory
 from redisvl.schema import IndexSchema
 
 
+@pytest.mark.requires_cluster
 def test_sync_client_validation(redis_url, redis_cluster_url):
     """Test validation of sync Redis client types."""
     # Test regular Redis client
@@ -25,6 +26,7 @@ def test_sync_client_validation(redis_url, redis_cluster_url):
     RedisConnectionFactory.validate_sync_redis(cluster_client)
 
 
+@pytest.mark.requires_cluster
 @pytest.mark.asyncio
 async def test_async_client_validation(redis_cluster_url):
     """Test validation of async Redis client types."""
@@ -34,6 +36,7 @@ async def test_async_client_validation(redis_cluster_url):
     await RedisConnectionFactory.validate_async_redis(async_cluster_client)
 
 
+@pytest.mark.requires_cluster
 @pytest.mark.asyncio
 async def test_sync_to_async_conversion_rejects_cluster_client(redis_cluster_url):
     """Test that sync-to-async conversion rejects RedisCluster clients."""
@@ -44,6 +47,7 @@ async def test_sync_to_async_conversion_rejects_cluster_client(redis_cluster_url
         RedisConnectionFactory.sync_to_async_redis(cluster_client)
 
 
+@pytest.mark.requires_cluster
 def test_search_index_cluster_client(redis_cluster_url):
     """Test that SearchIndex correctly accepts RedisCluster clients."""
     # Create a simple schema
@@ -66,6 +70,7 @@ def test_search_index_cluster_client(redis_cluster_url):
     index.delete(drop=True)
 
 
+@pytest.mark.requires_cluster
 @pytest.mark.asyncio
 async def test_async_search_index_client(redis_cluster_url):
     """Test that AsyncSearchIndex correctly handles AsyncRedis clients."""
@@ -94,6 +99,7 @@ async def test_async_search_index_client(redis_cluster_url):
         await cluster_client.aclose()
 
 
+@pytest.mark.requires_cluster
 @pytest.mark.asyncio
 async def test_embeddings_cache_cluster_async(redis_cluster_url):
     """Test that EmbeddingsCache correctly handles AsyncRedisCluster clients."""
@@ -117,6 +123,7 @@ async def test_embeddings_cache_cluster_async(redis_cluster_url):
         await cluster_client.aclose()
 
 
+@pytest.mark.requires_cluster
 def test_embeddings_cache_cluster_sync(redis_cluster_url):
     """Test that EmbeddingsCache correctly handles RedisCluster clients."""
     cluster_client = RedisCluster.from_url(redis_cluster_url)
@@ -147,6 +154,7 @@ def test_embeddings_cache_cluster_sync(redis_cluster_url):
     cache.clear()
 
 
+@pytest.mark.requires_cluster
 def test_semantic_router_cluster_client(redis_cluster_url, hf_vectorizer):
     """Test that SemanticRouter works correctly with RedisCluster clients."""
     routes = [

--- a/tests/integration/test_semantic_router.py
+++ b/tests/integration/test_semantic_router.py
@@ -13,7 +13,6 @@ from redisvl.extensions.router.schema import (
     RoutingConfig,
 )
 from redisvl.redis.connection import compare_versions
-from redisvl.utils.vectorize.text.huggingface import HFTextVectorizer
 
 
 def get_base_path():
@@ -39,13 +38,14 @@ def routes():
 
 
 @pytest.fixture
-def semantic_router(client, routes):
+def semantic_router(client, routes, hf_vectorizer):
     router = SemanticRouter(
         name=f"test-router-{str(ULID())}",
         routes=routes,
         routing_config=RoutingConfig(max_k=2),
         redis_client=client,
         overwrite=False,
+        vectorizer=hf_vectorizer,
     )
     yield router
     router.clear()

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,0 +1,618 @@
+"""
+Unit tests for error handling improvements in RedisVL.
+
+This module tests the enhanced error handling behavior introduced for:
+1. Redis error handling in index operations
+2. CROSSSLOT error detection and messaging
+3. Connection kwargs validation in BaseCache
+4. Router config error handling
+5. Cluster compatibility validation
+"""
+
+import asyncio
+from collections.abc import Mapping
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import redis.exceptions
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.cluster import RedisCluster
+
+from redisvl.exceptions import RedisSearchError
+from redisvl.extensions.cache.base import BaseCache
+from redisvl.extensions.router.semantic import SemanticRouter
+from redisvl.schema import StorageType
+
+
+class TestRedisErrorHandling:
+    """Test enhanced Redis error handling in index operations."""
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_redis_error_in_create_method(self, mock_validate):
+        """Test that Redis errors are caught and re-raised with context."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema
+        schema = Mock(spec=IndexSchema)
+        schema.redis_fields = ["test_field"]
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.prefix = "test:"
+        schema.index.storage_type = StorageType.HASH
+
+        # Create a mock Redis client that raises RedisError
+        mock_client = Mock(spec=Redis)
+        mock_client.ft.return_value.create_index.side_effect = (
+            redis.exceptions.RedisError("Connection failed")
+        )
+        mock_client.execute_command.return_value = []
+
+        index = SearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            index.create()
+
+        error_msg = str(exc_info.value)
+        assert "Failed to create index 'test_index' on Redis" in error_msg
+        assert "Connection failed" in error_msg
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_unexpected_error_in_create_method(self, mock_validate):
+        """Test that unexpected errors are caught and re-raised with context."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema
+        schema = Mock(spec=IndexSchema)
+        schema.redis_fields = ["test_field"]
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.prefix = "test:"
+        schema.index.storage_type = StorageType.HASH
+
+        # Create a mock Redis client that raises unexpected error
+        mock_client = Mock(spec=Redis)
+        mock_client.ft.return_value.create_index.side_effect = ValueError(
+            "Unexpected error"
+        )
+        mock_client.execute_command.return_value = []
+
+        index = SearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            index.create()
+
+        error_msg = str(exc_info.value)
+        assert "Unexpected error creating index 'test_index'" in error_msg
+        assert "Unexpected error" in error_msg
+
+
+class TestCrossSlotErrorHandling:
+    """Test CROSSSLOT error detection and helpful messaging."""
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_crossslot_error_in_search(self, mock_validate):
+        """Test that CROSSSLOT errors in search provide helpful guidance."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and index
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_client = Mock(spec=Redis)
+        crossslot_error = redis.exceptions.ResponseError(
+            "CROSSSLOT Keys in request don't hash to the same slot"
+        )
+        mock_client.ft.return_value.search.side_effect = crossslot_error
+
+        index = SearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            index.search("test query")
+
+        error_msg = str(exc_info.value)
+        assert "Cross-slot error during search" in error_msg
+        assert "hash tags" in error_msg
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_crossslot_error_in_aggregate(self, mock_validate):
+        """Test that CROSSSLOT errors in aggregate provide helpful guidance."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and index
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_client = Mock(spec=Redis)
+        crossslot_error = redis.exceptions.ResponseError(
+            "CROSSSLOT Keys in request don't hash to the same slot"
+        )
+        mock_client.ft.return_value.aggregate.side_effect = crossslot_error
+
+        index = SearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            index.aggregate("test query")
+
+        error_msg = str(exc_info.value)
+        assert "Cross-slot error during aggregation" in error_msg
+        assert "hash tags" in error_msg
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_other_redis_error_in_search(self, mock_validate):
+        """Test that other Redis errors are handled with generic message."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and index
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_client = Mock(spec=Redis)
+        other_error = redis.exceptions.ResponseError("Some other error")
+        mock_client.ft.return_value.search.side_effect = other_error
+
+        index = SearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            index.search("test query")
+
+        error_msg = str(exc_info.value)
+        assert "Error while searching" in error_msg
+        assert "Some other error" in error_msg
+
+
+class TestConnectionKwargsValidation:
+    """Test improved connection_kwargs validation in BaseCache."""
+
+    @pytest.mark.asyncio
+    async def test_connection_kwargs_type_error(self):
+        """Test that invalid connection_kwargs type raises TypeError with helpful message."""
+        cache = BaseCache(
+            name="test_cache",
+            connection_kwargs="not_a_dict",  # type: ignore
+        )
+
+        with pytest.raises(TypeError) as exc_info:
+            await cache._get_async_redis_client()
+
+        error_msg = str(exc_info.value)
+        assert "Expected `connection_kwargs` to be a dictionary" in error_msg
+        assert "{'decode_responses': True}" in error_msg
+        assert "got type: str" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_connection_kwargs_valid_dict(self):
+        """Test that valid connection_kwargs work correctly."""
+        cache = BaseCache(
+            name="test_cache", connection_kwargs={"decode_responses": True}
+        )
+
+        # Mock the RedisConnectionFactory to avoid actual connection
+        with patch(
+            "redisvl.extensions.cache.base.RedisConnectionFactory"
+        ) as mock_factory:
+            mock_client = Mock()
+            mock_factory.get_async_redis_connection.return_value = mock_client
+
+            result = await cache._get_async_redis_client()
+            assert result == mock_client
+            mock_factory.get_async_redis_connection.assert_called_once()
+
+
+class TestRouterConfigErrorHandling:
+    """Test improved router config error handling."""
+
+    def test_router_config_invalid_type_error(self):
+        """Test that invalid router config shows actual received value."""
+        # This simulates the error that would be raised in SemanticRouter.from_existing
+        invalid_router_dict = "not_a_dict"
+
+        with pytest.raises(ValueError) as exc_info:
+            if not isinstance(invalid_router_dict, dict):
+                raise ValueError(
+                    f"No valid router config found for test_router. Received: {invalid_router_dict!r}"
+                )
+
+        error_msg = str(exc_info.value)
+        assert "Received: 'not_a_dict'" in error_msg
+
+    def test_router_config_none_error(self):
+        """Test error message when router config is None."""
+        invalid_router_dict = None
+
+        with pytest.raises(ValueError) as exc_info:
+            if not isinstance(invalid_router_dict, dict):
+                raise ValueError(
+                    f"No valid router config found for test_router. Received: {invalid_router_dict!r}"
+                )
+
+        error_msg = str(exc_info.value)
+        assert "Received: None" in error_msg
+
+    def test_router_config_numeric_error(self):
+        """Test error message when router config is a number."""
+        invalid_router_dict = 42
+
+        with pytest.raises(ValueError) as exc_info:
+            if not isinstance(invalid_router_dict, dict):
+                raise ValueError(
+                    f"No valid router config found for test_router. Received: {invalid_router_dict!r}"
+                )
+
+        error_msg = str(exc_info.value)
+        assert "Received: 42" in error_msg
+
+
+class TestClusterCompatibilityValidation:
+    """Test cluster compatibility validation for drop_documents."""
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_drop_documents_cluster_validation_success(self, mock_validate):
+        """Test that documents with same hash tag work in cluster."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.prefix = "test"
+        schema.index.key_separator = ":"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_cluster_client = Mock(spec=RedisCluster)
+        mock_cluster_client.delete.return_value = 2
+
+        index = SearchIndex(schema=schema, redis_client=mock_cluster_client)
+
+        # These IDs will create keys with the same hash tag
+        ids = ["{user123}:doc1", "{user123}:doc2"]
+
+        result = index.drop_documents(ids)
+        assert result == 2
+        mock_cluster_client.delete.assert_called_once()
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_drop_documents_cluster_validation_failure(self, mock_validate):
+        """Test that documents with different hash tags fail in cluster."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.prefix = "test"
+        schema.index.key_separator = ":"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_cluster_client = Mock(spec=RedisCluster)
+
+        index = SearchIndex(schema=schema, redis_client=mock_cluster_client)
+
+        # These IDs will create keys with different hash tags
+        ids = ["{user123}:doc1", "{user456}:doc2"]
+
+        with pytest.raises(ValueError) as exc_info:
+            index.drop_documents(ids)
+
+        error_msg = str(exc_info.value)
+        assert "All keys must share a hash tag when using Redis Cluster" in error_msg
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_drop_documents_non_cluster_no_validation(self, mock_validate):
+        """Test that non-cluster clients don't perform hash tag validation."""
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and regular Redis client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.prefix = "test"
+        schema.index.key_separator = ":"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_client = Mock(spec=Redis)
+        mock_client.delete.return_value = 2
+
+        index = SearchIndex(schema=schema, redis_client=mock_client)
+
+        # These IDs would fail in cluster, but should work in regular Redis
+        ids = ["{user123}:doc1", "{user456}:doc2"]
+
+        result = index.drop_documents(ids)
+        assert result == 2
+        mock_client.delete.assert_called_once()
+
+
+class TestAsyncErrorHandling:
+    """Test error handling in async methods."""
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_async_redis")
+    @pytest.mark.asyncio
+    async def test_async_crossslot_error_in_search(self, mock_validate):
+        """Test that CROSSSLOT errors in async search provide helpful guidance."""
+        from redisvl.index import AsyncSearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_client = Mock(spec=AsyncRedis)
+        crossslot_error = redis.exceptions.ResponseError(
+            "CROSSSLOT Keys in request don't hash to the same slot"
+        )
+        mock_client.ft.return_value.search.side_effect = crossslot_error
+
+        index = AsyncSearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            await index.search("test query")
+
+        error_msg = str(exc_info.value)
+        assert "Cross-slot error during search" in error_msg
+        assert "hash tags" in error_msg
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_async_redis")
+    @pytest.mark.asyncio
+    async def test_async_crossslot_error_in_aggregate(self, mock_validate):
+        """Test that CROSSSLOT errors in async aggregate provide helpful guidance."""
+        from redisvl.index import AsyncSearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_client = Mock(spec=AsyncRedis)
+        crossslot_error = redis.exceptions.ResponseError(
+            "CROSSSLOT Keys in request don't hash to the same slot"
+        )
+        mock_client.ft.return_value.aggregate.side_effect = crossslot_error
+
+        index = AsyncSearchIndex(schema=schema, redis_client=mock_client)
+
+        with pytest.raises(RedisSearchError) as exc_info:
+            await index.aggregate("test query")
+
+        error_msg = str(exc_info.value)
+        assert "Cross-slot error during aggregation" in error_msg
+        assert "hash tags" in error_msg
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_async_redis")
+    @pytest.mark.asyncio
+    async def test_async_drop_documents_cluster_validation(self, mock_validate):
+        """Test async drop_documents cluster validation."""
+        from unittest.mock import AsyncMock
+
+        from redisvl.index import AsyncSearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and async cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.prefix = "test"
+        schema.index.key_separator = ":"
+        schema.index.storage_type = StorageType.HASH
+
+        # Create a mock that properly inherits from RedisCluster for isinstance check
+        mock_cluster_client = Mock()
+        mock_cluster_client.__class__ = AsyncRedisCluster
+        mock_cluster_client.delete = AsyncMock(return_value=2)
+
+        index = AsyncSearchIndex(schema=schema, redis_client=mock_cluster_client)
+
+        # These IDs will create keys with different hash tags
+        ids = ["{user123}:doc1", "{user456}:doc2"]
+
+        with pytest.raises(ValueError) as exc_info:
+            await index.drop_documents(ids)
+
+        error_msg = str(exc_info.value)
+        assert "All keys must share a hash tag when using Redis Cluster" in error_msg
+
+
+class TestClusterOperationsErrorHandling:
+    """Test error handling for cluster operations."""
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_clear_individual_key_deletion_errors(self, mock_validate):
+        """Test clear method handles individual key deletion errors in cluster."""
+        from unittest.mock import patch
+
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.prefix = "test"
+        schema.index.key_separator = ":"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_cluster_client = Mock(spec=RedisCluster)
+        mock_cluster_client.delete.side_effect = [
+            1,  # First key deletion succeeds
+            redis.exceptions.RedisError("Some cluster error"),  # Second fails
+            1,  # Third succeeds
+        ]
+
+        # Mock the paginate method to return test data
+        with patch.object(SearchIndex, "paginate") as mock_paginate:
+            mock_paginate.return_value = [
+                [{"id": "test:key1"}, {"id": "test:key2"}, {"id": "test:key3"}]
+            ]
+
+            # Create index with mocked client
+            index = SearchIndex(schema)
+            index._SearchIndex__redis_client = mock_cluster_client
+
+            # Test that clear handles individual key deletion errors
+            with patch("redisvl.index.index.logger") as mock_logger:
+                result = index.clear()
+
+                # Should have attempted to delete all 3 keys
+                assert mock_cluster_client.delete.call_count == 3
+                # Should have logged the error for the failed key
+                mock_logger.warning.assert_called_once_with(
+                    "Failed to delete key test:key2: Some cluster error"
+                )
+                # Should return count of successfully deleted keys (2 out of 3)
+                assert result == 2
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_async_redis")
+    @pytest.mark.asyncio
+    async def test_async_clear_individual_key_deletion_errors(self, mock_validate):
+        """Test async clear method handles individual key deletion errors in cluster."""
+        from unittest.mock import AsyncMock, patch
+
+        from redisvl.index import AsyncSearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and async cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.prefix = "test"
+        schema.index.key_separator = ":"
+        schema.index.storage_type = StorageType.HASH
+
+        mock_cluster_client = Mock(spec=AsyncRedisCluster)
+        mock_cluster_client.delete = AsyncMock(
+            side_effect=[
+                1,  # First key deletion succeeds
+                redis.exceptions.RedisError("Some cluster error"),  # Second fails
+                1,  # Third succeeds
+            ]
+        )
+
+        # Mock the paginate method to return test data
+        async def mock_paginate_generator(*args, **kwargs):
+            yield [{"id": "test:key1"}, {"id": "test:key2"}, {"id": "test:key3"}]
+
+        with patch.object(AsyncSearchIndex, "paginate", mock_paginate_generator):
+            # Create index with mocked client
+            index = AsyncSearchIndex(schema)
+            index._redis_client = mock_cluster_client
+
+            # Test that clear handles individual key deletion errors
+            with patch("redisvl.index.index.logger") as mock_logger:
+                result = await index.clear()
+
+                # Should have attempted to delete all 3 keys
+                assert mock_cluster_client.delete.call_count == 3
+                # Should have logged the error for the failed key
+                mock_logger.warning.assert_called_once_with(
+                    "Failed to delete key test:key2: Some cluster error"
+                )
+                # Should return count of successfully deleted keys (2 out of 3)
+                assert result == 2
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_delete_cluster_compatibility(self, mock_validate):
+        """Test delete method uses clear() for cluster compatibility when drop=True."""
+        from unittest.mock import Mock, patch
+
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+
+        mock_cluster_client = Mock(spec=RedisCluster)
+        mock_cluster_client.get_default_node.return_value = Mock()
+
+        # Create index with mocked client
+        index = SearchIndex(schema)
+        index._SearchIndex__redis_client = mock_cluster_client
+
+        # Test that delete() calls clear() first when drop=True in cluster
+        with patch.object(index, "clear") as mock_clear:
+            index.delete(drop=True)
+
+            # Should have called clear() first
+            mock_clear.assert_called_once()
+            # Should have called execute_command with just the index name (no DD flag)
+            mock_cluster_client.execute_command.assert_called_once_with(
+                "FT.DROPINDEX",
+                "test_index",
+                target_nodes=[mock_cluster_client.get_default_node.return_value],
+            )
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis")
+    def test_delete_non_cluster_standard_behavior(self, mock_validate):
+        """Test delete method uses standard behavior for non-cluster Redis."""
+        from unittest.mock import Mock
+
+        from redisvl.index import SearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and regular Redis client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+
+        mock_redis_client = Mock(spec=Redis)
+
+        # Create index with mocked client
+        index = SearchIndex(schema)
+        index._SearchIndex__redis_client = mock_redis_client
+
+        # Test that delete() uses standard behavior for non-cluster
+        index.delete(drop=True)
+
+        # Should have called execute_command with DD flag
+        mock_redis_client.execute_command.assert_called_once_with(
+            "FT.DROPINDEX", "test_index", "DD"
+        )
+
+    @patch("redisvl.redis.connection.RedisConnectionFactory.validate_async_redis")
+    @pytest.mark.asyncio
+    async def test_async_delete_cluster_compatibility(self, mock_validate):
+        """Test async delete method uses clear() for cluster compatibility when drop=True."""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        from redisvl.index import AsyncSearchIndex
+        from redisvl.schema import IndexSchema
+
+        # Create a mock schema and async cluster client
+        schema = Mock(spec=IndexSchema)
+        schema.index = Mock()
+        schema.index.name = "test_index"
+
+        mock_cluster_client = Mock(spec=AsyncRedisCluster)
+        mock_cluster_client.get_default_node.return_value = Mock()
+        mock_cluster_client.execute_command = AsyncMock()
+
+        # Create index with mocked client
+        index = AsyncSearchIndex(schema)
+        index._redis_client = mock_cluster_client
+
+        # Test that delete() calls clear() first when drop=True in cluster
+        with patch.object(index, "clear", new_callable=AsyncMock) as mock_clear:
+            await index.delete(drop=True)
+
+            # Should have called clear() first
+            mock_clear.assert_called_once()
+            # Should have called execute_command with just the index name (no DD flag)
+            mock_cluster_client.execute_command.assert_called_once_with(
+                "FT.DROPINDEX",
+                "test_index",
+                target_nodes=[mock_cluster_client.get_default_node.return_value],
+            )


### PR DESCRIPTION
## Description

This PR introduces **Redis Cluster support** throughout the library by updating internal client abstractions and connection logic. It ensures compatibility with both standalone and clustered Redis deployments.

### Key Changes

- **Redis client compatibility**
  - Upgraded `redis` from `5.2.1` → `6.1.0`, **keeping backwards-compatible support** for 5.x series
  - Replaced explicit `redis.Redis`/`redis.asyncio.Redis` types with union types (`SyncRedisClient`, `AsyncRedisClient`, etc.) in `redisvl.types`
  - Updated all cache, index, and router components to support both standalone and cluster Redis clients (sync and async)

- **Indexing improvements**
  - Cluster-safe implementations for `FT.CREATE`, `FT.SEARCH`, and `FT.DROPINDEX` (supposed to be supported, but redis-py 6.1 still isn't sending these to the default node...)
  - Introduced `cluster_create_index` and `cluster_search` utility functions to help fill these client gaps

- **Connection handling**
  - Refactored `RedisConnectionFactory` to detect and create cluster clients automatically
  - Improved sync-to-async conversion with type checks -- converting a sync Cluster client to async isn't possible because the connection pool works differently

- **Test infrastructure**
  - Added Docker Compose-based Redis Cluster setup for integration tests (`tests/cluster-compose.yml`)
  - New fixtures: `redis_cluster_url`, `cluster_client`
  - New tests validating cluster behavior (`test_redis_cluster_support.py`)
  - Updated tests that were creating new vectorizers unnecessarily to use the existing session-scoped fixtures (cut down API traffic to HF)

- **Other updates**
  - Added `tests/data` to `.gitignore`
  - Removed `types-redis` because its outdated type annotations cause erroneous lint errors
  - Improved TTL and async client cleanup logic
  - Cleaned up types, error handling, and inline documentation

## Gotchas
- I could not get Redis Cluster to come up in CI, only locally, and couldn't determine the problem from stdout/stderr, logs, etc.
- To unblock other work, I've flagged the cluster tests so they run separately, with `--run-cluster-tests`.
- This means Redis Cluster tests are currently turned off in CI

## Why

Supporting Redis Cluster enables RedisVL to operate in **high-availability, horizontally-scalable environments**, making it production-ready for distributed Redis deployments.

This also unblocks us from allowing downstream libraries, such as langgraph-redis, to support Redis Cluster.

## Breaking Changes

- **Dropped**: `types-redis` (not compatible with updated `redis` package)