### PR TITLE
LangCache integration cleanup

### DIFF
--- a/redisvl/extensions/cache/llm/__init__.py
+++ b/redisvl/extensions/cache/llm/__init__.py
@@ -4,7 +4,7 @@ Redis Vector Library - LLM Cache Extensions
 This module provides LLM cache implementations for RedisVL.
 """
 
-from redisvl.extensions.cache.llm.langcache import LangCacheWrapper
+from redisvl.extensions.cache.llm.langcache import LangCacheSemanticCache
 from redisvl.extensions.cache.llm.schema import (
     CacheEntry,
     CacheHit,
@@ -14,7 +14,7 @@ from redisvl.extensions.cache.llm.semantic import SemanticCache
 
 __all__ = [
     "SemanticCache",
-    "LangCacheWrapper",
+    "LangCacheSemanticCache",
     "CacheEntry",
     "CacheHit",
     "SemanticCacheIndexSchema",

--- a/redisvl/extensions/cache/llm/langcache.py
+++ b/redisvl/extensions/cache/llm/langcache.py
@@ -15,7 +15,7 @@ from redisvl.utils.utils import denorm_cosine_distance, norm_cosine_distance
 logger = get_logger(__name__)
 
 
-class LangCacheWrapper(BaseLLMCache):
+class LangCacheSemanticCache(BaseLLMCache):
     """LLM Cache implementation using the LangCache managed service.
 
     This cache uses the LangCache API service for semantic caching of LLM
@@ -24,9 +24,9 @@ class LangCacheWrapper(BaseLLMCache):
     Example:
         .. code-block:: python
 
-            from redisvl.extensions.cache.llm import LangCacheWrapper
+            from redisvl.extensions.cache.llm import LangCacheSemanticCache
 
-            cache = LangCacheWrapper(
+            cache = LangCacheSemanticCache(
                 name="my_cache",
                 server_url="https://api.langcache.com",
                 cache_id="your-cache-id",
@@ -79,9 +79,9 @@ class LangCacheWrapper(BaseLLMCache):
         self._distance_scale = distance_scale
 
         if not cache_id:
-            raise ValueError("cache_id is required for LangCacheWrapper")
+            raise ValueError("cache_id is required for LangCacheSemanticCache")
         if not api_key:
-            raise ValueError("api_key is required for LangCacheWrapper")
+            raise ValueError("api_key is required for LangCacheSemanticCache")
 
         super().__init__(name=name, ttl=ttl, **kwargs)
 
@@ -117,7 +117,7 @@ class LangCacheWrapper(BaseLLMCache):
             from langcache import LangCacheClient
         except ImportError as e:
             raise ImportError(
-                "The langcache package is required to use LangCacheWrapper. "
+                "The langcache package is required to use LangCacheSemanticCache. "
                 "Install it with: pip install langcache"
             ) from e
 

--- a/tests/unit/test_langcache_semantic_cache.py
+++ b/tests/unit/test_langcache_semantic_cache.py
@@ -1,17 +1,17 @@
-"""Unit tests for LangCacheWrapper."""
+"""Unit tests for LangCacheSemanticCache."""
 
 import importlib.util
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from redisvl.extensions.cache.llm.langcache import LangCacheWrapper
+from redisvl.extensions.cache.llm.langcache import LangCacheSemanticCache
 
 
 @pytest.fixture
 def mock_langcache_client():
     """Create a mock LangCache client via the wrapper factory method."""
-    with patch.object(LangCacheWrapper, "_create_client") as mock_create_client:
+    with patch.object(LangCacheSemanticCache, "_create_client") as mock_create_client:
         mock_client = MagicMock()
         mock_create_client.return_value = mock_client
 
@@ -28,13 +28,13 @@ def mock_langcache_client():
     importlib.util.find_spec("langcache") is None,
     reason="langcache package not installed",
 )
-class TestLangCacheWrapper:
-    """Test suite for LangCacheWrapper."""
+class TestLangCacheSemanticCache:
+    """Test suite for LangCacheSemanticCache."""
 
     def test_init_requires_cache_id(self):
         """Test that cache_id is required."""
         with pytest.raises(ValueError, match="cache_id is required"):
-            LangCacheWrapper(
+            LangCacheSemanticCache(
                 name="test",
                 server_url="https://api.example.com",
                 cache_id="",
@@ -44,7 +44,7 @@ class TestLangCacheWrapper:
     def test_init_requires_api_key(self):
         """Test that api_key is required."""
         with pytest.raises(ValueError, match="api_key is required"):
-            LangCacheWrapper(
+            LangCacheSemanticCache(
                 name="test",
                 server_url="https://api.example.com",
                 cache_id="test-cache",
@@ -54,7 +54,7 @@ class TestLangCacheWrapper:
     def test_init_requires_at_least_one_search_strategy(self):
         """Test that at least one search strategy must be enabled."""
         with pytest.raises(ValueError, match="At least one of use_exact_search"):
-            LangCacheWrapper(
+            LangCacheSemanticCache(
                 name="test",
                 server_url="https://api.example.com",
                 cache_id="test-cache",
@@ -67,7 +67,7 @@ class TestLangCacheWrapper:
         """Test successful initialization."""
         mock_create_client, _ = mock_langcache_client
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test_cache",
             server_url="https://api.example.com",
             cache_id="test-cache-id",
@@ -93,7 +93,7 @@ class TestLangCacheWrapper:
         mock_response.entry_id = "entry-123"
         mock_client.set.return_value = mock_response
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -123,7 +123,7 @@ class TestLangCacheWrapper:
         mock_response.entry_id = "entry-456"
         mock_client.set_async = AsyncMock(return_value=mock_response)
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -158,7 +158,7 @@ class TestLangCacheWrapper:
         mock_response.data = [mock_entry]
         mock_client.search.return_value = mock_response
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -198,7 +198,7 @@ class TestLangCacheWrapper:
         mock_response.data = [mock_entry]
         mock_client.search_async = AsyncMock(return_value=mock_response)
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -232,7 +232,7 @@ class TestLangCacheWrapper:
         mock_response.data = [mock_entry]
         mock_client.search.return_value = mock_response
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -268,7 +268,7 @@ class TestLangCacheWrapper:
         mock_response.data = [mock_entry]
         mock_client.search.return_value = mock_response
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -296,7 +296,7 @@ class TestLangCacheWrapper:
         """Test deleting the entire cache."""
         _, mock_client = mock_langcache_client
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -314,7 +314,7 @@ class TestLangCacheWrapper:
 
         mock_client.delete_query_async = AsyncMock()
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -329,7 +329,7 @@ class TestLangCacheWrapper:
         """Test deleting a single entry by ID."""
         _, mock_client = mock_langcache_client
 
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -342,7 +342,7 @@ class TestLangCacheWrapper:
 
     def test_update_not_supported(self, mock_langcache_client):
         """Test that update raises NotImplementedError."""
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -355,7 +355,7 @@ class TestLangCacheWrapper:
     @pytest.mark.asyncio
     async def test_aupdate_not_supported(self, mock_langcache_client):
         """Test that async update raises NotImplementedError."""
-        cache = LangCacheWrapper(
+        cache = LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",
@@ -373,7 +373,7 @@ def test_import_error_when_langcache_not_installed():
         pytest.skip("langcache package is installed")
 
     with pytest.raises(ImportError, match="langcache package is required"):
-        LangCacheWrapper(
+        LangCacheSemanticCache(
             name="test",
             server_url="https://api.example.com",
             cache_id="test-cache",


### PR DESCRIPTION
Made a few changes/fixes to the LangCache integration:
- The name "LangCacheWrapper" just doesn't hit as deep. Also, it doesn't follow the same pattern as "SemanticCache," the Redis-based cache in this library. Seeing "Cache" twice feels better than "Wrapper."
- Adjust how we send attributes
- Use the correct import for the LangCache client