### PR TITLE
fix: handle ClusterPipeline missing nodes_manager attribute (#365)

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -49,7 +49,8 @@ if TYPE_CHECKING:
 
 from redis import __version__ as redis_version
 from redis.client import NEVER_DECODE
-from redis.commands.helpers import get_protocol_version  # type: ignore
+
+from redisvl.utils.redis_protocol import get_protocol_version
 
 # Redis 5.x compatibility (6 fixed the import path)
 if redis_version.startswith("5"):

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -7,7 +7,6 @@ from redis import RedisCluster
 from redis import __version__ as redis_version
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.client import NEVER_DECODE, Pipeline
-from redis.commands.helpers import get_protocol_version
 from redis.commands.search import AsyncSearch, Search
 from redis.commands.search.commands import (
     CREATE_CMD,
@@ -22,6 +21,8 @@ from redis.commands.search.commands import (
     TEMPORARY,
 )
 from redis.commands.search.field import Field
+
+from redisvl.utils.redis_protocol import get_protocol_version
 
 # Redis 5.x compatibility (6 fixed the import path)
 if redis_version.startswith("5"):

--- a/redisvl/utils/redis_protocol.py
+++ b/redisvl/utils/redis_protocol.py
@@ -1,0 +1,95 @@
+"""
+Utilities for handling Redis protocol version detection safely across different client types.
+
+This module provides safe wrappers around redis-py's get_protocol_version function
+to handle edge cases with Redis Cluster pipelines.
+"""
+
+from typing import Union
+
+from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
+from redis.cluster import ClusterPipeline
+from redis.commands.helpers import get_protocol_version as redis_get_protocol_version
+
+from redisvl.utils.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def get_protocol_version(client) -> str:
+    """
+    Wrapper for redis-py's get_protocol_version that handles ClusterPipeline.
+
+    ClusterPipeline doesn't have nodes_manager attribute, so we need to
+    handle this case specially to avoid AttributeError.
+
+    Args:
+        client: Redis client, pipeline, or cluster pipeline object
+
+    Returns:
+        str: Protocol version ("2" or "3")
+
+    Note:
+        This function addresses issue #365 where get_protocol_version() fails
+        with ClusterPipeline objects due to missing nodes_manager attribute.
+    """
+    # Handle sync ClusterPipeline
+    if isinstance(client, ClusterPipeline):
+        try:
+            # Try to get protocol from the underlying cluster client
+            if hasattr(client, "_redis_cluster") and client._redis_cluster:
+                try:
+                    result = redis_get_protocol_version(client._redis_cluster)
+                    if result is not None:
+                        return result
+                except (AttributeError, Exception):
+                    # If anything fails, fall back to default
+                    pass
+
+            logger.debug(
+                "ClusterPipeline without valid _redis_cluster, defaulting to protocol 3"
+            )
+            return "3"
+        except AttributeError as e:
+            logger.debug(
+                f"Failed to get protocol version from ClusterPipeline: {e}, defaulting to protocol 3"
+            )
+            return "3"
+
+    # Handle async ClusterPipeline
+    if isinstance(client, AsyncClusterPipeline):
+        try:
+            # Try to get protocol from the underlying cluster client
+            if hasattr(client, "_redis_cluster") and client._redis_cluster:
+                try:
+                    result = redis_get_protocol_version(client._redis_cluster)
+                    if result is not None:
+                        return result
+                except (AttributeError, Exception):
+                    # If anything fails, fall back to default
+                    pass
+
+            logger.debug(
+                "AsyncClusterPipeline without valid _redis_cluster, defaulting to protocol 3"
+            )
+            return "3"
+        except AttributeError as e:
+            logger.debug(
+                f"Failed to get protocol version from AsyncClusterPipeline: {e}, defaulting to protocol 3"
+            )
+            return "3"
+
+    # For all other client types, use the standard function
+    try:
+        result = redis_get_protocol_version(client)
+        if result is None:
+            logger.warning(
+                f"get_protocol_version returned None for client {type(client)}, defaulting to protocol 3"
+            )
+            return "3"
+        return result
+    except AttributeError as e:
+        logger.warning(
+            f"Failed to get protocol version from client {type(client)}: {e}, defaulting to protocol 3"
+        )
+        return "3"

--- a/tests/integration/test_cluster_pipelining.py
+++ b/tests/integration/test_cluster_pipelining.py
@@ -1,0 +1,142 @@
+"""
+Integration test for issue #365: ClusterPipeline AttributeError fix
+https://github.com/redis/redis-vl-python/issues/365
+
+This test verifies that the safe_get_protocol_version fix prevents the
+AttributeError: 'ClusterPipeline' object has no attribute 'nodes_manager'
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
+from redis.cluster import ClusterPipeline
+
+from redisvl.index import SearchIndex
+from redisvl.query import FilterQuery
+from redisvl.schema import IndexSchema
+from redisvl.utils.redis_protocol import get_protocol_version
+
+
+def test_pipeline_operations_no_nodes_manager_error(redis_url):
+    """
+    Test that pipeline operations don't fail with nodes_manager AttributeError.
+
+    Before the fix, operations that use get_protocol_version() internally would fail
+    with AttributeError when using ClusterPipeline. This test ensures those operations
+    now work without that specific error.
+    """
+    # Create a simple schema
+    schema_dict = {
+        "index": {"name": "test-365-fix", "prefix": "doc", "storage_type": "hash"},
+        "fields": [{"name": "id", "type": "tag"}, {"name": "text", "type": "text"}],
+    }
+
+    schema = IndexSchema.from_dict(schema_dict)
+    index = SearchIndex(schema, redis_url=redis_url)
+
+    # Create the index
+    index.create(overwrite=True)
+
+    try:
+        # Test 1: Load with batching (uses pipelines internally)
+        test_data = [{"id": f"item{i}", "text": f"Document {i}"} for i in range(10)]
+
+        # This would fail with AttributeError before the fix
+        keys = index.load(
+            data=test_data,
+            id_field="id",
+            batch_size=3,  # Force multiple pipeline operations
+        )
+
+        assert len(keys) == 10
+
+        # Test 2: Batch search (uses safe_get_protocol_version internally)
+        queries = [FilterQuery(filter_expression=f"@id:{{item{i}}}") for i in range(3)]
+
+        try:
+            # The critical test: no AttributeError about nodes_manager
+            results = index.batch_search(queries, batch_size=2)
+            assert len(results) == 3
+        except Exception as e:
+            # If there's an error, it must NOT be the nodes_manager AttributeError
+            assert "nodes_manager" not in str(
+                e
+            ), f"Got nodes_manager error which indicates fix isn't working: {e}"
+
+        # Test 3: TTL operations
+        try:
+            index.expire_keys(keys[:3], 3600)
+        except Exception as e:
+            # Again, ensure no nodes_manager error
+            assert "nodes_manager" not in str(e)
+
+    finally:
+        index.delete()
+
+
+def test_json_storage_no_error(redis_url):
+    """Test with JSON storage type."""
+    schema_dict = {
+        "index": {"name": "test-365-json", "prefix": "json", "storage_type": "json"},
+        "fields": [{"name": "id", "type": "tag"}, {"name": "data", "type": "text"}],
+    }
+
+    schema = IndexSchema.from_dict(schema_dict)
+    index = SearchIndex(schema, redis_url=redis_url)
+
+    index.create(overwrite=True)
+
+    try:
+        # Load test data
+        test_data = [{"id": f"doc{i}", "data": f"Document {i}"} for i in range(5)]
+
+        # Should work without nodes_manager AttributeError
+        keys = index.load(data=test_data, id_field="id", batch_size=2)
+
+        assert len(keys) == 5
+
+    finally:
+        index.delete()
+
+
+def test_clusterpipeline_with_valid_redis_cluster_attribute():
+    """
+    Test get_protocol_version when ClusterPipeline has _redis_cluster attribute.
+    """
+    # Create mock ClusterPipeline with _redis_cluster attribute
+    mock_pipeline = Mock(spec=ClusterPipeline)
+    mock_cluster = Mock()
+    mock_cluster.nodes_manager.connection_kwargs.get.return_value = "3"
+    mock_pipeline._redis_cluster = mock_cluster
+
+    # Should successfully get protocol from _redis_cluster
+    result = get_protocol_version(mock_pipeline)
+    assert result == "3"
+
+
+def test_clusterpipeline_with_none_redis_cluster():
+    """
+    Test get_protocol_version when _redis_cluster is None.
+    """
+    mock_pipeline = Mock(spec=ClusterPipeline)
+    mock_pipeline._redis_cluster = None
+
+    # Should fallback to "3"
+    result = get_protocol_version(mock_pipeline)
+    assert result == "3"
+
+
+def test_async_clusterpipeline_without_nodes_manager():
+    """
+    Test get_protocol_version with AsyncClusterPipeline missing nodes_manager.
+    """
+    mock_pipeline = Mock(spec=AsyncClusterPipeline)
+    # Ensure no nodes_manager attribute
+    if hasattr(mock_pipeline, "nodes_manager"):
+        delattr(mock_pipeline, "nodes_manager")
+    mock_pipeline._redis_cluster = None
+
+    # Should fallback to "3" without error
+    result = get_protocol_version(mock_pipeline)
+    assert result == "3"

--- a/tests/unit/test_cluster_pipeline_nodes_manager.py
+++ b/tests/unit/test_cluster_pipeline_nodes_manager.py
@@ -1,0 +1,319 @@
+"""
+Unit tests for issue #365: ClusterPipeline AttributeError
+https://github.com/redis/redis-vl-python/issues/365
+
+The issue reports that index.load() fails with:
+AttributeError: 'ClusterPipeline' object has no attribute 'nodes_manager'
+when using Redis Cluster.
+
+The error occurs specifically in get_protocol_version() function from redis-py
+when called with a ClusterPipeline object.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from redis.cluster import ClusterPipeline
+from redis.commands.helpers import get_protocol_version
+
+from redisvl.index import SearchIndex
+from redisvl.schema import IndexSchema
+
+
+class TestClusterPipelineNodeManagerIssue:
+    """Unit tests for ClusterPipeline AttributeError issue #365."""
+
+    def test_get_protocol_version_with_cluster_pipeline_error(self):
+        """
+        Test that reproduces the get_protocol_version() error with ClusterPipeline.
+
+        This test directly calls get_protocol_version() with a ClusterPipeline object
+        to reproduce the AttributeError: 'ClusterPipeline' object has no attribute 'nodes_manager'.
+        """
+        # Create a mock ClusterPipeline that doesn't have nodes_manager attribute
+        mock_pipeline = Mock(spec=ClusterPipeline)
+        # Ensure nodes_manager attribute doesn't exist
+        del mock_pipeline.nodes_manager
+
+        # This should trigger the AttributeError
+        with pytest.raises(
+            AttributeError, match="Mock object has no attribute 'nodes_manager'"
+        ):
+            get_protocol_version(mock_pipeline)
+
+    def test_get_protocol_version_cluster_pipeline_missing_nodes_manager(self):
+        """
+        Test get_protocol_version() fails when ClusterPipeline lacks nodes_manager.
+        """
+        # Create actual ClusterPipeline mock with specific behavior
+        mock_pipeline = Mock()
+        mock_pipeline.__class__ = ClusterPipeline
+
+        # Remove nodes_manager to simulate the actual issue
+        if hasattr(mock_pipeline, "nodes_manager"):
+            delattr(mock_pipeline, "nodes_manager")
+
+        # The error occurs when trying to access nodes_manager.connection_kwargs
+        with pytest.raises(AttributeError):
+            get_protocol_version(mock_pipeline)
+
+    def test_search_index_demonstrates_cluster_pipeline_issue_before_fix(self):
+        """
+        Test that demonstrates the issue before the fix was applied.
+        This test shows what would happen if we still used get_protocol_version directly.
+        """
+        from redis.cluster import ClusterPipeline
+        from redis.commands.helpers import get_protocol_version
+
+        # Mock the ClusterPipeline without nodes_manager
+        mock_client = Mock(spec=ClusterPipeline)
+        if hasattr(mock_client, "nodes_manager"):
+            delattr(mock_client, "nodes_manager")
+
+        # This would fail with the original get_protocol_version
+        with pytest.raises(
+            AttributeError, match="Mock object has no attribute 'nodes_manager'"
+        ):
+            get_protocol_version(mock_client)
+
+    def test_proposed_fix_get_protocol_version_wrapper(self):
+        """
+        Test a proposed fix that wraps get_protocol_version to handle ClusterPipeline safely.
+        """
+        from redis.cluster import ClusterPipeline
+
+        def get_protocol_version(client):
+            """
+            Safe wrapper for get_protocol_version that handles ClusterPipeline.
+
+            ClusterPipeline doesn't have nodes_manager attribute, so we need to
+            get the protocol version from the underlying cluster client.
+            """
+            if isinstance(client, ClusterPipeline):
+                # For ClusterPipeline, try to get protocol from the cluster client
+                if hasattr(client, "_redis_cluster") and client._redis_cluster:
+                    return get_protocol_version(client._redis_cluster)
+                else:
+                    # Fallback to protocol 3 if we can't determine
+                    return "3"
+            else:
+                return get_protocol_version(client)
+
+        # Test with regular client (should work normally)
+        mock_regular_client = Mock()
+        mock_regular_client.nodes_manager.connection_kwargs.get.return_value = "3"
+
+        # Test with ClusterPipeline (should use fallback)
+        mock_pipeline = Mock(spec=ClusterPipeline)
+        if hasattr(mock_pipeline, "nodes_manager"):
+            delattr(mock_pipeline, "nodes_manager")
+
+        # Test the safe wrapper
+        result = get_protocol_version(mock_pipeline)
+        assert result == "3"  # Should fallback to protocol 3
+
+        # Test with pipeline that has _redis_cluster - simplified test
+        mock_pipeline_with_cluster = Mock(spec=ClusterPipeline)
+        if hasattr(mock_pipeline_with_cluster, "nodes_manager"):
+            delattr(mock_pipeline_with_cluster, "nodes_manager")
+        mock_pipeline_with_cluster._redis_cluster = None  # No cluster client available
+
+        # Should still fallback gracefully
+        result = get_protocol_version(mock_pipeline_with_cluster)
+        assert result == "3"  # Should fallback to protocol 3
+
+    def test_get_protocol_version_import_and_usage(self):
+        """
+        Test that the get_protocol_version function can be imported and used
+        as a replacement for get_protocol_version in the fixed code.
+        """
+        from redis.cluster import ClusterPipeline
+
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        # Test with ClusterPipeline mock
+        mock_pipeline = Mock(spec=ClusterPipeline)
+        if hasattr(mock_pipeline, "nodes_manager"):
+            delattr(mock_pipeline, "nodes_manager")
+
+        # This should not raise an exception anymore
+        result = get_protocol_version(mock_pipeline)
+        assert result == "3"  # Should fallback to protocol 3
+
+    def test_get_protocol_version_works_with_mocked_cluster_pipeline(self):
+        """
+        Test that get_protocol_version works with a mocked ClusterPipeline.
+        This demonstrates the fix working without needing SearchIndex integration.
+        """
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        # Mock the redis client to be a ClusterPipeline without nodes_manager
+        mock_client = Mock()
+        mock_client.__class__ = ClusterPipeline
+        if hasattr(mock_client, "nodes_manager"):
+            delattr(mock_client, "nodes_manager")
+
+        # Now test that get_protocol_version works without error
+        protocol_version = get_protocol_version(mock_client)
+        assert protocol_version == "3"  # Should fallback gracefully
+
+        # The safe version should not raise AttributeError
+        # This demonstrates the fix working
+        assert protocol_version in ["2", "3"]
+
+    def test_clusterpipeline_with_redis_cluster_returning_resp2(self):
+        """
+        Test ClusterPipeline with _redis_cluster that returns RESP2 protocol.
+        """
+        from unittest.mock import patch
+
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        mock_pipeline = Mock(spec=ClusterPipeline)
+        mock_cluster = Mock()
+        mock_pipeline._redis_cluster = mock_cluster
+
+        # Mock redis_get_protocol_version to return "2" when called with mock_cluster
+        with patch(
+            "redisvl.utils.redis_protocol.redis_get_protocol_version"
+        ) as mock_get:
+            mock_get.return_value = "2"
+            result = get_protocol_version(mock_pipeline)
+            assert result == "2"
+            mock_get.assert_called_once_with(mock_cluster)
+
+    def test_async_clusterpipeline_without_nodes_manager(self):
+        """
+        Test AsyncClusterPipeline without nodes_manager attribute.
+        """
+        from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
+
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        mock_pipeline = Mock(spec=AsyncClusterPipeline)
+        if hasattr(mock_pipeline, "nodes_manager"):
+            delattr(mock_pipeline, "nodes_manager")
+        mock_pipeline._redis_cluster = None
+
+        # Should fallback to "3" for async pipelines
+        result = get_protocol_version(mock_pipeline)
+        assert result == "3"
+
+    def test_async_clusterpipeline_with_valid_cluster(self):
+        """
+        Test AsyncClusterPipeline with valid _redis_cluster attribute.
+        """
+        from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
+
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        mock_pipeline = Mock(spec=AsyncClusterPipeline)
+        mock_cluster = Mock()
+        mock_cluster.nodes_manager.connection_kwargs.get.return_value = "3"
+        mock_pipeline._redis_cluster = mock_cluster
+
+        result = get_protocol_version(mock_pipeline)
+        assert result == "3"
+
+    def test_exception_during_protocol_detection(self):
+        """
+        Test that exceptions during protocol detection are handled gracefully.
+        """
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        mock_pipeline = Mock(spec=ClusterPipeline)
+        mock_cluster = Mock()
+        # Simulate exception when accessing connection_kwargs
+        mock_cluster.nodes_manager.connection_kwargs.get.side_effect = RuntimeError(
+            "Connection error"
+        )
+        mock_pipeline._redis_cluster = mock_cluster
+
+        # Should not raise, should fallback to "3"
+        result = get_protocol_version(mock_pipeline)
+        assert result == "3"
+
+    def test_regular_redis_client_passthrough(self):
+        """
+        Test that regular Redis clients pass through to standard get_protocol_version.
+        """
+        from unittest.mock import patch
+
+        from redis import Redis
+
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        mock_client = Mock(spec=Redis)
+
+        # Mock redis_get_protocol_version to return "2" for regular clients
+        with patch(
+            "redisvl.utils.redis_protocol.redis_get_protocol_version"
+        ) as mock_get:
+            mock_get.return_value = "2"
+            result = get_protocol_version(mock_client)
+            assert result == "2"
+            mock_get.assert_called_once_with(mock_client)
+
+    def test_none_client_handling(self):
+        """
+        Test handling of None as client parameter.
+        """
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        # Should handle None gracefully
+        result = get_protocol_version(None)
+        assert result == "3"  # Should fallback
+
+    def test_integer_protocol_version_handling(self):
+        """
+        Test handling of integer protocol versions (instead of strings).
+        """
+        from unittest.mock import patch
+
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        mock_client = Mock()
+
+        # Mock redis_get_protocol_version to return integer 3
+        with patch(
+            "redisvl.utils.redis_protocol.redis_get_protocol_version"
+        ) as mock_get:
+            mock_get.return_value = 3
+            result = get_protocol_version(mock_client)
+            assert result == 3  # Should handle integer return
+
+    def test_clusterpipeline_attribute_chain_partial(self):
+        """
+        Test ClusterPipeline with incomplete attribute chains.
+        """
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        # Test with _redis_cluster having no nodes_manager
+        mock_pipeline = Mock(spec=ClusterPipeline)
+        mock_cluster = Mock()
+        delattr(mock_cluster, "nodes_manager")
+        mock_pipeline._redis_cluster = mock_cluster
+
+        result = get_protocol_version(mock_pipeline)
+        assert result == "3"  # Should fallback
+
+    def test_multiple_fallback_scenarios(self):
+        """
+        Test that multiple types of failures all fallback correctly.
+        """
+        from redisvl.utils.redis_protocol import get_protocol_version
+
+        test_cases = [
+            # ClusterPipeline with no _redis_cluster
+            (Mock(spec=ClusterPipeline), "3"),
+            # ClusterPipeline with None _redis_cluster
+            (Mock(spec=ClusterPipeline, _redis_cluster=None), "3"),
+            # Unknown client type
+            (Mock(), "3"),
+            # String client (edge case)
+            ("not_a_client", "3"),
+        ]
+
+        for client, expected in test_cases:
+            result = get_protocol_version(client)
+            assert result == expected


### PR DESCRIPTION
  - Add get_protocol_version wrapper to safely handle ClusterPipeline objects
  - ClusterPipeline objects lack nodes_manager attribute, causing AttributeError
  - Fallback to protocol "3" when unable to detect version from cluster pipelines
  - Handle both sync and async ClusterPipeline cases

  Fixes #365