### PR TITLE
Use 0.11.0 for the next release, actually

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redisvl"
-version = "0.12.0"
+version = "0.11.0"
 description = "Python client library and CLI for using Redis as a vector database"
 authors = [{ name = "Redis Inc.", email = "applied.ai@redis.com" }]
 requires-python = ">=3.9.2,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -4196,7 +4196,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.12.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },


### PR DESCRIPTION
We had already bumped the version in a previous PR.