### PR TITLE
ci: Use Applied AI release bot token to create release commits

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -119,7 +119,7 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           auto create-labels
-          auto latest --name "${GH_ACTIONS_BOT_NAME}" --email "${GH_ACTIONS_BOT_EMAIL}"
+          auto latest --name "${GH_ACTIONS_BOT_NAME}" --email "${GH_ACTIONS_BOT_EMAIL}" --no-changelog
 
   build-and-publish:
     needs: release


### PR DESCRIPTION
Branch protection rules in the repository prevent the release process from pushing a commit bumping the version. @tylerhutcherson and I created a GitHub App that can be excluded from that rule to enable the frictionless release workflow we want.

This PR adapts the workflow to use that bot's GitHub token for its operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation to authenticate with a GitHub App token and push to `main`, which can impact publishing if token/scopes/secret configuration is wrong. Introduces reliance on a new secret (`RELEASE_BOT_PRIVATE_KEY`) for release creation and version-bump commits.
> 
> **Overview**
> **Release automation now runs under a GitHub App identity instead of the default `GITHUB_TOKEN`.** The `release-new.yml` workflow generates an App token (`actions/create-github-app-token@v2`) using `RELEASE_BOT_PRIVATE_KEY`, uses it for `actions/checkout`, and swaps `GH_TOKEN` to the App token for `auto` commands.
> 
> The release step also changes `auto latest` to run with `--no-changelog`, and adds release-bot identity env vars (`RELEASE_BOT_NAME`/`RELEASE_BOT_EMAIL`) for the new bot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbc6a90a5e3a734540731eafb69b8775a625aada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->