### PR TITLE
fix: avoid NLTK download race condition in parallel test workers

### DIFF
--- a/redisvl/utils/full_text_query_helper.py
+++ b/redisvl/utils/full_text_query_helper.py
@@ -93,8 +93,14 @@ class FullTextQueryHelper:
             return set()
         elif isinstance(stopwords, str):
             try:
-                nltk.download("stopwords", quiet=True)
-                return set(nltk_stopwords.words(stopwords))
+                # Try loading first; only download if not already present.
+                # This avoids race conditions when parallel workers (e.g.
+                # pytest-xdist) call nltk.download() concurrently.
+                try:
+                    return set(nltk_stopwords.words(stopwords))
+                except LookupError:
+                    nltk.download("stopwords", quiet=True)
+                    return set(nltk_stopwords.words(stopwords))
             except ImportError:
                 raise ValueError(
                     f"Loading stopwords for {stopwords} failed: nltk is not installed."


### PR DESCRIPTION
Try loading stopwords before downloading to prevent concurrent pytest-xdist workers from racing on nltk.download(), which raises FileExistsError when multiple processes write to the same path.