### PR TITLE
fix: resolve Pydantic model_name field conflict warning

### DIFF
--- a/redisvl/extensions/cache/embeddings/schema.py
+++ b/redisvl/extensions/cache/embeddings/schema.py
@@ -6,7 +6,7 @@ related data structures.
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from redisvl.extensions.constants import EMBEDDING_FIELD_NAME, METADATA_FIELD_NAME
 from redisvl.utils.utils import current_timestamp, deserialize, serialize
@@ -14,6 +14,8 @@ from redisvl.utils.utils import current_timestamp, deserialize, serialize
 
 class CacheEntry(BaseModel):
     """Embedding cache entry data model"""
+
+    model_config = ConfigDict(protected_namespaces=())
 
     entry_id: str
     """Cache entry identifier"""


### PR DESCRIPTION
Add protected_namespaces=() to CacheEntry model config to resolve
UserWarning about field 'model_name' conflicting with protected
namespace 'model_'.

Fixes #371

Generated with [Claude Code](https://claude.ai/code)