### PR TITLE
chore: remove unused imports and variables

### DIFF
--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -6,7 +6,6 @@ from redisvl.cli.utils import add_index_parsing_options, create_redis_url
 from redisvl.index import SearchIndex
 from redisvl.schema.schema import IndexSchema
 from redisvl.utils.log import get_logger
-from redisvl.utils.utils import lazy_import
 
 logger = get_logger("[RedisVL]")
 

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -5,13 +5,13 @@ specific cache types such as LLM caches and embedding caches.
 """
 
 from collections.abc import Mapping
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from redis import Redis  # For backwards compatibility in type checking
 from redis.cluster import RedisCluster
 
 from redisvl.redis.connection import RedisConnectionFactory
-from redisvl.types import AsyncRedisClient, SyncRedisClient, SyncRedisCluster
+from redisvl.types import AsyncRedisClient, SyncRedisClient
 
 
 class BaseCache:

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 import redis.commands.search.reducers as reducers
 import yaml

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -286,9 +286,13 @@ class BaseSearchIndex:
     def _validate_hybrid_query(self, query: Any) -> None:
         """Validate that a hybrid query can be executed."""
         try:
-            from redis.commands.search.hybrid_result import HybridResult
+            from redis.commands.search.hybrid_result import (  # noqa: F401
+                HybridResult as _HybridResult,
+            )
 
             from redisvl.query.hybrid import HybridQuery
+
+            del _HybridResult  # Only imported to check availability
         except (ImportError, ModuleNotFoundError):
             raise ImportError(_HYBRID_SEARCH_ERROR_MESSAGE)
 
@@ -894,14 +898,14 @@ class SearchIndex(BaseSearchIndex):
                 batch_size=batch_size,
                 validate=self._validate_on_load,
             )
-        except SchemaValidationError as e:
+        except SchemaValidationError:
             # Log the detailed validation error with actionable information
             logger.error("Data validation failed during load operation")
             raise
-        except Exception as e:
+        except Exception as exc:
             # Wrap other errors as general RedisVL errors
             logger.exception("Error while loading data to Redis")
-            raise RedisVLError(f"Failed to load data: {str(e)}") from e
+            raise RedisVLError(f"Failed to load data: {str(exc)}") from exc
 
     def fetch(self, id: str) -> Optional[Dict[str, Any]]:
         """Fetch an object from Redis by id.
@@ -1840,14 +1844,14 @@ class AsyncSearchIndex(BaseSearchIndex):
                 batch_size=batch_size,
                 validate=self._validate_on_load,
             )
-        except SchemaValidationError as e:
+        except SchemaValidationError:
             # Log the detailed validation error with actionable information
             logger.error("Data validation failed during load operation")
             raise
-        except Exception as e:
+        except Exception as exc:
             # Wrap other errors as general RedisVL errors
             logger.exception("Error while loading data to Redis")
-            raise RedisVLError(f"Failed to load data: {str(e)}") from e
+            raise RedisVLError(f"Failed to load data: {str(exc)}") from exc
 
     async def fetch(self, id: str) -> Optional[Dict[str, Any]]:
         """Asynchronously etch an object from Redis by id. The id is typically

--- a/redisvl/index/storage.py
+++ b/redisvl/index/storage.py
@@ -1,16 +1,5 @@
 from collections.abc import Collection
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, ValidationError
 from redis import __version__ as redis_version

--- a/redisvl/query/aggregate.py
+++ b/redisvl/query/aggregate.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Dict, List, Optional, Set, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator

--- a/redisvl/utils/redis_protocol.py
+++ b/redisvl/utils/redis_protocol.py
@@ -4,10 +4,8 @@ Wrapper for redis-py's get_protocol_version to handle edge cases.
 This fixes issue #365 where ClusterPipeline objects may not have nodes_manager attribute.
 """
 
-from typing import Optional, Union
+from typing import Optional
 
-from redis.asyncio.cluster import ClusterPipeline as AsyncClusterPipeline
-from redis.cluster import ClusterPipeline
 from redis.commands.helpers import get_protocol_version as redis_get_protocol_version
 
 

--- a/redisvl/utils/rerank/hf_cross_encoder.py
+++ b/redisvl/utils/rerank/hf_cross_encoder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import PrivateAttr
 

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -2,14 +2,13 @@ import asyncio
 import importlib
 import inspect
 import json
-import logging
 import sys
 import warnings
 from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
 from time import time
-from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, TypeVar, cast
+from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, TypeVar
 from warnings import warn
 
 from pydantic import BaseModel
@@ -238,7 +237,7 @@ def sync_wrapper(fn: Callable[[], Coroutine[Any, Any, Any]]) -> Callable[[], Non
                 asyncio.set_event_loop(loop)
             task = loop.create_task(fn())
             loop.run_until_complete(task)
-        except (RuntimeError, AttributeError, TypeError) as e:
+        except (RuntimeError, AttributeError, TypeError):
             # This could happen if an object stored an event loop and now
             # that event loop is closed, or if asyncio modules are being
             # torn down during interpreter shutdown.

--- a/redisvl/utils/vectorize/__init__.py
+++ b/redisvl/utils/vectorize/__init__.py
@@ -1,5 +1,3 @@
-import os
-
 from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.utils.vectorize.base import BaseVectorizer, Vectorizers
 from redisvl.utils.vectorize.bedrock import BedrockVectorizer


### PR DESCRIPTION
- Remove unused imports: Union, ClusterPipeline, AsyncClusterPipeline, logging, cast, Optional, os, lazy_import, SyncRedisCluster, Mapping, Awaitable, warnings
- Fix unused exception variables in index.py exception handlers
- Clean up HybridResult import used only for feature detection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup-only change: removes unused imports/variables and minor exception-handler refactors without altering core control flow or Redis commands.
> 
> **Overview**
> Removes a set of unused imports across CLI, cache, router, query, storage, vectorize, and protocol helper modules to satisfy linters and reduce dead dependencies.
> 
> Cleans up `SearchIndex`/`AsyncSearchIndex` exception handling to avoid unused exception variables, and tweaks hybrid-search feature detection by importing `HybridResult` under an alias purely to confirm availability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fab84bd9c58c5c17223a3110bc2276fd74d9e7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->