### PR TITLE
ci: Use correct env variable for git name/email

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -83,12 +83,18 @@ jobs:
           sudo mv auto-linux /usr/local/bin/auto
           auto --version
 
+      - name: Sanity check
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          auto latest --name "${RELEASE_BOT_NAME}" --email "${RELEASE_BOT_EMAIL}" --dry-run -v
+
       - name: Resolve release version
         id: latest_release
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          RAW_VERSION="$(auto latest --name "${GH_ACTIONS_BOT_NAME}" --email "${GH_ACTIONS_BOT_EMAIL}" --dry-run --quiet | tail -n1 | tr -d '\r')"
+          RAW_VERSION="$(auto latest --name "${RELEASE_BOT_NAME}" --email "${RELEASE_BOT_EMAIL}" --dry-run --quiet | tail -n1 | tr -d '\r')"
           VERSION="${RAW_VERSION#v}"
           if [ -z "$VERSION" ]; then
             echo "Could not resolve release version"
@@ -109,8 +115,8 @@ jobs:
             echo "No pyproject version change to commit."
             exit 0
           fi
-          git config user.name "${GH_ACTIONS_BOT_NAME}"
-          git config user.email "${GH_ACTIONS_BOT_EMAIL}"
+          git config user.name "${RELEASE_BOT_NAME}"
+          git config user.email "${RELEASE_BOT_EMAIL}"
           git add pyproject.toml
           git commit -m "chore(release): set pyproject version to ${{ steps.latest_release.outputs.version }}"
           git push origin HEAD:main
@@ -120,7 +126,7 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           auto create-labels
-          auto latest --name "${GH_ACTIONS_BOT_NAME}" --email "${GH_ACTIONS_BOT_EMAIL}" --no-changelog
+          auto latest --name "${RELEASE_BOT_NAME}" --email "${RELEASE_BOT_EMAIL}" --no-changelog
 
   build-and-publish:
     needs: release


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is on release automation behavior if the new bot identity/token lacks expected permissions or repo access.
> 
> **Overview**
> Updates the `Publish Release` GitHub Actions workflow to consistently use the release bot identity (`RELEASE_BOT_NAME`/`RELEASE_BOT_EMAIL`) for `auto latest` and for committing the `pyproject.toml` version bump.
> 
> Adds an `auto latest` *sanity check* step (dry-run with verbose output) before resolving the release version to fail fast if release metadata can’t be computed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8501fd168bfcea65ba8d0187c62adedce3879218. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->