### PR TITLE
RAAE-1309: add support for wildcard TAG filters

### DIFF
--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -120,11 +120,13 @@ class Tag(FilterField):
         FilterOperator.EQ: "==",
         FilterOperator.NE: "!=",
         FilterOperator.IN: "==",
+        FilterOperator.LIKE: "%",
     }
     OPERATOR_MAP: Dict[FilterOperator, str] = {
         FilterOperator.EQ: "@%s:{%s}",
         FilterOperator.NE: "(-@%s:{%s})",
         FilterOperator.IN: "@%s:{%s}",
+        FilterOperator.LIKE: "@%s:{%s}",
     }
     SUPPORTED_VAL_TYPES = (list, set, tuple, str, type(None))
 
@@ -177,9 +179,37 @@ class Tag(FilterField):
         self._set_tag_value(other, FilterOperator.NE)
         return FilterExpression(str(self))
 
+    def __mod__(self, other: Union[List[str], str]) -> "FilterExpression":
+        """Create a Tag wildcard filter expression for prefix matching.
+
+        This enables wildcard pattern matching on tag fields using the ``*``
+        character. Unlike the equality operator, wildcards are not escaped,
+        allowing prefix searches like ``"tech*"`` to match "technology",
+        "technical", etc.
+
+        Args:
+            other (Union[List[str], str]): The tag pattern(s) to filter on.
+                Use ``*`` for prefix matching (e.g., ``"tech*"``).
+
+        .. code-block:: python
+
+            from redisvl.query.filter import Tag
+
+            f = Tag("category") % "tech*"           # Prefix match
+            f = Tag("category") % "elec*|soft*"     # Multiple prefix patterns
+            f = Tag("category") % ["tech*", "sci*"] # List of patterns
+
+        """
+        self._set_tag_value(other, FilterOperator.LIKE)
+        return FilterExpression(str(self))
+
     @property
     def _formatted_tag_value(self) -> str:
-        return "|".join([self.escaper.escape(tag) for tag in self._value])
+        # For LIKE operator, preserve wildcards (*) in the pattern
+        preserve_wildcards = self._operator == FilterOperator.LIKE
+        return "|".join(
+            [self.escaper.escape(tag, preserve_wildcards) for tag in self._value]
+        )
 
     def __str__(self) -> str:
         """Return the Redis Query string for the Tag filter"""

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -180,24 +180,28 @@ class Tag(FilterField):
         return FilterExpression(str(self))
 
     def __mod__(self, other: Union[List[str], str]) -> "FilterExpression":
-        """Create a Tag wildcard filter expression for prefix matching.
+        """Create a Tag wildcard filter expression for pattern matching.
 
         This enables wildcard pattern matching on tag fields using the ``*``
         character. Unlike the equality operator, wildcards are not escaped,
-        allowing prefix searches like ``"tech*"`` to match "technology",
-        "technical", etc.
+        allowing patterns with wildcards in any position, such as prefix
+        (``"tech*"``), suffix (``"*tech"``), or middle (``"*tech*"``)
+        matches.
 
         Args:
             other (Union[List[str], str]): The tag pattern(s) to filter on.
-                Use ``*`` for prefix matching (e.g., ``"tech*"``).
+                Use ``*`` for wildcard matching (e.g., ``"tech*"``, ``"*tech"``,
+                or ``"*tech*"``).
 
         .. code-block:: python
 
             from redisvl.query.filter import Tag
 
-            f = Tag("category") % "tech*"           # Prefix match
-            f = Tag("category") % "elec*|soft*"     # Multiple prefix patterns
-            f = Tag("category") % ["tech*", "sci*"] # List of patterns
+            f = Tag("category") % "tech*"               # Prefix match
+            f = Tag("category") % "*tech"               # Suffix match
+            f = Tag("category") % "*tech*"              # Contains match
+            f = Tag("category") % "elec*|*soft"         # Multiple wildcard patterns
+            f = Tag("category") % ["tech*", "*science"] # List of patterns
 
         """
         self._set_tag_value(other, FilterOperator.LIKE)

--- a/redisvl/utils/token_escaper.py
+++ b/redisvl/utils/token_escaper.py
@@ -12,13 +12,30 @@ class TokenEscaper:
     # Source: https://redis.io/docs/stack/search/reference/escaping/#the-rules-of-text-field-tokenization
     DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ ]"
 
+    # Same as above but excludes * to allow wildcard patterns
+    ESCAPED_CHARS_NO_WILDCARD = r"[,.<>{}\[\]\\\"\':;!@#$%^&()\-+=~\/ ]"
+
     def __init__(self, escape_chars_re: Optional[Pattern] = None):
         if escape_chars_re:
             self.escaped_chars_re = escape_chars_re
         else:
             self.escaped_chars_re = re.compile(self.DEFAULT_ESCAPED_CHARS)
+        self.escaped_chars_no_wildcard_re = re.compile(self.ESCAPED_CHARS_NO_WILDCARD)
 
-    def escape(self, value: str) -> str:
+    def escape(self, value: str, preserve_wildcards: bool = False) -> str:
+        """Escape special characters in a string for use in Redis queries.
+
+        Args:
+            value: The string value to escape.
+            preserve_wildcards: If True, preserves * characters for wildcard
+                matching. Defaults to False.
+
+        Returns:
+            The escaped string.
+
+        Raises:
+            TypeError: If value is not a string.
+        """
         if not isinstance(value, str):
             raise TypeError(
                 f"Value must be a string object for token escaping, got type {type(value)}"
@@ -28,4 +45,6 @@ class TokenEscaper:
             value = match.group(0)
             return f"\\{value}"
 
+        if preserve_wildcards:
+            return self.escaped_chars_no_wildcard_re.sub(escape_symbol, value)
         return self.escaped_chars_re.sub(escape_symbol, value)


### PR DESCRIPTION
Allow using modulo queries to enable wildcard (prefix search) support in `Tag` filters, e.g.:

```python
wildcard_match = Tag("category") % "tech*"
```

closes #453 / RAAE-1309