### PR TITLE
Decode LangCache attribute values on retrieval

### DIFF
--- a/tests/integration/test_langcache_semantic_cache_integration.py
+++ b/tests/integration/test_langcache_semantic_cache_integration.py
@@ -261,7 +261,12 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
             num_results=3,
         )
         assert hits
+        # Response must match, and metadata should contain the original value
+        # (the client handles encoding/decoding around the LangCache API).
         assert any(hit["response"] == response for hit in hits)
+        assert any(
+            hit.get("metadata", {}).get("llm_string") == raw_llm_string for hit in hits
+        )
 
 
 @pytest.mark.requires_api_keys


### PR DESCRIPTION
In #429, we found and fixed an issue with LangCache attribute values, which is that some characters are not allowed (commas) and some are accepted but silently fail during retrieval (slashes). Our solution was to encode these characters when we persist them and at query time. This PR decodes the values in retrieved data as well.