### PR TITLE
fix: Avoid catching non-exception; skip retry for ValueErrors from VertexAI

### DIFF
--- a/tests/integration/test_redis_cluster_support.py
+++ b/tests/integration/test_redis_cluster_support.py
@@ -89,6 +89,7 @@ def test_search_index_cluster_info(redis_cluster_url):
     finally:
         index.delete(drop=True)
 
+
 @pytest.mark.requires_cluster
 @pytest.mark.asyncio
 async def test_async_search_index_cluster_info(redis_cluster_url):
@@ -109,6 +110,7 @@ async def test_async_search_index_cluster_info(redis_cluster_url):
     finally:
         await index.delete(drop=True)
         await client.aclose()
+
 
 @pytest.mark.requires_cluster
 @pytest.mark.asyncio

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -304,6 +304,7 @@ def test_search_index_delete(index):
     assert not index.exists()
     assert index.name not in convert_bytes(index.client.execute_command("FT._LIST"))
 
+
 @pytest.mark.parametrize("num_docs", [0, 1, 5, 10, 2042])
 def test_search_index_clear(index, num_docs):
     index.create(overwrite=True, drop=True)


### PR DESCRIPTION
The `VertexAIVectorizer` attempts to handle an error from Google that, it turns out, is not an exception despite being in the Google exceptions module. This PR removes this catch, and adjusts retry logic to capture the correct set of exceptions for VertexAI use. In particular, this fixes an issue where using an invalid model name would break with an unclear error - this now breaks as expected, by reporting that the provided model name was not found.

fixes #469 