### PR TITLE
docs: Add note about automated version bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "redisvl"
+# NOTE: This version value is automatically incremented by the release workflow - do not manually adjust it.
 version = "0.14.0"
 description = "Python client library and CLI for using Redis as a vector database"
 authors = [{ name = "Redis Inc.", email = "applied.ai@redis.com" }]


### PR DESCRIPTION
Just a small change to trigger a release. Turns out if a PR has one commit with a skip token, it skips the release workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a comment-only change in `pyproject.toml` with no runtime or dependency impact.
> 
> **Overview**
> Adds an inline comment next to `version` in `pyproject.toml` clarifying that release automation updates the value and it should not be manually edited.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a428551320505f3a7ab9f79855711562d8464c3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->