### PR TITLE
docs: Fix broken links to hash and json data types

### DIFF
--- a/docs/user_guide/05_hash_vs_json.ipynb
+++ b/docs/user_guide/05_hash_vs_json.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "\n",
     "Out of the box, Redis provides a [variety of data structures](https://redis.com/redis-enterprise/data-structures/) that can adapt to your domain specific applications and use cases.\n",
-    "In this notebook, we will demonstrate how to use RedisVL with both [Hash](https://redis.io/docs/data-types/hashes/) and [JSON](https://redis.io/docs/data-types/json/) data.\n",
+    "In this notebook, we will demonstrate how to use RedisVL with both [Hash](https://redis.io/docs/latest/develop/data-types/#hashes) and [JSON](https://redis.io/docs/latest/develop/data-types/json/) data.\n",
     "\n",
     "\n",
     "Before running this notebook, be sure to\n",


### PR DESCRIPTION
https://redislabs.atlassian.net/browse/DOC-5930

Two links on the page https://redis.io/docs/latest/develop/ai/redisvl/user_guide/hash_vs_json/ were broken.