### PR TITLE
ci: Add app ID and repo owner to workflow

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -63,8 +63,9 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: applied-ai-release-bot
+          app-id: 2959093
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow tweak, but it affects release automation credentials; a wrong `app-id`/`owner` could break or mis-scope release pushes.
> 
> **Overview**
> Updates the release GitHub Actions workflow to generate the GitHub App token using the numeric `app-id` (`2959093`) instead of the app slug, and explicitly sets `owner: ${{ github.repository_owner }}` when creating the token.
> 
> This ensures subsequent `checkout`/push and release steps use a correctly scoped App token during automated releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b3cbfe1347895012dc96af3ed8f1469eba0cfdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->