### PR TITLE
Handle missing multivector distance

### DIFF
--- a/redisvl/query/aggregate.py
+++ b/redisvl/query/aggregate.py
@@ -329,7 +329,11 @@ class MultiVectorQuery(AggregationQuery):
 
         # calculate the respective vector similarities
         for i in range(len(self._vectors)):
-            self.apply(**{f"score_{i}": f"(2 - @distance_{i})/2"})
+            self.apply(
+                **{
+                    f"score_{i}": f"case(exists(@distance_{i}), (2 - @distance_{i})/2, 0)"
+                }
+            )
 
         # construct the scoring string based on the vector similarity scores and weights
         combined_scores = []

--- a/tests/unit/test_aggregation_types.py
+++ b/tests/unit/test_aggregation_types.py
@@ -367,7 +367,7 @@ def test_multi_vector_query_string():
 
     assert (
         str(multi_vector_query)
-        == f"@{field_1}:[VECTOR_RANGE 2.0 $vector_0]=>{{$YIELD_DISTANCE_AS: distance_0}} | @{field_2}:[VECTOR_RANGE 2.0 $vector_1]=>{{$YIELD_DISTANCE_AS: distance_1}} SCORER TFIDF DIALECT 2 APPLY (2 - @distance_0)/2 AS score_0 APPLY (2 - @distance_1)/2 AS score_1 APPLY @score_0 * {weight_1} + @score_1 * {weight_2} AS combined_score SORTBY 2 @combined_score DESC MAX 10"
+        == f"@{field_1}:[VECTOR_RANGE 2.0 $vector_0]=>{{$YIELD_DISTANCE_AS: distance_0}} | @{field_2}:[VECTOR_RANGE 2.0 $vector_1]=>{{$YIELD_DISTANCE_AS: distance_1}} SCORER TFIDF DIALECT 2 APPLY case(exists(@distance_0), (2 - @distance_0)/2, 0) AS score_0 APPLY case(exists(@distance_1), (2 - @distance_1)/2, 0) AS score_1 APPLY @score_0 * {weight_1} + @score_1 * {weight_2} AS combined_score SORTBY 2 @combined_score DESC MAX 10"
     )
 
 


### PR DESCRIPTION
When running a multi vector query, I noticed redis would sometimes return:

`Could not find the value for a parameter name, consider using EXISTS if applicable for distance_2`

This is running `redis-stack-server/7.4.0-v8` from brew.

I confirmed all documents contained the referenced embedding fields, but somehow the third distance was not always calculated and the query would error out. Maybe a match in other distances causes redis to skip the final distance calculation? Without debugging the specifics of query execution, this PR adds a case() in the query to set a default score of 0 for missing distances.

I also noticed that the vector radius is always hard coded to 2.0 - looks like there's a [separate PR](https://github.com/redis/redis-vl-python/pull/478) just opened to add custom ranges so I've left those changes out here. This fallback may solve issues downstream of that, and allow for safer handling of OR multi vectors of different ranges, rather than forcing AND.