### PR TITLE
release: Bump version to 0.13.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redisvl"
-version = "0.13.1"
+version = "0.13.2"
 description = "Python client library and CLI for using Redis as a vector database"
 authors = [{ name = "Redis Inc.", email = "applied.ai@redis.com" }]
 requires-python = ">=3.9.2,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -4255,7 +4255,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.13.0"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },


### PR DESCRIPTION
Release 0.13.1 was created without the corresponding bump in `pyproject.toml` - as a result, the Git tag was created but the version was not published to PyPi. To avoid confusion (and messing with the repository tags), we are bumping the release to 0.13.2.