### PR TITLE
Voyageai refactoring and multimodal capability

### DIFF
--- a/redisvl/utils/vectorize/voyageai.py
+++ b/redisvl/utils/vectorize/voyageai.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
@@ -12,6 +13,9 @@ from redisvl.utils.vectorize.base import BaseVectorizer
 
 # ignore that voyageai isn't imported
 # mypy: disable-error-code="name-defined"
+
+# Sentinel used to detect when model is not explicitly passed to __init__
+_MODEL_NOT_SET = object()
 
 # Token limits for VoyageAI models (used for token-aware batching)
 VOYAGE_TOTAL_TOKEN_LIMITS = {
@@ -128,7 +132,7 @@ class VoyageAIVectorizer(BaseVectorizer):
 
     def __init__(
         self,
-        model: str = "voyage-3-large",
+        model: str = _MODEL_NOT_SET,  # type: ignore[assignment]
         api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
         cache: "EmbeddingsCache | None" = None,
@@ -140,6 +144,8 @@ class VoyageAIVectorizer(BaseVectorizer):
 
         Args:
             model (str): Model to use for embedding. Defaults to "voyage-3-large".
+                The default will be removed in the next major version; please specify
+                the model explicitly.
             api_config (Optional[Dict], optional): Dictionary containing the API key.
                 Defaults to None.
             dtype (str): the default datatype to use when embedding content as byte arrays.
@@ -157,6 +163,16 @@ class VoyageAIVectorizer(BaseVectorizer):
                 ffmpeg installed on the system. Image embeddings require pillow to be installed.
 
         """
+        if model is _MODEL_NOT_SET:
+            warnings.warn(
+                "Instantiating VoyageAIVectorizer without an explicit 'model' "
+                "parameter is deprecated. The default ('voyage-3-large') will be "
+                "removed in the next major version. Please pass model='voyage-3-large' "
+                "(or your preferred model) explicitly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            model = "voyage-3-large"
         super().__init__(model=model, dtype=dtype, cache=cache)
         # Initialize client and set up the model
         self._setup(api_config, **kwargs)
@@ -353,7 +369,9 @@ class VoyageAIVectorizer(BaseVectorizer):
         Args:
             contents: List of items to embed - each item must be one of str, PIL.Image.Image, or
                 voyageai.video_utils.Video. Images and video require a multimodal model to be configured.
-            batch_size: Number of items to process in each API call
+            batch_size: Deprecated. Number of items to process in each API call.
+                Batch size is now determined automatically based on the model.
+                This parameter will be removed in the next major version.
             **kwargs: Additional parameters to pass to the VoyageAI API
 
         Returns:
@@ -371,8 +389,17 @@ class VoyageAIVectorizer(BaseVectorizer):
         # Validate inputs
         self._validate_input(contents, input_type, truncation)
 
-        # Determine batch size if not provided
-        if batch_size is None:
+        # Determine batch size - auto-determined based on model; explicit
+        # batch_size is deprecated.
+        if batch_size is not None:
+            warnings.warn(
+                "The 'batch_size' parameter is deprecated for VoyageAIVectorizer. "
+                "Batch size is now automatically determined based on the model's "
+                "token limits. This parameter will be removed in the next major version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
             batch_size = self._get_batch_size()
 
         try:
@@ -428,7 +455,9 @@ class VoyageAIVectorizer(BaseVectorizer):
         Args:
             contents: List of items to embed - each item must be one of str, PIL.Image.Image, or
                 voyageai.video_utils.Video. Images and video require a multimodal model to be configured.
-            batch_size: Number of texts to process in each API call
+            batch_size: Deprecated. Number of texts to process in each API call.
+                Batch size is now determined automatically based on the model.
+                This parameter will be removed in the next major version.
             **kwargs: Additional parameters to pass to the VoyageAI API
 
         Returns:
@@ -446,8 +475,17 @@ class VoyageAIVectorizer(BaseVectorizer):
         # Validate inputs
         self._validate_input(contents, input_type, truncation)
 
-        # Determine batch size if not provided
-        if batch_size is None:
+        # Determine batch size - auto-determined based on model; explicit
+        # batch_size is deprecated.
+        if batch_size is not None:
+            warnings.warn(
+                "The 'batch_size' parameter is deprecated for VoyageAIVectorizer. "
+                "Batch size is now automatically determined based on the model's "
+                "token limits. This parameter will be removed in the next major version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
             batch_size = self._get_batch_size()
 
         try:
@@ -495,17 +533,20 @@ class VoyageAIVectorizer(BaseVectorizer):
         """
         return "context" in self.model
 
-    def count_tokens(self, texts: List[str]) -> List[int]:
+    def count_tokens(self, texts: list[str]) -> list[int]:
         """
-        Count tokens for the given texts using VoyageAI's tokenization API.
+        Count tokens for the given texts using VoyageAI's local tokenizer.
 
-        This is useful for managing API usage and optimizing batching strategies.
+        This method runs entirely on the CPU using the HuggingFace ``tokenizers``
+        library — it does NOT make any network/API calls. It is safe to call
+        frequently (e.g., for token-aware batching) without incurring API costs
+        or latency.
 
         Args:
             texts: List of texts to count tokens for.
 
         Returns:
-            List[int]: List of token counts for each text.
+            list[int]: List of token counts for each text.
 
         Raises:
             ValueError: If tokenization fails.
@@ -519,25 +560,27 @@ class VoyageAIVectorizer(BaseVectorizer):
             return []
 
         try:
+            # tokenize() is a local CPU operation using HuggingFace tokenizers,
+            # not a remote API call.
             token_lists = self._client.tokenize(texts, model=self.model)
             return [len(token_list) for token_list in token_lists]
         except Exception as e:
             raise ValueError(f"Token counting failed: {e}")
 
-    async def acount_tokens(self, texts: List[str]) -> List[int]:
+    async def acount_tokens(self, texts: list[str]) -> list[int]:
         """
-        Asynchronously count tokens for the given texts using VoyageAI's tokenization API.
+        Asynchronously count tokens for the given texts using VoyageAI's local tokenizer.
 
-        This is useful for managing API usage and optimizing batching strategies.
-
-        Note: The underlying VoyageAI tokenize API is synchronous, so this method
-        provides async compatibility but doesn't offer true async performance benefits.
+        This method runs entirely on the CPU using the HuggingFace ``tokenizers``
+        library — it does NOT make any network/API calls. The underlying
+        tokenize operation is synchronous (CPU-bound), so this async wrapper
+        provides interface compatibility but does not yield to the event loop.
 
         Args:
             texts: List of texts to count tokens for.
 
         Returns:
-            List[int]: List of token counts for each text.
+            list[int]: List of token counts for each text.
 
         Raises:
             ValueError: If tokenization fails.
@@ -551,7 +594,8 @@ class VoyageAIVectorizer(BaseVectorizer):
             return []
 
         try:
-            # Note: VoyageAI's tokenize is synchronous even on AsyncClient
+            # tokenize() is a local CPU operation (HuggingFace tokenizers),
+            # not a remote API call. Synchronous even on AsyncClient.
             token_lists = self._aclient.tokenize(texts, model=self.model)
             return [len(token_list) for token_list in token_lists]
         except Exception as e:

--- a/tests/integration/test_vectorizers.py
+++ b/tests/integration/test_vectorizers.py
@@ -646,3 +646,70 @@ def test_deprecated_text_parameter_warning():
         embeddings = vectorizer.embed_many(texts=TEST_TEXTS)
     assert isinstance(embeddings, list)
     assert len(embeddings) == len(TEST_TEXTS)
+
+
+# VoyageAI-specific tests for token counting and context model detection
+@pytest.mark.requires_api_keys
+def test_voyageai_count_tokens():
+    """Test VoyageAI token counting functionality."""
+    vectorizer = VoyageAIVectorizer(model="voyage-3.5")
+    texts = ["Hello world", "This is a longer test sentence."]
+
+    token_counts = vectorizer.count_tokens(texts)
+    assert isinstance(token_counts, list)
+    assert len(token_counts) == len(texts)
+    assert all(isinstance(count, int) and count > 0 for count in token_counts)
+
+    # Empty list should return empty list
+    assert vectorizer.count_tokens([]) == []
+
+
+@pytest.mark.requires_api_keys
+@pytest.mark.asyncio
+async def test_voyageai_acount_tokens():
+    """Test VoyageAI async token counting functionality."""
+    vectorizer = VoyageAIVectorizer(model="voyage-3.5")
+    texts = ["Hello world", "This is a longer test sentence."]
+
+    token_counts = await vectorizer.acount_tokens(texts)
+    assert isinstance(token_counts, list)
+    assert len(token_counts) == len(texts)
+    assert all(isinstance(count, int) and count > 0 for count in token_counts)
+
+    # Empty list should return empty list
+    assert await vectorizer.acount_tokens([]) == []
+
+
+def test_voyageai_token_limits():
+    """Test VoyageAI token limit constants."""
+    from redisvl.utils.vectorize.voyageai import VOYAGE_TOTAL_TOKEN_LIMITS
+
+    # Verify token limits are defined correctly
+    assert VOYAGE_TOTAL_TOKEN_LIMITS.get("voyage-context-3") == 32_000
+    assert VOYAGE_TOTAL_TOKEN_LIMITS.get("voyage-3.5-lite") == 1_000_000
+    assert VOYAGE_TOTAL_TOKEN_LIMITS.get("voyage-3.5") == 320_000
+    assert VOYAGE_TOTAL_TOKEN_LIMITS.get("voyage-multimodal-3") == 32_000
+    assert VOYAGE_TOTAL_TOKEN_LIMITS.get("voyage-multimodal-3.5") == 32_000
+
+    # Default for unknown models
+    assert VOYAGE_TOTAL_TOKEN_LIMITS.get("unknown-model", 120_000) == 120_000
+
+
+def test_voyageai_context_model_detection():
+    """Test detection of contextualized embedding models."""
+    # Test the context model detection logic directly
+    # The method checks if "context" is in the model name
+    assert "context" not in "voyage-3.5"
+    assert "context" in "voyage-context-3"
+    assert "context" not in "voyage-multimodal-3.5"
+
+    # Verify the detection would work correctly for known models
+    test_cases = [
+        ("voyage-3.5", False),
+        ("voyage-context-3", True),
+        ("voyage-multimodal-3.5", False),
+        ("voyage-3-large", False),
+    ]
+    for model_name, expected in test_cases:
+        # The _is_context_model method simply checks: "context" in self.model
+        assert ("context" in model_name) == expected, f"Failed for {model_name}"

--- a/tests/integration/test_vectorizers.py
+++ b/tests/integration/test_vectorizers.py
@@ -713,3 +713,113 @@ def test_voyageai_context_model_detection():
     for model_name, expected in test_cases:
         # The _is_context_model method simply checks: "context" in self.model
         assert ("context" in model_name) == expected, f"Failed for {model_name}"
+
+
+@pytest.mark.requires_api_keys
+def test_voyageai_multimodal_text_only():
+    """Test VoyageAI multimodal vectorizer with text-only input."""
+    vectorizer = VoyageAIVectorizer(model="voyage-multimodal-3")
+
+    # Test single text embedding via embed()
+    embedding = vectorizer.embed("A red apple on a wooden table")
+    assert isinstance(embedding, list)
+    assert len(embedding) > 0
+    assert all(isinstance(x, float) for x in embedding)
+
+    # Test another text embedding to verify consistency
+    embedding2 = vectorizer.embed("A cat sleeping on a couch")
+    assert isinstance(embedding2, list)
+    assert len(embedding2) == len(embedding)
+
+
+@pytest.mark.requires_api_keys
+def test_voyageai_multimodal_image():
+    """Test VoyageAI multimodal vectorizer with image input."""
+    import os
+    import tempfile
+
+    from PIL import Image
+
+    vectorizer = VoyageAIVectorizer(model="voyage-multimodal-3")
+
+    # Create a simple test image
+    img = Image.new("RGB", (100, 100), color="red")
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        img.save(f, format="PNG")
+        temp_path = f.name
+
+    try:
+        # Test embed_image
+        embedding = vectorizer.embed_image(temp_path)
+        assert isinstance(embedding, list)
+        assert len(embedding) > 0
+        assert all(isinstance(x, float) for x in embedding)
+    finally:
+        os.unlink(temp_path)
+
+
+@pytest.mark.requires_api_keys
+def test_voyageai_multimodal_video():
+    """Test VoyageAI multimodal vectorizer with video input."""
+    import os
+    import subprocess
+    import tempfile
+
+    from PIL import Image
+
+    vectorizer = VoyageAIVectorizer(model="voyage-multimodal-3.5")
+
+    # Create a minimal test video using ffmpeg
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create 3 frames
+        for i in range(3):
+            img = Image.new("RGB", (64, 64), color=(i * 80, 100, 150))
+            img.save(os.path.join(tmpdir, f"frame_{i:03d}.png"))
+
+        video_path = os.path.join(tmpdir, "test_video.mp4")
+
+        # Create video from frames
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-framerate",
+                "1",
+                "-i",
+                os.path.join(tmpdir, "frame_%03d.png"),
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-t",
+                "3",
+                video_path,
+            ],
+            capture_output=True,
+        )
+
+        if result.returncode != 0:
+            pytest.skip("ffmpeg not available or failed to create test video")
+
+        # Test embed_video
+        embedding = vectorizer.embed_video(video_path)
+        assert isinstance(embedding, list)
+        assert len(embedding) > 0
+        assert all(isinstance(x, float) for x in embedding)
+
+
+@pytest.mark.requires_api_keys
+@pytest.mark.asyncio
+async def test_voyageai_multimodal_async():
+    """Test VoyageAI multimodal vectorizer async methods."""
+    vectorizer = VoyageAIVectorizer(model="voyage-multimodal-3")
+
+    # Test async text embedding
+    embedding = await vectorizer.aembed("A beautiful sunset over mountains")
+    assert isinstance(embedding, list)
+    assert len(embedding) > 0
+
+    # Test async batch
+    texts = ["Ocean waves", "Forest trees"]
+    embeddings = await vectorizer.aembed_many(texts)
+    assert len(embeddings) == 2


### PR DESCRIPTION
Voyageai refactoring:
 - contextual model(s)
 - remove default model value
 - token counting and effective batching
 - test with new reranker, rerank-2.5 as well
 - multimodal capability (text, image, video)
 - more tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates VoyageAI embedding behavior and public surface (new deprecations for implicit `model` and `batch_size`, plus new token-counting APIs), which could affect existing integrations and batching behavior. Most risk is functional/regression around embedding calls and new integration tests that depend on external tooling (API keys, Pillow, ffmpeg).
> 
> **Overview**
> Improves `VoyageAIVectorizer` by adding local token counting (`count_tokens`/`acount_tokens`) and introducing a `VOYAGE_TOTAL_TOKEN_LIMITS` table to support token-aware batching.
> 
> Deprecates instantiating the vectorizer without an explicit `model` (now emits a `DeprecationWarning` and will remove the implicit default in a future major version) and deprecates passing `batch_size` to `_embed_many`/`_aembed_many` in favor of automatic batch sizing.
> 
> Expands integration coverage with VoyageAI-specific tests for token counting, token limit constants, and multimodal embedding flows (text, image, video, and async), including conditional skipping when `ffmpeg` isn’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e971a6a93ee5078641175e81808f6a1dea5aeab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->