### PR TITLE
Relax redis-py upper bound to <8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.0,<3",
     "pyyaml>=5.4,<7.0",
-    "redis>=5.0,<7.2",
+    "redis>=5.0,<8.0",
     "pydantic>=2,<3",
     "tenacity>=8.2.2",
     "ml-dtypes>=0.4.0,<1.0.0",
@@ -148,4 +148,3 @@ filterwarnings = [
 warn_unused_configs = true
 ignore_missing_imports = true
 exclude = ["env", "venv", ".venv"]
-

--- a/uv.lock
+++ b/uv.lock
@@ -4898,7 +4898,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=5.4,<7.0" },
-    { name = "redis", specifier = ">=5.0,<7.2" },
+    { name = "redis", specifier = ">=5.0,<8.0" },
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=3.4.0,<4" },
     { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=3.4.0,<4" },
     { name = "sql-redis", marker = "extra == 'all'", specifier = ">=0.2.0" },


### PR DESCRIPTION
## Summary
- relax `redis` dependency upper bound from `<7.2` to `<8.0`
- update `uv.lock` to match the new constraint

Closes #527

## Validation
- ran `uv lock`
- ran `uv run pytest` (local environment has existing unrelated integration/import failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency constraint change; main risk is incompatibility with `redis` 7.x API/behavior if consumers upgrade without corresponding test coverage.
> 
> **Overview**
> **Relaxes dependency constraints** by widening the `redis` requirement from `<7.2` to `<8.0` in `pyproject.toml`.
> 
> **Lockfile updated** (`uv.lock`) to reflect the new `redis` version range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceaa1786e58b4c27154ab218149c647e561a8b46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->