### PR TITLE
Add support for item-specific TTLs; quote() and unquote() attributes

### DIFF
--- a/redisvl/extensions/cache/llm/langcache.py
+++ b/redisvl/extensions/cache/llm/langcache.py
@@ -454,7 +454,7 @@ class LangCacheSemanticCache(BaseLLMCache):
             logger.warning("LangCache does not support filters")
 
         try:
-            ttl_millis = int(ttl * 1000) if ttl is not None else None
+            ttl_millis = round(ttl * 1000) if ttl is not None else None
             if metadata:
                 safe_metadata = _encode_attributes_for_langcache(metadata)
                 result = self._client.set(

--- a/redisvl/extensions/cache/llm/langcache.py
+++ b/redisvl/extensions/cache/llm/langcache.py
@@ -527,7 +527,7 @@ class LangCacheSemanticCache(BaseLLMCache):
             logger.warning("LangCache does not support filters")
 
         try:
-            ttl_millis = int(ttl * 1000) if ttl is not None else None
+            ttl_millis = round(ttl * 1000) if ttl is not None else None
             if metadata:
                 safe_metadata = _encode_attributes_for_langcache(metadata)
                 result = await self._client.set_async(


### PR DESCRIPTION
This PR adds support for LangCache supports item-specific TTLs. We also begin using quote() and unquote() to manage the variety of characters that can disrupt queries that use attributes.