### PR TITLE
Fix: Escape ? and | characters in TokenEscaper

### DIFF
--- a/redisvl/utils/token_escaper.py
+++ b/redisvl/utils/token_escaper.py
@@ -27,8 +27,8 @@ class TokenEscaper:
 
         Args:
             value: The string value to escape.
-            preserve_wildcards: If True, preserves * characters for wildcard
-                matching. Defaults to False.
+            preserve_wildcards: If True, preserves * and ? characters for
+                wildcard matching. Defaults to False.
 
         Returns:
             The escaped string.

--- a/tests/unit/test_token_escaper.py
+++ b/tests/unit/test_token_escaper.py
@@ -127,21 +127,15 @@ def test_escape_long_string(escaper):
 @pytest.mark.parametrize(
     ("test_input,expected"),
     [
-        ("wild*card", "wild*card"),
-        ("single?char", "single?char"),
-        ("combo*test?", "combo*test?"),
-        ("mixed*and|pipe", "mixed*and\|pipe"),
-        ("question?and|pipe", "question\?and\|pipe"),  # ? escaped when not preserving
+        ("wild*card", r"wild*card"),
+        ("single?char", r"single?char"),
+        ("combo*test?", r"combo*test?"),
+        ("mixed*and|pipe", r"mixed*and\|pipe"),
+        ("question?and|pipe", r"question\?and\|pipe"),  # ? escaped when not preserving
     ],
     ids=["star", "question", "both", "star-only", "question-escaped"],
 )
 def test_escape_preserve_wildcards(escaper, test_input, expected):
     """Test that * and ? are preserved when preserve_wildcards=True."""
-    # These tests verify wildcard preservation behavior
-    if "*" in test_input and "?" in test_input:
-        result = escaper.escape(test_input, preserve_wildcards=True)
-        assert "*" in result and "?" in result
-    elif "*" in test_input:
-        assert "*" in escaper.escape(test_input, preserve_wildcards=True)
-    elif "?" in test_input:
-        assert "?" in escaper.escape(test_input, preserve_wildcards=True)
+    result = escaper.escape(test_input, preserve_wildcards=True)
+    assert result == expected


### PR DESCRIPTION
## Summary
- Added `?` and `|` to the escape patterns in `TokenEscaper` to comply with RediSearch query syntax requirements
- Enabled previously commented-out test cases for pipe and question mark
- Updated test expectations for the symbols test case

## Problem
The `TokenEscaper` class was not escaping `?` and `|` characters, which are special characters in RediSearch queries that need to be escaped according to [Redis documentation](https://redis.io/docs/stack/search/reference/escaping/#the-rules-of-text-field-tokenization).

## Solution
Updated the regex patterns:
- `DEFAULT_ESCAPED_CHARS`: Added `?` and `|` to the character class
- `ESCAPED_CHARS_NO_WILDCARD`: Added `?` and `|` to the character class

## Testing
Verified locally that:
- `question?mark` → `question\?mark`
- `pipe|tag` → `pipe\|tag`
- `& symbols, like * and ?` → `\&\ symbols\,\ like\ \*\ and\ \?`

Fixes #490

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the query-escaping rules for `TokenEscaper`, which can alter generated RediSearch query strings and therefore matching behavior. Scope is small and covered by updated/added unit tests, but could impact downstream callers that relied on the previous escaping output.
> 
> **Overview**
> Fixes RediSearch query escaping by updating `TokenEscaper` to treat `?` and `|` as escapable punctuation.
> 
> `preserve_wildcards=True` now preserves both `*` and `?` (while still escaping other specials like `|`), and unit tests are updated to assert the new escaping behavior (including previously skipped `?`/`|` cases and new wildcard-preservation coverage).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 204a50b9befdeb5fb8872961b3572d68fae41974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->