### PR TITLE
Fix filter expression being overridden with blank string

### DIFF
--- a/redisvl/query/aggregate.py
+++ b/redisvl/query/aggregate.py
@@ -210,10 +210,9 @@ class HybridQuery(AggregationQuery):
 
     def _build_query_string(self) -> str:
         """Build the full query string for text search with optional filtering."""
+        filter_expression = self._filter_expression
         if isinstance(self._filter_expression, FilterExpression):
             filter_expression = str(self._filter_expression)
-        else:
-            filter_expression = ""
 
         # base KNN query
         knn_query = f"KNN {self._num_results} @{self._vector_field} ${self.VECTOR_PARAM} AS {self.DISTANCE_ID}"
@@ -224,3 +223,7 @@ class HybridQuery(AggregationQuery):
             text += f" AND {filter_expression}"
 
         return f"{text})=>[{knn_query}]"
+
+    def __str__(self) -> str:
+        """Return the string representation of the query."""
+        return " ".join([str(x) for x in self.build_args()])

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -305,7 +305,6 @@ def test_text_query_with_string_filter():
     query_string = str(text_query)
     assert f"@{text_field_name}:(search | document | 12345)" in query_string
     assert f"AND {string_filter}" in query_string
-    assert string_filter in query_string
 
     # Test with FilterExpression - should also work (existing functionality)
     filter_expression = Tag("category") == "tech"


### PR DESCRIPTION
passing a string as filter expression no longer sets the filter to a blank string
