### PR TITLE
ci: Remove deprecated `auto` configuration field

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -8,7 +8,6 @@
   "owner": "redis",
   "repo": "redis-vl-python",
   "onlyPublishWithReleaseLabel": true,
-  "noChangelog": true,
   "labels": [
     {
       "name": "auto:major",


### PR DESCRIPTION
It looks like a configuration key I added based on the `auto` docs doesn't exist anymore - hoping this resolves the automated release issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a deprecated CI/release configuration key and should only affect `auto` release automation behavior if the repo still relied on the old field.
> 
> **Overview**
> Removes the deprecated `noChangelog` field from `.autorc`, leaving the rest of the `auto` release configuration unchanged (plugins, repo metadata, and label-driven release rules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d21ad3ba20eb3c4b85a27fcbd1dd0a3381cc050a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->