### PR TITLE
fix: stabilize test_text_query_word_weights with structural assertions

### DIFF
--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -354,22 +354,32 @@ def test_text_query_word_weights():
     desc_clause = query_str[desc_start + len("@description:(") : desc_close]
 
     # Weighted terms appear inside the description clause
-    assert "alpha=>{$weight:2}" in desc_clause
     assert "delta=>{$weight:0.555}" in desc_clause
 
-    # alpha appears twice (once per occurrence in input text) — count
-    assert desc_clause.count("alpha") == 2
+    # alpha appears twice and both occurrences are weighted
+    alpha_weighted = "alpha=>{$weight:2}"
+    assert desc_clause.count(alpha_weighted) == 2
+    # Ensure no unweighted 'alpha' tokens slipped through
+    idx = 0
+    while True:
+        idx = desc_clause.find("alpha", idx)
+        if idx == -1:
+            break
+        assert desc_clause.startswith(alpha_weighted, idx)
+        idx += len("alpha")
 
     # Unweighted terms are present
     for term in ["query", "string", "bravo", "tango"]:
         assert term in desc_clause
 
-    # Post-query modifiers follow after the closing paren
-    suffix = query_str[desc_close + 1 :]
-    assert suffix.lstrip().startswith("SCORER BM25STD")
-    assert "WITHSCORES" in suffix
-    assert "DIALECT 2" in suffix
-    assert "LIMIT 0 10" in suffix
+    # Post-query modifiers follow after the closing paren in expected order
+    suffix_stripped = suffix.lstrip()
+    assert suffix_stripped.startswith("SCORER BM25STD")
+    scorer_idx = suffix_stripped.index("SCORER BM25STD")
+    withscores_idx = suffix_stripped.index("WITHSCORES")
+    dialect_idx = suffix_stripped.index("DIALECT 2")
+    limit_idx = suffix_stripped.index("LIMIT 0 10")
+    assert scorer_idx <= withscores_idx <= dialect_idx <= limit_idx
 
     # raise an error if weights are not positive floats
     with pytest.raises(ValueError):

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -335,7 +335,6 @@ def test_text_query_with_string_filter():
     assert "AND" not in query_string_wildcard
 
 
-@pytest.mark.skip("Test is flaking")
 def test_text_query_word_weights():
     # verify word weights get added into the raw Redis query syntax
     query = TextQuery(
@@ -344,10 +343,33 @@ def test_text_query_word_weights():
         text_weights={"alpha": 2, "delta": 0.555, "gamma": 0.95},
     )
 
-    assert (
-        str(query)
-        == "@description:(query | string | alpha=>{$weight:2} | bravo | delta=>{$weight:0.555} | tango | alpha=>{$weight:2}) SCORER BM25STD WITHSCORES DIALECT 2 LIMIT 0 10"
-    )
+    # Check query components with structural guarantees,
+    # not exact token ordering (which is non-deterministic).
+    query_str = str(query)
+
+    # Description clause is properly delimited
+    assert "@description:(" in query_str
+    desc_start = query_str.index("@description:(")
+    desc_close = query_str.index(")", desc_start)
+    desc_clause = query_str[desc_start + len("@description:(") : desc_close]
+
+    # Weighted terms appear inside the description clause
+    assert "alpha=>{$weight:2}" in desc_clause
+    assert "delta=>{$weight:0.555}" in desc_clause
+
+    # alpha appears twice (once per occurrence in input text) — count
+    assert desc_clause.count("alpha") == 2
+
+    # Unweighted terms are present
+    for term in ["query", "string", "bravo", "tango"]:
+        assert term in desc_clause
+
+    # Post-query modifiers follow after the closing paren
+    suffix = query_str[desc_close + 1 :]
+    assert suffix.lstrip().startswith("SCORER BM25STD")
+    assert "WITHSCORES" in suffix
+    assert "DIALECT 2" in suffix
+    assert "LIMIT 0 10" in suffix
 
     # raise an error if weights are not positive floats
     with pytest.raises(ValueError):

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -373,6 +373,7 @@ def test_text_query_word_weights():
         assert term in desc_clause
 
     # Post-query modifiers follow after the closing paren in expected order
+    suffix = query_str[desc_close + 1 :]
     suffix_stripped = suffix.lstrip()
     assert suffix_stripped.startswith("SCORER BM25STD")
     scorer_idx = suffix_stripped.index("SCORER BM25STD")


### PR DESCRIPTION
## Summary
Fixes the flaky `test_text_query_word_weights` test (related to #497).

Replaces the exact-string assertion (sensitive to non-deterministic token ordering in older Python dicts) with **structural component checks**:

- Description clause is properly delimited with `(...)`
- Weighted terms (`alpha=>{$weight:2}`, `delta=>{$weight:0.555}`) appear inside the clause
- `alpha` count matches input frequency (2 occurrences)
- All unweighted terms are present
- Post-query modifiers (SCORER, WITHSCORES, DIALECT, LIMIT) follow in order

This is resistant to token ordering while still catching regressions in query structure. Addresses review feedback on #524.

## Testing
- [x] Unit tests pass (verified locally without Docker)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a unit test, replacing a brittle exact-string assertion with order-insensitive structural checks to reduce flakiness.
> 
> **Overview**
> Stabilizes `test_text_query_word_weights` by removing the skipped/brittle exact query-string comparison and replacing it with **structural assertions** that tolerate non-deterministic token ordering.
> 
> The test now validates the `@description:(...)` clause contents (including weighted terms and repeated weighted `alpha`) and ensures the expected post-query modifiers (`SCORER`, `WITHSCORES`, `DIALECT`, `LIMIT`) appear after the clause in the correct sequence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96805235c881f3af0ad8287f430a8c3c20e5d8e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->