### PR TITLE
fix: pass withsuffixtrie attribute to Redis Text and Tag fields

### DIFF
--- a/redisvl/schema/fields.py
+++ b/redisvl/schema/fields.py
@@ -400,6 +400,10 @@ class TextField(BaseField):
         if self.attrs.phonetic_matcher is not None:  # type: ignore
             kwargs["phonetic_matcher"] = self.attrs.phonetic_matcher  # type: ignore
 
+        # Add WITHSUFFIXTRIE if enabled
+        if self.attrs.withsuffixtrie:  # type: ignore
+            kwargs["withsuffixtrie"] = True
+
         # Add INDEXMISSING if enabled
         if self.attrs.index_missing:  # type: ignore
             kwargs["index_missing"] = True
@@ -441,6 +445,10 @@ class TagField(BaseField):
         # Only add as_name if it's not None
         if as_name is not None:
             kwargs["as_name"] = as_name
+
+        # Add WITHSUFFIXTRIE if enabled
+        if self.attrs.withsuffixtrie:  # type: ignore
+            kwargs["withsuffixtrie"] = True
 
         # Add INDEXMISSING if enabled
         if self.attrs.index_missing:  # type: ignore

--- a/tests/integration/test_withsuffixtrie_integration.py
+++ b/tests/integration/test_withsuffixtrie_integration.py
@@ -5,8 +5,6 @@ Tests verify that the WITHSUFFIXTRIE modifier is correctly passed to Redis
 when creating indexes, enabling optimized suffix and contains queries.
 """
 
-import pytest
-
 from redisvl.index import SearchIndex
 from redisvl.schema import IndexSchema
 

--- a/tests/integration/test_withsuffixtrie_integration.py
+++ b/tests/integration/test_withsuffixtrie_integration.py
@@ -1,0 +1,190 @@
+"""
+Integration tests for withsuffixtrie attribute on Text and Tag fields.
+
+Tests verify that the WITHSUFFIXTRIE modifier is correctly passed to Redis
+when creating indexes, enabling optimized suffix and contains queries.
+"""
+
+import pytest
+
+from redisvl.index import SearchIndex
+from redisvl.schema import IndexSchema
+
+
+class TestTextFieldWithSuffixTrie:
+    """Integration tests for TextField withsuffixtrie attribute."""
+
+    def test_textfield_withsuffixtrie_creates_successfully(
+        self, client, redis_url, worker_id
+    ):
+        """Test TextField with withsuffixtrie creates successfully."""
+        schema_dict = {
+            "index": {
+                "name": f"test_text_suffix_{worker_id}",
+                "prefix": f"text_suffix_{worker_id}:",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {
+                    "name": "email",
+                    "type": "text",
+                    "attrs": {"withsuffixtrie": True},
+                }
+            ],
+        }
+
+        schema = IndexSchema.from_dict(schema_dict)
+        index = SearchIndex(schema=schema, redis_url=redis_url)
+        index.create(overwrite=True)
+
+        # Verify index was created and has WITHSUFFIXTRIE
+        info = client.execute_command("FT.INFO", f"test_text_suffix_{worker_id}")
+
+        # Find the field attributes in the info response
+        # FT.INFO returns a flat list, we need to find the attributes section
+        info_dict = _parse_ft_info(info)
+        field_attrs = _get_field_attributes(info_dict, "email")
+
+        assert (
+            "WITHSUFFIXTRIE" in field_attrs
+        ), f"WITHSUFFIXTRIE not found in field attributes: {field_attrs}"
+
+        # Cleanup
+        index.delete(drop=True)
+
+    def test_textfield_withsuffixtrie_and_sortable(self, client, redis_url, worker_id):
+        """Test TextField with withsuffixtrie and sortable combined."""
+        schema_dict = {
+            "index": {
+                "name": f"test_text_suffix_sort_{worker_id}",
+                "prefix": f"text_suffix_sort_{worker_id}:",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {
+                    "name": "title",
+                    "type": "text",
+                    "attrs": {"withsuffixtrie": True, "sortable": True},
+                }
+            ],
+        }
+
+        schema = IndexSchema.from_dict(schema_dict)
+        index = SearchIndex(schema=schema, redis_url=redis_url)
+        index.create(overwrite=True)
+
+        info = client.execute_command("FT.INFO", f"test_text_suffix_sort_{worker_id}")
+        info_dict = _parse_ft_info(info)
+        field_attrs = _get_field_attributes(info_dict, "title")
+
+        assert "WITHSUFFIXTRIE" in field_attrs
+        assert "SORTABLE" in field_attrs
+
+        index.delete(drop=True)
+
+
+class TestTagFieldWithSuffixTrie:
+    """Integration tests for TagField withsuffixtrie attribute."""
+
+    def test_tagfield_withsuffixtrie_creates_successfully(
+        self, client, redis_url, worker_id
+    ):
+        """Test TagField with withsuffixtrie creates successfully."""
+        schema_dict = {
+            "index": {
+                "name": f"test_tag_suffix_{worker_id}",
+                "prefix": f"tag_suffix_{worker_id}:",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {
+                    "name": "domain",
+                    "type": "tag",
+                    "attrs": {"withsuffixtrie": True},
+                }
+            ],
+        }
+
+        schema = IndexSchema.from_dict(schema_dict)
+        index = SearchIndex(schema=schema, redis_url=redis_url)
+        index.create(overwrite=True)
+
+        info = client.execute_command("FT.INFO", f"test_tag_suffix_{worker_id}")
+        info_dict = _parse_ft_info(info)
+        field_attrs = _get_field_attributes(info_dict, "domain")
+
+        assert (
+            "WITHSUFFIXTRIE" in field_attrs
+        ), f"WITHSUFFIXTRIE not found in field attributes: {field_attrs}"
+
+        index.delete(drop=True)
+
+    def test_tagfield_withsuffixtrie_and_case_sensitive(
+        self, client, redis_url, worker_id
+    ):
+        """Test TagField with withsuffixtrie and case_sensitive combined."""
+        schema_dict = {
+            "index": {
+                "name": f"test_tag_suffix_cs_{worker_id}",
+                "prefix": f"tag_suffix_cs_{worker_id}:",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {
+                    "name": "sku",
+                    "type": "tag",
+                    "attrs": {"withsuffixtrie": True, "case_sensitive": True},
+                }
+            ],
+        }
+
+        schema = IndexSchema.from_dict(schema_dict)
+        index = SearchIndex(schema=schema, redis_url=redis_url)
+        index.create(overwrite=True)
+
+        info = client.execute_command("FT.INFO", f"test_tag_suffix_cs_{worker_id}")
+        info_dict = _parse_ft_info(info)
+        field_attrs = _get_field_attributes(info_dict, "sku")
+
+        assert "WITHSUFFIXTRIE" in field_attrs
+        assert "CASESENSITIVE" in field_attrs
+
+        index.delete(drop=True)
+
+
+# Helper functions to parse FT.INFO response
+
+
+def _parse_ft_info(info) -> dict:
+    """Parse FT.INFO response into a dictionary."""
+    result = {}
+    if isinstance(info, list):
+        i = 0
+        while i < len(info) - 1:
+            key = info[i]
+            value = info[i + 1]
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            result[key] = value
+            i += 2
+    return result
+
+
+def _get_field_attributes(info_dict: dict, field_name: str) -> list:
+    """Extract field attributes from parsed FT.INFO for a specific field."""
+    attributes = info_dict.get("attributes", [])
+    if isinstance(attributes, list):
+        for field_info in attributes:
+            if isinstance(field_info, list):
+                # Field info is a list like [b'identifier', b'email', b'type', b'TEXT', ...]
+                # Convert bytes to strings for comparison
+                field_info_str = [
+                    x.decode("utf-8") if isinstance(x, bytes) else str(x)
+                    for x in field_info
+                ]
+                # Check if this is the field we're looking for
+                for i, item in enumerate(field_info_str):
+                    if item == "identifier" and i + 1 < len(field_info_str):
+                        if field_info_str[i + 1] == field_name:
+                            return field_info_str
+    return []


### PR DESCRIPTION
Related: #535 
The withsuffixtrie attribute was defined in TextFieldAttributes and TagFieldAttributes but never passed to the underlying Redis field constructors in as_redis_field() methods. This meant the attribute was silently ignored - indexes were created without suffix trie support even when explicitly specified.

Solution

- Added withsuffixtrie parameter to both RedisTextField() and RedisTagField() constructor calls in redisvl/schema/fields.py.

Changes

- TextField.as_redis_field() - now passes withsuffixtrie=True when enabled
- TagField.as_redis_field() - now passes withsuffixtrie=True when enabled
- Added 4 integration tests verifying WITHSUFFIXTRIE appears in FT.INFO output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Redis search indexes are created by enabling an additional field modifier when configured, which can affect index size/performance and query behavior. Coverage is improved via integration tests, but correctness depends on Redis/redis-py support for the parameter.
> 
> **Overview**
> Fixes schema-to-Redis translation so `TextField.as_redis_field()` and `TagField.as_redis_field()` pass `withsuffixtrie=True` to the underlying Redis field constructors when the attribute is enabled.
> 
> Adds integration tests that create indexes with `withsuffixtrie` and assert `WITHSUFFIXTRIE` appears in `FT.INFO`, including combinations with `sortable` and `case_sensitive`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56a3d9497be5495e7adeb2f213c751f8dc631314. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->