### PR TITLE
feat(migrate): [1/6] Design and base models

### DIFF
--- a/redisvl/migration/__init__.py
+++ b/redisvl/migration/__init__.py
@@ -1,0 +1,7 @@
+from redisvl.migration.planner import MigrationPlanner
+from redisvl.migration.validation import MigrationValidator
+
+__all__ = [
+    "MigrationPlanner",
+    "MigrationValidator",
+]

--- a/redisvl/migration/models.py
+++ b/redisvl/migration/models.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class FieldUpdate(BaseModel):
+    """Partial field update for schema patch inputs."""
+
+    name: str
+    type: Optional[str] = None
+    path: Optional[str] = None
+    attrs: Dict[str, Any] = Field(default_factory=dict)
+    options: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def merge_options_into_attrs(self) -> "FieldUpdate":
+        if self.options:
+            merged_attrs = dict(self.attrs)
+            merged_attrs.update(self.options)
+            self.attrs = merged_attrs
+            self.options = {}
+        return self
+
+
+class FieldRename(BaseModel):
+    """Field rename specification for schema patch inputs."""
+
+    old_name: str
+    new_name: str
+
+
+class SchemaPatchChanges(BaseModel):
+    add_fields: List[Dict[str, Any]] = Field(default_factory=list)
+    remove_fields: List[str] = Field(default_factory=list)
+    update_fields: List[FieldUpdate] = Field(default_factory=list)
+    rename_fields: List[FieldRename] = Field(default_factory=list)
+    index: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SchemaPatch(BaseModel):
+    version: int = 1
+    changes: SchemaPatchChanges = Field(default_factory=SchemaPatchChanges)
+
+
+class KeyspaceSnapshot(BaseModel):
+    storage_type: str
+    prefixes: List[str]
+    key_separator: str
+    key_sample: List[str] = Field(default_factory=list)
+
+
+class SourceSnapshot(BaseModel):
+    index_name: str
+    schema_snapshot: Dict[str, Any]
+    stats_snapshot: Dict[str, Any]
+    keyspace: KeyspaceSnapshot
+
+
+class DiffClassification(BaseModel):
+    supported: bool
+    blocked_reasons: List[str] = Field(default_factory=list)
+
+
+class ValidationPolicy(BaseModel):
+    require_doc_count_match: bool = True
+    require_schema_match: bool = True
+
+
+class RenameOperations(BaseModel):
+    """Tracks which rename operations are required for a migration."""
+
+    rename_index: Optional[str] = None  # New index name if renaming
+    change_prefix: Optional[str] = None  # New prefix if changing
+    rename_fields: List[FieldRename] = Field(default_factory=list)
+
+    @property
+    def has_operations(self) -> bool:
+        return bool(
+            self.rename_index is not None
+            or self.change_prefix is not None
+            or self.rename_fields
+        )
+
+
+class MigrationPlan(BaseModel):
+    version: int = 1
+    mode: str = "drop_recreate"
+    source: SourceSnapshot
+    requested_changes: Dict[str, Any]
+    merged_target_schema: Dict[str, Any]
+    diff_classification: DiffClassification
+    rename_operations: RenameOperations = Field(default_factory=RenameOperations)
+    warnings: List[str] = Field(default_factory=list)
+    validation: ValidationPolicy = Field(default_factory=ValidationPolicy)
+
+
+class QueryCheckResult(BaseModel):
+    name: str
+    passed: bool
+    details: Optional[str] = None
+
+
+class MigrationValidation(BaseModel):
+    schema_match: bool = False
+    doc_count_match: bool = False
+    key_sample_exists: bool = False
+    indexing_failures_delta: int = 0
+    query_checks: List[QueryCheckResult] = Field(default_factory=list)
+    errors: List[str] = Field(default_factory=list)
+
+
+class MigrationTimings(BaseModel):
+    total_migration_duration_seconds: Optional[float] = None
+    drop_duration_seconds: Optional[float] = None
+    quantize_duration_seconds: Optional[float] = None
+    field_rename_duration_seconds: Optional[float] = None
+    key_rename_duration_seconds: Optional[float] = None
+    recreate_duration_seconds: Optional[float] = None
+    initial_indexing_duration_seconds: Optional[float] = None
+    validation_duration_seconds: Optional[float] = None
+    downtime_duration_seconds: Optional[float] = None
+
+
+class MigrationBenchmarkSummary(BaseModel):
+    documents_indexed_per_second: Optional[float] = None
+    source_index_size_mb: Optional[float] = None
+    target_index_size_mb: Optional[float] = None
+    index_size_delta_mb: Optional[float] = None
+
+
+class MigrationReport(BaseModel):
+    version: int = 1
+    mode: str = "drop_recreate"
+    source_index: str
+    target_index: str
+    result: str
+    started_at: str
+    finished_at: str
+    timings: MigrationTimings = Field(default_factory=MigrationTimings)
+    validation: MigrationValidation = Field(default_factory=MigrationValidation)
+    benchmark_summary: MigrationBenchmarkSummary = Field(
+        default_factory=MigrationBenchmarkSummary
+    )
+    disk_space_estimate: Optional["DiskSpaceEstimate"] = None
+    warnings: List[str] = Field(default_factory=list)
+    manual_actions: List[str] = Field(default_factory=list)
+
+
+# -----------------------------------------------------------------------------
+# Disk Space Estimation
+# -----------------------------------------------------------------------------
+
+# Bytes per element for each vector datatype
+DTYPE_BYTES: Dict[str, int] = {
+    "float64": 8,
+    "float32": 4,
+    "float16": 2,
+    "bfloat16": 2,
+    "int8": 1,
+    "uint8": 1,
+}
+
+# AOF protocol overhead per HSET command (RESP framing)
+AOF_HSET_OVERHEAD_BYTES = 114
+# JSON.SET has slightly larger RESP framing
+AOF_JSON_SET_OVERHEAD_BYTES = 140
+# RDB compression ratio for pseudo-random vector data (compresses poorly)
+RDB_COMPRESSION_RATIO = 0.95
+
+
+class VectorFieldEstimate(BaseModel):
+    """Per-field disk space breakdown for a single vector field."""
+
+    field_name: str
+    dims: int
+    source_dtype: str
+    target_dtype: str
+    source_bytes_per_doc: int
+    target_bytes_per_doc: int
+
+
+class DiskSpaceEstimate(BaseModel):
+    """Pre-migration estimate of disk and memory costs.
+
+    Produced by estimate_disk_space() as a pure calculation from the migration
+    plan. No Redis mutations are performed.
+    """
+
+    # Index metadata
+    index_name: str
+    doc_count: int
+    storage_type: str = "hash"
+
+    # Per-field breakdowns
+    vector_fields: List[VectorFieldEstimate] = Field(default_factory=list)
+
+    # Aggregate vector data sizes
+    total_source_vector_bytes: int = 0
+    total_target_vector_bytes: int = 0
+
+    # RDB snapshot cost (BGSAVE before migration)
+    rdb_snapshot_disk_bytes: int = 0
+    rdb_cow_memory_if_concurrent_bytes: int = 0
+
+    # AOF growth cost (only if aof_enabled is True)
+    aof_enabled: bool = False
+    aof_growth_bytes: int = 0
+
+    # Totals
+    total_new_disk_bytes: int = 0
+    memory_savings_after_bytes: int = 0
+
+    @property
+    def has_quantization(self) -> bool:
+        return len(self.vector_fields) > 0
+
+    def summary(self) -> str:
+        """Human-readable summary for CLI output."""
+        if not self.has_quantization:
+            return "No vector quantization in this migration. No additional disk space required."
+
+        lines = [
+            "Pre-migration disk space estimate:",
+            f"  Index: {self.index_name} ({self.doc_count:,} documents)",
+        ]
+        for vf in self.vector_fields:
+            lines.append(
+                f"  Vector field '{vf.field_name}': {vf.dims} dims, "
+                f"{vf.source_dtype} -> {vf.target_dtype}"
+            )
+
+        lines.append("")
+        lines.append(
+            f"  RDB snapshot (BGSAVE):        ~{_format_bytes(self.rdb_snapshot_disk_bytes)}"
+        )
+        if self.aof_enabled:
+            lines.append(
+                f"  AOF growth (appendonly=yes):  ~{_format_bytes(self.aof_growth_bytes)}"
+            )
+        else:
+            lines.append(
+                "  AOF growth:                  not estimated (pass aof_enabled=True if AOF is on)"
+            )
+        lines.append(
+            f"  Total new disk required:      ~{_format_bytes(self.total_new_disk_bytes)}"
+        )
+        lines.append("")
+        lines.append(
+            f"  Post-migration memory delta:   ~{_format_bytes(abs(self.memory_savings_after_bytes))} "
+            f"({'reduction' if self.memory_savings_after_bytes >= 0 else 'increase'}, "
+            f"{abs(self._savings_pct())}%)"
+        )
+        return "\n".join(lines)
+
+    def _savings_pct(self) -> int:
+        if self.total_source_vector_bytes == 0:
+            return 0
+        return round(
+            100 * self.memory_savings_after_bytes / self.total_source_vector_bytes
+        )
+
+
+def _format_bytes(n: int) -> str:
+    """Format byte count as human-readable string."""
+    if n >= 1_073_741_824:
+        return f"{n / 1_073_741_824:.2f} GB"
+    if n >= 1_048_576:
+        return f"{n / 1_048_576:.1f} MB"
+    if n >= 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n} bytes"
+
+
+# -----------------------------------------------------------------------------
+# Batch Migration Models
+# -----------------------------------------------------------------------------
+
+
+class BatchIndexEntry(BaseModel):
+    """Entry for a single index in a batch migration plan."""
+
+    name: str
+    applicable: bool = True
+    skip_reason: Optional[str] = None
+
+
+class BatchPlan(BaseModel):
+    """Plan for migrating multiple indexes with a shared patch."""
+
+    version: int = 1
+    batch_id: str
+    mode: str = "drop_recreate"
+    failure_policy: str = "fail_fast"  # or "continue_on_error"
+    requires_quantization: bool = False
+    shared_patch: SchemaPatch
+    indexes: List[BatchIndexEntry] = Field(default_factory=list)
+    created_at: str
+
+    @property
+    def applicable_count(self) -> int:
+        return sum(1 for idx in self.indexes if idx.applicable)
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for idx in self.indexes if not idx.applicable)
+
+
+class BatchIndexState(BaseModel):
+    """State of a single index in batch execution."""
+
+    name: str
+    status: str  # pending, in_progress, success, failed, skipped
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    failed_at: Optional[str] = None
+    error: Optional[str] = None
+    report_path: Optional[str] = None
+
+
+class BatchState(BaseModel):
+    """Checkpoint state for batch migration execution."""
+
+    batch_id: str
+    plan_path: str
+    started_at: str
+    updated_at: str
+    completed: List[BatchIndexState] = Field(default_factory=list)
+    current_index: Optional[str] = None
+    remaining: List[str] = Field(default_factory=list)
+
+    @property
+    def success_count(self) -> int:
+        return sum(1 for idx in self.completed if idx.status == "success")
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for idx in self.completed if idx.status == "failed")
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for idx in self.completed if idx.status == "skipped")
+
+    @property
+    def is_complete(self) -> bool:
+        return len(self.remaining) == 0 and self.current_index is None
+
+
+class BatchReportSummary(BaseModel):
+    """Summary statistics for batch migration."""
+
+    total_indexes: int = 0
+    successful: int = 0
+    failed: int = 0
+    skipped: int = 0
+    total_duration_seconds: float = 0.0
+
+
+class BatchIndexReport(BaseModel):
+    """Report for a single index in batch execution."""
+
+    name: str
+    status: str  # success, failed, skipped
+    duration_seconds: Optional[float] = None
+    docs_migrated: Optional[int] = None
+    report_path: Optional[str] = None
+    error: Optional[str] = None
+
+
+class BatchReport(BaseModel):
+    """Final report for batch migration execution."""
+
+    version: int = 1
+    batch_id: str
+    status: str  # completed, partial_failure, failed
+    summary: BatchReportSummary = Field(default_factory=BatchReportSummary)
+    indexes: List[BatchIndexReport] = Field(default_factory=list)
+    started_at: str
+    completed_at: str

--- a/redisvl/migration/planner.py
+++ b/redisvl/migration/planner.py
@@ -1,0 +1,735 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from redisvl.index import SearchIndex
+from redisvl.migration.models import (
+    DiffClassification,
+    FieldRename,
+    KeyspaceSnapshot,
+    MigrationPlan,
+    RenameOperations,
+    SchemaPatch,
+    SourceSnapshot,
+)
+from redisvl.redis.connection import supports_svs
+from redisvl.schema.schema import IndexSchema
+
+
+class MigrationPlanner:
+    """Migration planner for drop/recreate-based index migrations.
+
+    The `drop_recreate` mode drops the index definition and recreates it with
+    a new schema. By default, documents are preserved in Redis. When possible,
+    the planner/executor can apply transformations so the preserved documents
+    remain compatible with the new index schema.
+
+    This means:
+    - Index-only changes are always safe (algorithm, distance metric, tuning
+      params, quantization, etc.)
+    - Some document-dependent changes are supported via explicit migration
+      operations in the migration plan
+
+    Supported document-dependent changes:
+    - Prefix/keyspace changes: keys are renamed via RENAME command
+    - Field renames: documents are updated to use new field names
+    - Index renaming: the new index is created with a different name
+
+    Document-dependent changes that remain unsupported:
+    - Vector dimensions: stored vectors have wrong number of dimensions
+    - Storage type: documents are in hash format but index expects JSON
+    """
+
+    def __init__(self, key_sample_limit: int = 10):
+        self.key_sample_limit = key_sample_limit
+
+    def create_plan(
+        self,
+        index_name: str,
+        *,
+        redis_url: Optional[str] = None,
+        schema_patch_path: Optional[str] = None,
+        target_schema_path: Optional[str] = None,
+        redis_client: Optional[Any] = None,
+    ) -> MigrationPlan:
+        if not schema_patch_path and not target_schema_path:
+            raise ValueError(
+                "Must provide either --schema-patch or --target-schema for migration planning"
+            )
+        if schema_patch_path and target_schema_path:
+            raise ValueError(
+                "Provide only one of --schema-patch or --target-schema for migration planning"
+            )
+
+        snapshot = self.snapshot_source(
+            index_name,
+            redis_url=redis_url,
+            redis_client=redis_client,
+        )
+        source_schema = IndexSchema.from_dict(snapshot.schema_snapshot)
+
+        if schema_patch_path:
+            schema_patch = self.load_schema_patch(schema_patch_path)
+        else:
+            # target_schema_path is guaranteed non-None here due to validation above
+            assert target_schema_path is not None
+            schema_patch = self.normalize_target_schema_to_patch(
+                source_schema, target_schema_path
+            )
+
+        return self.create_plan_from_patch(
+            index_name,
+            schema_patch=schema_patch,
+            redis_url=redis_url,
+            redis_client=redis_client,
+            _snapshot=snapshot,
+        )
+
+    def create_plan_from_patch(
+        self,
+        index_name: str,
+        *,
+        schema_patch: SchemaPatch,
+        redis_url: Optional[str] = None,
+        redis_client: Optional[Any] = None,
+        _snapshot: Optional[Any] = None,
+    ) -> MigrationPlan:
+        if _snapshot is None:
+            _snapshot = self.snapshot_source(
+                index_name,
+                redis_url=redis_url,
+                redis_client=redis_client,
+            )
+        snapshot = _snapshot
+        source_schema = IndexSchema.from_dict(snapshot.schema_snapshot)
+        merged_target_schema = self.merge_patch(source_schema, schema_patch)
+
+        # Extract rename operations first
+        rename_operations, rename_warnings = self._extract_rename_operations(
+            source_schema, schema_patch
+        )
+
+        # Classify diff with awareness of rename operations
+        diff_classification = self.classify_diff(
+            source_schema, schema_patch, merged_target_schema, rename_operations
+        )
+
+        # Build warnings list
+        warnings = ["Index downtime is required"]
+        warnings.extend(rename_warnings)
+
+        # Check for SVS-VAMANA in target schema and add appropriate warnings
+        svs_warnings = self._check_svs_vamana_requirements(
+            merged_target_schema,
+            redis_url=redis_url,
+            redis_client=redis_client,
+        )
+        warnings.extend(svs_warnings)
+
+        return MigrationPlan(
+            source=snapshot,
+            requested_changes=schema_patch.model_dump(exclude_none=True),
+            merged_target_schema=merged_target_schema.to_dict(),
+            diff_classification=diff_classification,
+            rename_operations=rename_operations,
+            warnings=warnings,
+        )
+
+    def snapshot_source(
+        self,
+        index_name: str,
+        *,
+        redis_url: Optional[str] = None,
+        redis_client: Optional[Any] = None,
+    ) -> SourceSnapshot:
+        index = SearchIndex.from_existing(
+            index_name,
+            redis_url=redis_url,
+            redis_client=redis_client,
+        )
+        schema_dict = index.schema.to_dict()
+        stats_snapshot = index.info()
+        prefixes = index.schema.index.prefix
+        prefix_list = prefixes if isinstance(prefixes, list) else [prefixes]
+
+        return SourceSnapshot(
+            index_name=index_name,
+            schema_snapshot=schema_dict,
+            stats_snapshot=stats_snapshot,
+            keyspace=KeyspaceSnapshot(
+                storage_type=index.schema.index.storage_type.value,
+                prefixes=prefix_list,
+                key_separator=index.schema.index.key_separator,
+                key_sample=self._sample_keys(
+                    client=index.client,
+                    prefixes=prefix_list,
+                    key_separator=index.schema.index.key_separator,
+                ),
+            ),
+        )
+
+    def load_schema_patch(self, schema_patch_path: str) -> SchemaPatch:
+        patch_path = Path(schema_patch_path).resolve()
+        if not patch_path.exists():
+            raise FileNotFoundError(
+                f"Schema patch file {schema_patch_path} does not exist"
+            )
+
+        with open(patch_path, "r") as f:
+            patch_data = yaml.safe_load(f) or {}
+        return SchemaPatch.model_validate(patch_data)
+
+    def normalize_target_schema_to_patch(
+        self, source_schema: IndexSchema, target_schema_path: str
+    ) -> SchemaPatch:
+        target_schema = IndexSchema.from_yaml(target_schema_path)
+        source_dict = source_schema.to_dict()
+        target_dict = target_schema.to_dict()
+
+        changes: Dict[str, Any] = {
+            "add_fields": [],
+            "remove_fields": [],
+            "update_fields": [],
+            "index": {},
+        }
+
+        source_fields = {field["name"]: field for field in source_dict["fields"]}
+        target_fields = {field["name"]: field for field in target_dict["fields"]}
+
+        for field_name, target_field in target_fields.items():
+            if field_name not in source_fields:
+                changes["add_fields"].append(target_field)
+            elif source_fields[field_name] != target_field:
+                changes["update_fields"].append(target_field)
+
+        for field_name in source_fields:
+            if field_name not in target_fields:
+                changes["remove_fields"].append(field_name)
+
+        for index_key, target_value in target_dict["index"].items():
+            source_value = source_dict["index"].get(index_key)
+            if source_value != target_value:
+                changes["index"][index_key] = target_value
+
+        return SchemaPatch.model_validate({"version": 1, "changes": changes})
+
+    def merge_patch(
+        self, source_schema: IndexSchema, schema_patch: SchemaPatch
+    ) -> IndexSchema:
+        schema_dict = deepcopy(source_schema.to_dict())
+        changes = schema_patch.changes
+        fields_by_name = {
+            field["name"]: deepcopy(field) for field in schema_dict["fields"]
+        }
+
+        # Apply field renames first (before other modifications)
+        # This ensures the merged schema's field names match the executor's renamed fields
+        for rename in changes.rename_fields:
+            if rename.old_name not in fields_by_name:
+                raise ValueError(
+                    f"Cannot rename field '{rename.old_name}' because it does not exist in the source schema"
+                )
+            if rename.new_name in fields_by_name and rename.new_name != rename.old_name:
+                raise ValueError(
+                    f"Cannot rename field '{rename.old_name}' to '{rename.new_name}' because a field with the new name already exists"
+                )
+            if rename.new_name == rename.old_name:
+                continue  # No-op rename
+            field_def = fields_by_name.pop(rename.old_name)
+            field_def["name"] = rename.new_name
+            fields_by_name[rename.new_name] = field_def
+
+        for field_name in changes.remove_fields:
+            fields_by_name.pop(field_name, None)
+
+        # Build a mapping from old field names to new names so that
+        # update_fields entries referencing pre-rename names still resolve.
+        rename_map = {
+            rename.old_name: rename.new_name
+            for rename in changes.rename_fields
+            if rename.old_name != rename.new_name
+        }
+
+        for field_update in changes.update_fields:
+            # Resolve through renames: if the update references the old name,
+            # look up the field under its new name.
+            resolved_name = rename_map.get(field_update.name, field_update.name)
+            if resolved_name not in fields_by_name:
+                raise ValueError(
+                    f"Cannot update field '{field_update.name}' because it does not exist in the source schema"
+                )
+            existing_field = fields_by_name[resolved_name]
+            if field_update.type is not None:
+                existing_field["type"] = field_update.type
+            if field_update.path is not None:
+                existing_field["path"] = field_update.path
+            if field_update.attrs:
+                merged_attrs = dict(existing_field.get("attrs", {}))
+                merged_attrs.update(field_update.attrs)
+                existing_field["attrs"] = merged_attrs
+
+        for field in changes.add_fields:
+            field_name = field["name"]
+            if field_name in fields_by_name:
+                raise ValueError(
+                    f"Cannot add field '{field_name}' because it already exists in the source schema"
+                )
+            fields_by_name[field_name] = deepcopy(field)
+
+        schema_dict["fields"] = list(fields_by_name.values())
+        schema_dict["index"].update(changes.index)
+        return IndexSchema.from_dict(schema_dict)
+
+    def _extract_rename_operations(
+        self,
+        source_schema: IndexSchema,
+        schema_patch: SchemaPatch,
+    ) -> Tuple[RenameOperations, List[str]]:
+        """Extract rename operations from the patch and generate warnings.
+
+        Returns:
+            Tuple of (RenameOperations, warnings list)
+        """
+        source_dict = source_schema.to_dict()
+        changes = schema_patch.changes
+        warnings: List[str] = []
+
+        # Index rename
+        rename_index: Optional[str] = None
+        if "name" in changes.index:
+            new_name = changes.index["name"]
+            old_name = source_dict["index"].get("name")
+            if new_name != old_name:
+                rename_index = new_name
+                warnings.append(
+                    f"Index rename: '{old_name}' -> '{new_name}' (index-only change, no document migration needed)"
+                )
+
+        # Prefix change
+        change_prefix: Optional[str] = None
+        if "prefix" in changes.index:
+            new_prefix = changes.index["prefix"]
+            # Normalize list-type prefix to a single string (local copy only)
+            if isinstance(new_prefix, list):
+                if len(new_prefix) != 1:
+                    raise ValueError(
+                        f"Target prefix must be a single string, got list: {new_prefix}. "
+                        f"Multi-prefix migrations are not supported."
+                    )
+                new_prefix = new_prefix[0]
+            old_prefix = source_dict["index"].get("prefix")
+            # Normalize single-element list to string for comparison
+            if isinstance(old_prefix, list) and len(old_prefix) == 1:
+                old_prefix = old_prefix[0]
+            if new_prefix != old_prefix:
+                # Block multi-prefix migrations - we only support single prefix
+                if isinstance(old_prefix, list) and len(old_prefix) > 1:
+                    raise ValueError(
+                        f"Cannot change prefix for multi-prefix indexes. "
+                        f"Source index has multiple prefixes: {old_prefix}. "
+                        f"Multi-prefix migrations are not supported."
+                    )
+                change_prefix = new_prefix
+                warnings.append(
+                    f"Prefix change: '{old_prefix}' -> '{new_prefix}' "
+                    "(requires RENAME for all keys, may be slow for large datasets)"
+                )
+
+        # Field renames from explicit rename_fields
+        rename_fields: List[FieldRename] = list(changes.rename_fields)
+        for field_rename in rename_fields:
+            warnings.append(
+                f"Field rename: '{field_rename.old_name}' -> '{field_rename.new_name}' "
+                "(requires read/write for all documents, may be slow for large datasets)"
+            )
+
+        return (
+            RenameOperations(
+                rename_index=rename_index,
+                change_prefix=change_prefix,
+                rename_fields=rename_fields,
+            ),
+            warnings,
+        )
+
+    def _check_svs_vamana_requirements(
+        self,
+        target_schema: IndexSchema,
+        *,
+        redis_url: Optional[str] = None,
+        redis_client: Optional[Any] = None,
+    ) -> List[str]:
+        """Check SVS-VAMANA requirements and return warnings.
+
+        Checks:
+        1. If target uses SVS-VAMANA, verify Redis version supports it
+        2. Add Intel hardware warning for LVQ/LeanVec optimizations
+        """
+        warnings: List[str] = []
+        target_dict = target_schema.to_dict()
+
+        # Check if any vector field uses SVS-VAMANA
+        uses_svs = False
+        uses_compression = False
+        compression_type = None
+
+        for field in target_dict.get("fields", []):
+            if field.get("type") != "vector":
+                continue
+            attrs = field.get("attrs", {})
+            algo = attrs.get("algorithm", "").upper()
+            if algo == "SVS-VAMANA":
+                uses_svs = True
+                compression = attrs.get("compression", "")
+                if compression:
+                    uses_compression = True
+                    compression_type = compression
+
+        if not uses_svs:
+            return warnings
+
+        # Check Redis version support
+        created_client = None
+        try:
+            if redis_client:
+                client = redis_client
+            elif redis_url:
+                from redis import Redis
+
+                client = Redis.from_url(redis_url)
+                created_client = client
+            else:
+                client = None
+
+            if client and not supports_svs(client):
+                warnings.append(
+                    "SVS-VAMANA requires Redis >= 8.2.0 and Redis Search >= 2.8.10. "
+                    "The target Redis instance may not support this algorithm. "
+                    "Migration will fail at apply time if requirements are not met."
+                )
+        except Exception:
+            # If we can't check, add a general warning
+            warnings.append(
+                "SVS-VAMANA requires Redis >= 8.2.0 and Redis Search >= 2.8.10. "
+                "Verify your Redis instance supports this algorithm before applying."
+            )
+        finally:
+            if created_client:
+                created_client.close()
+
+        # Intel hardware warning for compression
+        if uses_compression:
+            warnings.append(
+                f"SVS-VAMANA with {compression_type} compression: "
+                "LVQ and LeanVec optimizations require Intel hardware with AVX-512 support. "
+                "On non-Intel platforms or Redis Open Source, these fall back to basic "
+                "8-bit scalar quantization with reduced performance benefits."
+            )
+        else:
+            warnings.append(
+                "SVS-VAMANA: For optimal performance, Intel hardware with AVX-512 support "
+                "is recommended. LVQ/LeanVec compression options provide additional memory "
+                "savings on supported hardware."
+            )
+
+        return warnings
+
+    def classify_diff(
+        self,
+        source_schema: IndexSchema,
+        schema_patch: SchemaPatch,
+        merged_target_schema: IndexSchema,
+        rename_operations: Optional[RenameOperations] = None,
+    ) -> DiffClassification:
+        blocked_reasons: List[str] = []
+        changes = schema_patch.changes
+        source_dict = source_schema.to_dict()
+        target_dict = merged_target_schema.to_dict()
+
+        # Check which rename operations are being handled
+        has_index_rename = rename_operations and rename_operations.rename_index
+        has_prefix_change = (
+            rename_operations and rename_operations.change_prefix is not None
+        )
+        has_field_renames = (
+            rename_operations and len(rename_operations.rename_fields) > 0
+        )
+
+        for index_key, target_value in changes.index.items():
+            source_value = source_dict["index"].get(index_key)
+            # Normalize single-element list prefixes for comparison so that
+            # e.g. source ``["docs"]`` and target ``"docs"`` are treated as equal.
+            sv, tv = source_value, target_value
+            if index_key == "prefix":
+                if isinstance(sv, list) and len(sv) == 1:
+                    sv = sv[0]
+                if isinstance(tv, list) and len(tv) == 1:
+                    tv = tv[0]
+            if sv == tv:
+                continue
+            if index_key == "name":
+                # Index rename is now supported - skip blocking if we have rename_operations
+                if not has_index_rename:
+                    blocked_reasons.append(
+                        "Changing the index name requires document migration (not yet supported)."
+                    )
+            elif index_key == "prefix":
+                # Prefix change is now supported
+                if not has_prefix_change:
+                    blocked_reasons.append(
+                        "Changing index prefixes requires document migration (not yet supported)."
+                    )
+            elif index_key == "key_separator":
+                blocked_reasons.append(
+                    "Changing the key separator requires document migration (not yet supported)."
+                )
+            elif index_key == "storage_type":
+                blocked_reasons.append(
+                    "Changing the storage type requires document migration (not yet supported)."
+                )
+
+        source_fields = {field["name"]: field for field in source_dict["fields"]}
+        target_fields = {field["name"]: field for field in target_dict["fields"]}
+
+        for field in changes.add_fields:
+            if field["type"] == "vector":
+                blocked_reasons.append(
+                    f"Adding vector field '{field['name']}' requires document migration (not yet supported)."
+                )
+
+        # Build rename mappings: old->new and new->old so update_fields
+        # can reference either the pre-rename or post-rename name
+        classify_rename_map = {
+            rename.old_name: rename.new_name
+            for rename in changes.rename_fields
+            if rename.old_name != rename.new_name
+        }
+        reverse_rename_map = {v: k for k, v in classify_rename_map.items()}
+
+        for field_update in changes.update_fields:
+            # Resolve through renames: update_fields may use old or new name
+            if field_update.name in classify_rename_map:
+                # update references old name -> look up source by old, target by new
+                source_name = field_update.name
+                target_name = classify_rename_map[field_update.name]
+            elif field_update.name in reverse_rename_map:
+                # update references new name -> look up source by old, target by new
+                source_name = reverse_rename_map[field_update.name]
+                target_name = field_update.name
+            else:
+                # no rename involved
+                source_name = field_update.name
+                target_name = field_update.name
+            source_field = source_fields.get(source_name)
+            target_field = target_fields.get(target_name)
+            if source_field is None or target_field is None:
+                # Field not found in source or target; skip classification
+                continue
+            source_type = source_field["type"]
+            target_type = target_field["type"]
+
+            if source_type != target_type:
+                blocked_reasons.append(
+                    f"Changing field '{field_update.name}' type from {source_type} to {target_type} is not supported by drop_recreate."
+                )
+                continue
+
+            source_path = source_field.get("path")
+            target_path = target_field.get("path")
+            if source_path != target_path:
+                blocked_reasons.append(
+                    f"Changing field '{field_update.name}' path from {source_path} to {target_path} is not supported by drop_recreate."
+                )
+                continue
+
+            if target_type == "vector" and source_field != target_field:
+                # Check for document-dependent changes that are not yet supported
+                vector_blocked = self._classify_vector_field_change(
+                    source_field, target_field
+                )
+                blocked_reasons.extend(vector_blocked)
+
+        # Detect possible undeclared field renames. When explicit renames
+        # exist, exclude those fields from heuristic detection so we still
+        # catch additional add/remove pairs that look like renames.
+        detect_source = dict(source_fields)
+        detect_target = dict(target_fields)
+        if has_field_renames and rename_operations:
+            for fr in rename_operations.rename_fields:
+                detect_source.pop(fr.old_name, None)
+                detect_target.pop(fr.new_name, None)
+        blocked_reasons.extend(
+            self._detect_possible_field_renames(detect_source, detect_target)
+        )
+
+        return DiffClassification(
+            supported=len(blocked_reasons) == 0,
+            blocked_reasons=self._dedupe(blocked_reasons),
+        )
+
+    def write_plan(self, plan: MigrationPlan, plan_out: str) -> None:
+        plan_path = Path(plan_out).resolve()
+        with open(plan_path, "w") as f:
+            yaml.safe_dump(plan.model_dump(exclude_none=True), f, sort_keys=False)
+
+    def _sample_keys(
+        self, *, client: Any, prefixes: List[str], key_separator: str
+    ) -> List[str]:
+        key_sample: List[str] = []
+        if client is None or self.key_sample_limit <= 0:
+            return key_sample
+
+        for prefix in prefixes:
+            if len(key_sample) >= self.key_sample_limit:
+                break
+            if prefix == "":
+                match_pattern = "*"
+            elif prefix.endswith(key_separator):
+                match_pattern = f"{prefix}*"
+            else:
+                match_pattern = f"{prefix}{key_separator}*"
+            cursor = 0
+            while True:
+                cursor, keys = client.scan(
+                    cursor=cursor,
+                    match=match_pattern,
+                    count=max(self.key_sample_limit, 10),
+                )
+                for key in keys:
+                    decoded_key = key.decode() if isinstance(key, bytes) else str(key)
+                    if decoded_key not in key_sample:
+                        key_sample.append(decoded_key)
+                    if len(key_sample) >= self.key_sample_limit:
+                        return key_sample
+                if cursor == 0:
+                    break
+        return key_sample
+
+    def _detect_possible_field_renames(
+        self,
+        source_fields: Dict[str, Dict[str, Any]],
+        target_fields: Dict[str, Dict[str, Any]],
+    ) -> List[str]:
+        blocked_reasons: List[str] = []
+        added_fields = [
+            field for name, field in target_fields.items() if name not in source_fields
+        ]
+        removed_fields = [
+            field for name, field in source_fields.items() if name not in target_fields
+        ]
+
+        for removed_field in removed_fields:
+            for added_field in added_fields:
+                if self._fields_match_except_name(removed_field, added_field):
+                    blocked_reasons.append(
+                        f"Possible field rename from '{removed_field['name']}' to '{added_field['name']}' is not supported by drop_recreate."
+                    )
+        return blocked_reasons
+
+    @staticmethod
+    def _classify_vector_field_change(
+        source_field: Dict[str, Any], target_field: Dict[str, Any]
+    ) -> List[str]:
+        """Classify vector field changes as supported or blocked for drop_recreate.
+
+        Index-only changes (allowed with drop_recreate):
+            - algorithm (FLAT -> HNSW -> SVS-VAMANA)
+            - distance_metric (COSINE, L2, IP)
+            - initial_cap
+            - Algorithm tuning: m, ef_construction, ef_runtime, epsilon, block_size,
+              graph_max_degree, construction_window_size, search_window_size, etc.
+
+        Quantization changes (allowed with drop_recreate, requires vector re-encoding):
+            - datatype (float32 -> float16, etc.) - executor will re-encode vectors
+
+        Document-dependent changes (blocked, not yet supported):
+            - dims (vectors stored with wrong number of dimensions)
+        """
+        blocked_reasons: List[str] = []
+        field_name = source_field.get("name", "unknown")
+        source_attrs = source_field.get("attrs", {})
+        target_attrs = target_field.get("attrs", {})
+
+        # Document-dependent properties (not yet supported)
+        if source_attrs.get("dims") != target_attrs.get("dims"):
+            blocked_reasons.append(
+                f"Changing vector field '{field_name}' dims from {source_attrs.get('dims')} "
+                f"to {target_attrs.get('dims')} requires document migration (not yet supported). "
+                "Vectors are stored with incompatible dimensions."
+            )
+
+        # Datatype changes are now ALLOWED - executor will re-encode vectors
+        # before recreating the index
+
+        # All other vector changes are index-only and allowed
+        return blocked_reasons
+
+    @staticmethod
+    def get_vector_datatype_changes(
+        source_schema: Dict[str, Any],
+        target_schema: Dict[str, Any],
+        rename_operations: Optional[Any] = None,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Identify vector fields that need datatype conversion (quantization).
+
+        Handles renamed vector fields by using rename_operations to map
+        source field names to their target counterparts.
+
+        Returns:
+            Dict mapping source_field_name -> {
+                "source": source_dtype,
+                "target": target_dtype,
+                "dims": int  # vector dimensions for idempotent detection
+            }
+        """
+        changes: Dict[str, Dict[str, Any]] = {}
+        source_fields = {f["name"]: f for f in source_schema.get("fields", [])}
+        target_fields = {f["name"]: f for f in target_schema.get("fields", [])}
+
+        # Build rename map: source_name -> target_name
+        field_rename_map: Dict[str, str] = {}
+        if rename_operations and hasattr(rename_operations, "rename_fields"):
+            for fr in rename_operations.rename_fields:
+                field_rename_map[fr.old_name] = fr.new_name
+
+        for name, source_field in source_fields.items():
+            if source_field.get("type") != "vector":
+                continue
+            # Look up target by renamed name if applicable
+            target_name = field_rename_map.get(name, name)
+            target_field = target_fields.get(target_name)
+            if not target_field or target_field.get("type") != "vector":
+                continue
+
+            source_dtype = source_field.get("attrs", {}).get("datatype", "float32")
+            target_dtype = target_field.get("attrs", {}).get("datatype", "float32")
+            dims = source_field.get("attrs", {}).get("dims", 0)
+
+            if source_dtype != target_dtype:
+                changes[name] = {
+                    "source": source_dtype,
+                    "target": target_dtype,
+                    "dims": dims,
+                }
+
+        return changes
+
+    @staticmethod
+    def _fields_match_except_name(
+        source_field: Dict[str, Any], target_field: Dict[str, Any]
+    ) -> bool:
+        comparable_source = {k: v for k, v in source_field.items() if k != "name"}
+        comparable_target = {k: v for k, v in target_field.items() if k != "name"}
+        return comparable_source == comparable_target
+
+    @staticmethod
+    def _dedupe(values: List[str]) -> List[str]:
+        deduped: List[str] = []
+        for value in values:
+            if value not in deduped:
+                deduped.append(value)
+        return deduped

--- a/redisvl/migration/planner.py
+++ b/redisvl/migration/planner.py
@@ -212,7 +212,15 @@ class MigrationPlanner:
 
         for index_key, target_value in target_dict["index"].items():
             source_value = source_dict["index"].get(index_key)
-            if source_value != target_value:
+            # Normalize single-element list prefixes for comparison so that
+            # e.g. source ["docs"] and target "docs" are treated as equal.
+            sv, tv = source_value, target_value
+            if index_key == "prefix":
+                if isinstance(sv, list) and len(sv) == 1:
+                    sv = sv[0]
+                if isinstance(tv, list) and len(tv) == 1:
+                    tv = tv[0]
+            if sv != tv:
                 changes["index"][index_key] = target_value
 
         return SchemaPatch.model_validate({"version": 1, "changes": changes})

--- a/redisvl/migration/utils.py
+++ b/redisvl/migration/utils.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import yaml
+
+from redisvl.utils.log import get_logger
+
+logger = get_logger(__name__)
+
+from redisvl.index import SearchIndex
+from redisvl.migration.models import (
+    AOF_HSET_OVERHEAD_BYTES,
+    AOF_JSON_SET_OVERHEAD_BYTES,
+    DTYPE_BYTES,
+    RDB_COMPRESSION_RATIO,
+    DiskSpaceEstimate,
+    MigrationPlan,
+    MigrationReport,
+    VectorFieldEstimate,
+)
+from redisvl.redis.connection import RedisConnectionFactory
+from redisvl.schema.schema import IndexSchema
+
+
+def list_indexes(
+    *, redis_url: Optional[str] = None, redis_client: Optional[Any] = None
+):
+    if redis_client is None:
+        if not redis_url:
+            raise ValueError("Must provide either redis_url or redis_client")
+        redis_client = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
+    index = SearchIndex.from_dict(
+        {"index": {"name": "__redisvl_migration_helper__"}, "fields": []},
+        redis_client=redis_client,
+    )
+    return index.listall()
+
+
+def load_yaml(path: str) -> Dict[str, Any]:
+    resolved = Path(path).resolve()
+    with open(resolved, "r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def write_yaml(data: Dict[str, Any], path: str) -> None:
+    resolved = Path(path).resolve()
+    with open(resolved, "w") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+
+
+def load_migration_plan(path: str) -> MigrationPlan:
+    return MigrationPlan.model_validate(load_yaml(path))
+
+
+def write_migration_report(report: MigrationReport, path: str) -> None:
+    write_yaml(report.model_dump(exclude_none=True), path)
+
+
+def write_benchmark_report(report: MigrationReport, path: str) -> None:
+    benchmark_report = {
+        "version": report.version,
+        "mode": report.mode,
+        "source_index": report.source_index,
+        "target_index": report.target_index,
+        "result": report.result,
+        "timings": report.timings.model_dump(exclude_none=True),
+        "benchmark_summary": report.benchmark_summary.model_dump(exclude_none=True),
+        "validation": {
+            "schema_match": report.validation.schema_match,
+            "doc_count_match": report.validation.doc_count_match,
+            "indexing_failures_delta": report.validation.indexing_failures_delta,
+            "key_sample_exists": report.validation.key_sample_exists,
+        },
+    }
+    write_yaml(benchmark_report, path)
+
+
+def normalize_keys(keys: List[str]) -> List[str]:
+    """Deduplicate and sort keys for deterministic resume behavior."""
+    return sorted(set(keys))
+
+
+def build_scan_match_patterns(prefixes: List[str], key_separator: str) -> List[str]:
+    """Build SCAN patterns for all configured prefixes."""
+    if not prefixes:
+        logger.warning(
+            "No prefixes provided for SCAN pattern. "
+            "Using '*' which will scan the entire keyspace."
+        )
+        return ["*"]
+
+    patterns = set()
+    for prefix in prefixes:
+        if not prefix:
+            logger.warning(
+                "Empty prefix in prefix list. "
+                "Using '*' which will scan the entire keyspace."
+            )
+            return ["*"]
+        if key_separator and not prefix.endswith(key_separator):
+            patterns.add(f"{prefix}{key_separator}*")
+        else:
+            patterns.add(f"{prefix}*")
+    return sorted(patterns)
+
+
+def detect_aof_enabled(client: Any) -> bool:
+    """Best-effort detection of whether AOF is enabled on the live Redis."""
+    try:
+        info = client.info("persistence")
+        if isinstance(info, dict) and "aof_enabled" in info:
+            return bool(int(info["aof_enabled"]))
+    except Exception:
+        pass
+
+    try:
+        config = client.config_get("appendonly")
+        if isinstance(config, dict):
+            value = config.get("appendonly")
+            if value is not None:
+                return str(value).lower() in {"yes", "1", "true", "on"}
+    except Exception:
+        pass
+
+    return False
+
+
+def get_schema_field_path(schema: Dict[str, Any], field_name: str) -> Optional[str]:
+    """Return the JSON path configured for a field, if present."""
+    for field in schema.get("fields", []):
+        if field.get("name") != field_name:
+            continue
+        path = field.get("path")
+        if path is None:
+            path = field.get("attrs", {}).get("path")
+        return str(path) if path is not None else None
+    return None
+
+
+# Attributes excluded from schema validation comparison.
+# These are query-time or creation-hint parameters that FT.INFO does not return
+# and are not relevant for index structure validation (confirmed by RediSearch team).
+# - ef_runtime, epsilon: query-time tuning knobs, not index definition attributes
+# - initial_cap: creation-time memory pre-allocation hint, diverges after indexing
+EXCLUDED_VECTOR_ATTRS = {"ef_runtime", "epsilon", "initial_cap"}
+# phonetic_matcher: the matcher string (e.g. "dm:en") is not stored server-side,
+#   only a boolean flag is kept, so it cannot be read back.
+# withsuffixtrie: returned as a flag in FT.INFO but not as a KV attribute,
+#   so RedisVL's parser does not capture it yet.
+EXCLUDED_TEXT_ATTRS = {"phonetic_matcher", "withsuffixtrie"}
+EXCLUDED_TAG_ATTRS = {"withsuffixtrie"}
+
+
+def _strip_excluded_attrs(field: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove attributes not relevant for index validation comparison.
+
+    These are either query-time parameters, creation-time hints, or attributes
+    whose server-side representation differs from the schema definition.
+
+    Also normalizes attributes that have implicit behavior:
+    - For NUMERIC + SORTABLE, Redis auto-applies UNF, so we normalize to unf=True
+    """
+    field = field.copy()
+    attrs = field.get("attrs", {})
+    if not attrs:
+        return field
+
+    attrs = attrs.copy()
+    field_type = field.get("type", "").lower()
+
+    if field_type == "vector":
+        for attr in EXCLUDED_VECTOR_ATTRS:
+            attrs.pop(attr, None)
+    elif field_type == "text":
+        for attr in EXCLUDED_TEXT_ATTRS:
+            attrs.pop(attr, None)
+        # Normalize weight to int for comparison (FT.INFO may return float)
+        if "weight" in attrs and isinstance(attrs["weight"], float):
+            if attrs["weight"] == int(attrs["weight"]):
+                attrs["weight"] = int(attrs["weight"])
+    elif field_type == "tag":
+        for attr in EXCLUDED_TAG_ATTRS:
+            attrs.pop(attr, None)
+    elif field_type == "numeric":
+        # Redis auto-applies UNF when SORTABLE is set on NUMERIC fields.
+        # Normalize unf to True when sortable is True to avoid false mismatches.
+        if attrs.get("sortable"):
+            attrs["unf"] = True
+
+    field["attrs"] = attrs
+    return field
+
+
+def canonicalize_schema(
+    schema_dict: Dict[str, Any],
+    *,
+    strip_unreliable: bool = False,
+    strip_excluded: bool = False,
+) -> Dict[str, Any]:
+    """Canonicalize schema for comparison.
+
+    Args:
+        schema_dict: The schema dictionary to canonicalize.
+        strip_unreliable: Deprecated alias for strip_excluded. Kept for
+            backward compatibility.
+        strip_excluded: If True, remove query-time and creation-hint attributes
+            that are not part of index structure validation.
+    """
+    schema = IndexSchema.from_dict(schema_dict).to_dict()
+
+    should_strip = strip_excluded or strip_unreliable
+    fields = schema.get("fields", [])
+    if should_strip:
+        fields = [_strip_excluded_attrs(f) for f in fields]
+
+    schema["fields"] = sorted(fields, key=lambda field: field["name"])
+    prefixes = schema["index"].get("prefix")
+    if isinstance(prefixes, list):
+        schema["index"]["prefix"] = sorted(prefixes)
+    stopwords = schema["index"].get("stopwords")
+    if isinstance(stopwords, list):
+        schema["index"]["stopwords"] = sorted(stopwords)
+    return schema
+
+
+def schemas_equal(
+    left: Dict[str, Any],
+    right: Dict[str, Any],
+    *,
+    strip_unreliable: bool = False,
+    strip_excluded: bool = False,
+) -> bool:
+    """Compare two schemas for equality.
+
+    Args:
+        left: First schema dictionary.
+        right: Second schema dictionary.
+        strip_unreliable: Deprecated alias for strip_excluded. Kept for
+            backward compatibility.
+        strip_excluded: If True, exclude query-time and creation-hint attributes
+            (ef_runtime, epsilon, initial_cap, phonetic_matcher) from comparison.
+    """
+    should_strip = strip_excluded or strip_unreliable
+    return json.dumps(
+        canonicalize_schema(left, strip_excluded=should_strip), sort_keys=True
+    ) == json.dumps(
+        canonicalize_schema(right, strip_excluded=should_strip), sort_keys=True
+    )
+
+
+def wait_for_index_ready(
+    index: SearchIndex,
+    *,
+    timeout_seconds: int = 1800,
+    poll_interval_seconds: float = 0.5,
+    progress_callback: Optional[Callable[[int, int, float], None]] = None,
+) -> Tuple[Dict[str, Any], float]:
+    """Wait for index to finish indexing all documents.
+
+    Args:
+        index: The SearchIndex to monitor.
+        timeout_seconds: Maximum time to wait.
+        poll_interval_seconds: How often to check status.
+        progress_callback: Optional callback(indexed_docs, total_docs, percent).
+    """
+    start = time.perf_counter()
+    deadline = start + timeout_seconds
+    latest_info = index.info()
+
+    stable_ready_checks: Optional[int] = None
+    while time.perf_counter() < deadline:
+        ready = False
+        latest_info = index.info()
+        indexing = latest_info.get("indexing")
+        percent_indexed = latest_info.get("percent_indexed")
+
+        if percent_indexed is not None or indexing is not None:
+            pct = float(percent_indexed) if percent_indexed is not None else None
+            is_indexing = bool(indexing)
+            if pct is not None:
+                ready = pct >= 1.0 and not is_indexing
+            else:
+                # percent_indexed missing but indexing flag present:
+                # treat as ready when indexing flag is falsy (0 / False).
+                ready = not is_indexing
+            if progress_callback:
+                total_docs = int(latest_info.get("num_docs", 0))
+                display_pct = pct if pct is not None else (1.0 if ready else 0.0)
+                indexed_docs = int(total_docs * display_pct)
+                progress_callback(indexed_docs, total_docs, display_pct * 100)
+        else:
+            current_docs = latest_info.get("num_docs")
+            if current_docs is None:
+                ready = True
+            else:
+                if stable_ready_checks is None:
+                    stable_ready_checks = int(current_docs)
+                    time.sleep(poll_interval_seconds)
+                    continue
+                current = int(current_docs)
+                if current == stable_ready_checks:
+                    ready = True
+                else:
+                    # num_docs changed; update baseline and keep waiting
+                    stable_ready_checks = current
+
+        if ready:
+            return latest_info, round(time.perf_counter() - start, 3)
+
+        time.sleep(poll_interval_seconds)
+
+    raise TimeoutError(
+        f"Index {index.schema.index.name} did not become ready within {timeout_seconds} seconds"
+    )
+
+
+def current_source_matches_snapshot(
+    index_name: str,
+    expected_schema: Dict[str, Any],
+    *,
+    redis_url: Optional[str] = None,
+    redis_client: Optional[Any] = None,
+) -> bool:
+    try:
+        current_index = SearchIndex.from_existing(
+            index_name,
+            redis_url=redis_url,
+            redis_client=redis_client,
+        )
+    except Exception:
+        # Index no longer exists (e.g. already dropped during migration)
+        return False
+    return schemas_equal(current_index.schema.to_dict(), expected_schema)
+
+
+def timestamp_utc() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def estimate_disk_space(
+    plan: MigrationPlan,
+    *,
+    aof_enabled: bool = False,
+) -> DiskSpaceEstimate:
+    """Estimate disk space required for a migration with quantization.
+
+    This is a pure calculation based on the migration plan. No Redis
+    operations are performed.
+
+    Args:
+        plan: The migration plan containing source/target schemas.
+        aof_enabled: Whether AOF persistence is active on the Redis instance.
+
+    Returns:
+        DiskSpaceEstimate with projected costs.
+    """
+    doc_count = int(plan.source.stats_snapshot.get("num_docs", 0) or 0)
+    storage_type = plan.source.keyspace.storage_type
+    index_name = plan.source.index_name
+
+    # Find vector fields with datatype changes
+    source_fields = {
+        f["name"]: f for f in plan.source.schema_snapshot.get("fields", [])
+    }
+    target_fields = {f["name"]: f for f in plan.merged_target_schema.get("fields", [])}
+
+    # Build rename map: source_name -> target_name
+    field_rename_map: Dict[str, str] = {}
+    rename_ops = plan.rename_operations
+    if rename_ops and rename_ops.rename_fields:
+        for fr in rename_ops.rename_fields:
+            field_rename_map[fr.old_name] = fr.new_name
+
+    vector_field_estimates: list[VectorFieldEstimate] = []
+    total_source_bytes = 0
+    total_target_bytes = 0
+    total_aof_growth = 0
+
+    aof_overhead = (
+        AOF_JSON_SET_OVERHEAD_BYTES
+        if storage_type == "json"
+        else AOF_HSET_OVERHEAD_BYTES
+    )
+
+    for name, source_field in source_fields.items():
+        if source_field.get("type") != "vector":
+            continue
+        # Look up target by renamed name if applicable
+        target_name = field_rename_map.get(name, name)
+        target_field = target_fields.get(target_name)
+        if not target_field or target_field.get("type") != "vector":
+            continue
+
+        source_attrs = source_field.get("attrs", {})
+        target_attrs = target_field.get("attrs", {})
+        source_dtype = source_attrs.get("datatype", "float32").lower()
+        target_dtype = target_attrs.get("datatype", "float32").lower()
+
+        if source_dtype == target_dtype:
+            continue
+
+        if source_dtype not in DTYPE_BYTES:
+            raise ValueError(
+                f"Unknown source vector datatype '{source_dtype}' for field '{name}'. "
+                f"Supported datatypes: {', '.join(sorted(DTYPE_BYTES.keys()))}"
+            )
+        if target_dtype not in DTYPE_BYTES:
+            raise ValueError(
+                f"Unknown target vector datatype '{target_dtype}' for field '{name}'. "
+                f"Supported datatypes: {', '.join(sorted(DTYPE_BYTES.keys()))}"
+            )
+
+        if storage_type == "json":
+            # JSON-backed migrations do not rewrite per-document vector payloads
+            # during apply(); they rely on recreate + re-index instead.
+            continue
+
+        dims = int(source_attrs.get("dims", 0))
+        source_bpe = DTYPE_BYTES[source_dtype]
+        target_bpe = DTYPE_BYTES[target_dtype]
+
+        source_vec_size = dims * source_bpe
+        target_vec_size = dims * target_bpe
+
+        vector_field_estimates.append(
+            VectorFieldEstimate(
+                field_name=name,
+                dims=dims,
+                source_dtype=source_dtype,
+                target_dtype=target_dtype,
+                source_bytes_per_doc=source_vec_size,
+                target_bytes_per_doc=target_vec_size,
+            )
+        )
+
+        field_source_total = doc_count * source_vec_size
+        field_target_total = doc_count * target_vec_size
+        total_source_bytes += field_source_total
+        total_target_bytes += field_target_total
+
+        if aof_enabled:
+            total_aof_growth += doc_count * (target_vec_size + aof_overhead)
+
+    rdb_snapshot_disk = int(total_source_bytes * RDB_COMPRESSION_RATIO)
+    rdb_cow_memory = total_source_bytes
+    total_new_disk = rdb_snapshot_disk + total_aof_growth
+    memory_savings = total_source_bytes - total_target_bytes
+
+    return DiskSpaceEstimate(
+        index_name=index_name,
+        doc_count=doc_count,
+        storage_type=storage_type,
+        vector_fields=vector_field_estimates,
+        total_source_vector_bytes=total_source_bytes,
+        total_target_vector_bytes=total_target_bytes,
+        rdb_snapshot_disk_bytes=rdb_snapshot_disk,
+        rdb_cow_memory_if_concurrent_bytes=rdb_cow_memory,
+        aof_enabled=aof_enabled,
+        aof_growth_bytes=total_aof_growth,
+        total_new_disk_bytes=total_new_disk,
+        memory_savings_after_bytes=memory_savings,
+    )

--- a/redisvl/migration/utils.py
+++ b/redisvl/migration/utils.py
@@ -7,10 +7,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import yaml
 
-from redisvl.utils.log import get_logger
-
-logger = get_logger(__name__)
-
 from redisvl.index import SearchIndex
 from redisvl.migration.models import (
     AOF_HSET_OVERHEAD_BYTES,
@@ -24,6 +20,9 @@ from redisvl.migration.models import (
 )
 from redisvl.redis.connection import RedisConnectionFactory
 from redisvl.schema.schema import IndexSchema
+from redisvl.utils.log import get_logger
+
+logger = get_logger(__name__)
 
 
 def list_indexes(

--- a/redisvl/migration/validation.py
+++ b/redisvl/migration/validation.py
@@ -61,14 +61,12 @@ class MigrationValidator:
             if plan.rename_operations.change_prefix is not None:
                 old_prefix = plan.source.keyspace.prefixes[0]
                 new_prefix = plan.rename_operations.change_prefix
-                key_sep = plan.source.keyspace.key_separator
-                # Normalize prefixes: strip trailing separator for consistent slicing
-                old_base = old_prefix.rstrip(key_sep) if old_prefix else ""
-                new_base = new_prefix.rstrip(key_sep) if new_prefix else ""
+                # Mirror executor logic exactly:
+                #   new_key = new_prefix + key[len(old_prefix):]
                 keys_to_check = []
                 for k in key_sample:
-                    if old_base and k.startswith(old_base):
-                        keys_to_check.append(new_base + k[len(old_base) :])
+                    if k.startswith(old_prefix):
+                        keys_to_check.append(new_prefix + k[len(old_prefix) :])
                     else:
                         keys_to_check.append(k)
             existing_count = target_index.client.exists(*keys_to_check)

--- a/redisvl/migration/validation.py
+++ b/redisvl/migration/validation.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+from redis.commands.search.query import Query
+
+from redisvl.index import SearchIndex
+from redisvl.migration.models import (
+    MigrationPlan,
+    MigrationValidation,
+    QueryCheckResult,
+)
+from redisvl.migration.utils import load_yaml, schemas_equal
+
+
+class MigrationValidator:
+    def validate(
+        self,
+        plan: MigrationPlan,
+        *,
+        redis_url: Optional[str] = None,
+        redis_client: Optional[Any] = None,
+        query_check_file: Optional[str] = None,
+    ) -> tuple[MigrationValidation, Dict[str, Any], float]:
+        started = time.perf_counter()
+        target_index = SearchIndex.from_existing(
+            plan.merged_target_schema["index"]["name"],
+            redis_url=redis_url,
+            redis_client=redis_client,
+        )
+        target_info = target_index.info()
+        validation = MigrationValidation()
+
+        live_schema = target_index.schema.to_dict()
+        # Exclude query-time and creation-hint attributes (ef_runtime, epsilon,
+        # initial_cap, phonetic_matcher) that are not part of index structure
+        # validation. Confirmed by RediSearch team as not relevant for this check.
+        validation.schema_match = schemas_equal(
+            live_schema, plan.merged_target_schema, strip_excluded=True
+        )
+
+        source_num_docs = int(plan.source.stats_snapshot.get("num_docs", 0) or 0)
+        target_num_docs = int(target_info.get("num_docs", 0) or 0)
+        validation.doc_count_match = source_num_docs == target_num_docs
+
+        source_failures = int(
+            plan.source.stats_snapshot.get("hash_indexing_failures", 0) or 0
+        )
+        target_failures = int(target_info.get("hash_indexing_failures", 0) or 0)
+        validation.indexing_failures_delta = target_failures - source_failures
+
+        key_sample = plan.source.keyspace.key_sample
+        if not key_sample:
+            validation.key_sample_exists = True
+        else:
+            # Handle prefix change: transform key_sample to use new prefix.
+            # Must match the executor's RENAME logic exactly:
+            #   new_key = new_prefix + key[len(old_prefix):]
+            keys_to_check = key_sample
+            if plan.rename_operations.change_prefix is not None:
+                old_prefix = plan.source.keyspace.prefixes[0]
+                new_prefix = plan.rename_operations.change_prefix
+                key_sep = plan.source.keyspace.key_separator
+                # Normalize prefixes: strip trailing separator for consistent slicing
+                old_base = old_prefix.rstrip(key_sep) if old_prefix else ""
+                new_base = new_prefix.rstrip(key_sep) if new_prefix else ""
+                keys_to_check = []
+                for k in key_sample:
+                    if old_base and k.startswith(old_base):
+                        keys_to_check.append(new_base + k[len(old_base) :])
+                    else:
+                        keys_to_check.append(k)
+            existing_count = target_index.client.exists(*keys_to_check)
+            validation.key_sample_exists = existing_count == len(keys_to_check)
+
+        # Run automatic functional checks (always)
+        functional_checks = self._run_functional_checks(target_index, source_num_docs)
+        validation.query_checks.extend(functional_checks)
+
+        # Run user-provided query checks (if file provided)
+        if query_check_file:
+            user_checks = self._run_query_checks(target_index, query_check_file)
+            validation.query_checks.extend(user_checks)
+
+        if not validation.schema_match and plan.validation.require_schema_match:
+            validation.errors.append("Live schema does not match merged_target_schema.")
+        if not validation.doc_count_match and plan.validation.require_doc_count_match:
+            validation.errors.append(
+                "Live document count does not match source num_docs."
+            )
+        if validation.indexing_failures_delta > 0:
+            validation.errors.append("Indexing failures increased during migration.")
+        if not validation.key_sample_exists:
+            validation.errors.append(
+                "One or more sampled source keys is missing after migration."
+            )
+        if any(not query_check.passed for query_check in validation.query_checks):
+            validation.errors.append("One or more query checks failed.")
+
+        return validation, target_info, round(time.perf_counter() - started, 3)
+
+    def _run_query_checks(
+        self,
+        target_index: SearchIndex,
+        query_check_file: str,
+    ) -> list[QueryCheckResult]:
+        query_checks = load_yaml(query_check_file)
+        results: list[QueryCheckResult] = []
+
+        for doc_id in query_checks.get("fetch_ids", []):
+            fetched = target_index.fetch(doc_id)
+            results.append(
+                QueryCheckResult(
+                    name=f"fetch:{doc_id}",
+                    passed=fetched is not None,
+                    details=(
+                        "Document fetched successfully"
+                        if fetched is not None
+                        else "Document not found"
+                    ),
+                )
+            )
+
+        for key in query_checks.get("keys_exist", []):
+            client = target_index.client
+            if client is None:
+                raise ValueError("Redis client not connected")
+            exists = bool(client.exists(key))
+            results.append(
+                QueryCheckResult(
+                    name=f"key:{key}",
+                    passed=exists,
+                    details="Key exists" if exists else "Key not found",
+                )
+            )
+
+        return results
+
+    def _run_functional_checks(
+        self, target_index: SearchIndex, expected_doc_count: int
+    ) -> List[QueryCheckResult]:
+        """Run automatic functional checks to verify the index is operational.
+
+        These checks run automatically after every migration to prove the index
+        actually works, not just that the schema looks correct.
+        """
+        results: List[QueryCheckResult] = []
+
+        # Check 1: Wildcard search - proves the index responds and returns docs
+        try:
+            search_result = target_index.search(Query("*").paging(0, 1))
+            total_found = search_result.total
+            # When expected_doc_count is 0 (empty index), a successful
+            # search returning 0 docs is correct behaviour, not a failure.
+            if expected_doc_count == 0:
+                passed = total_found == 0
+            else:
+                passed = total_found > 0
+            results.append(
+                QueryCheckResult(
+                    name="functional:wildcard_search",
+                    passed=passed,
+                    details=(
+                        f"Wildcard search returned {total_found} docs "
+                        f"(expected {expected_doc_count})"
+                    ),
+                )
+            )
+        except Exception as e:
+            results.append(
+                QueryCheckResult(
+                    name="functional:wildcard_search",
+                    passed=False,
+                    details=f"Wildcard search failed: {str(e)}",
+                )
+            )
+
+        return results

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -304,6 +304,19 @@ def convert_index_info_to_schema(index_info: Dict[str, Any]) -> Dict[str, Any]:
             # Default to float32 if missing
             normalized["datatype"] = "float32"
 
+        # Handle HNSW-specific parameters
+        if "m" in vector_attrs:
+            try:
+                normalized["m"] = int(vector_attrs["m"])
+            except (ValueError, TypeError):
+                pass
+
+        if "ef_construction" in vector_attrs:
+            try:
+                normalized["ef_construction"] = int(vector_attrs["ef_construction"])
+            except (ValueError, TypeError):
+                pass
+
         # Handle SVS-VAMANA specific parameters
         # Compression - Redis uses different internal names, so we need to map them
         if "compression" in vector_attrs:

--- a/tests/unit/test_migration_planner.py
+++ b/tests/unit/test_migration_planner.py
@@ -1,0 +1,890 @@
+from fnmatch import fnmatch
+
+import yaml
+
+from redisvl.migration import MigrationPlanner
+from redisvl.schema.schema import IndexSchema
+
+
+class DummyClient:
+    def __init__(self, keys):
+        self.keys = keys
+
+    def scan(self, cursor=0, match=None, count=None):
+        matched = []
+        for key in self.keys:
+            decoded_key = key.decode() if isinstance(key, bytes) else str(key)
+            if match is None or fnmatch(decoded_key, match):
+                matched.append(key)
+        return 0, matched
+
+
+class DummyIndex:
+    def __init__(self, schema, stats, keys):
+        self.schema = schema
+        self._stats = stats
+        self._client = DummyClient(keys)
+
+    @property
+    def client(self):
+        return self._client
+
+    def info(self):
+        return self._stats
+
+
+def _make_source_schema():
+    return IndexSchema.from_dict(
+        {
+            "index": {
+                "name": "docs",
+                "prefix": "docs",
+                "key_separator": ":",
+                "storage_type": "json",
+            },
+            "fields": [
+                {
+                    "name": "title",
+                    "type": "text",
+                    "path": "$.title",
+                    "attrs": {"sortable": False},
+                },
+                {
+                    "name": "price",
+                    "type": "numeric",
+                    "path": "$.price",
+                    "attrs": {"sortable": True},
+                },
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "path": "$.embedding",
+                    "attrs": {
+                        "algorithm": "flat",
+                        "dims": 3,
+                        "distance_metric": "cosine",
+                        "datatype": "float32",
+                    },
+                },
+            ],
+        }
+    )
+
+
+def test_create_plan_from_schema_patch_preserves_unspecified_config(
+    monkeypatch, tmp_path
+):
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(
+        source_schema,
+        {"num_docs": 2, "indexing": False},
+        [b"docs:1", b"docs:2", b"docs:3"],
+    )
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    patch_path = tmp_path / "schema_patch.yaml"
+    patch_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "changes": {
+                    "add_fields": [
+                        {
+                            "name": "category",
+                            "type": "tag",
+                            "path": "$.category",
+                            "attrs": {"separator": ","},
+                        }
+                    ],
+                    "remove_fields": ["price"],
+                    "update_fields": [
+                        {
+                            "name": "title",
+                            "options": {"sortable": True},
+                        }
+                    ],
+                },
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner(key_sample_limit=2)
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        schema_patch_path=str(patch_path),
+    )
+
+    assert plan.diff_classification.supported is True
+    assert plan.source.index_name == "docs"
+    assert plan.source.keyspace.storage_type == "json"
+    assert plan.source.keyspace.prefixes == ["docs"]
+    assert plan.source.keyspace.key_separator == ":"
+    assert plan.source.keyspace.key_sample == ["docs:1", "docs:2"]
+    assert plan.warnings == ["Index downtime is required"]
+
+    merged_fields = {
+        field["name"]: field for field in plan.merged_target_schema["fields"]
+    }
+    assert plan.merged_target_schema["index"]["prefix"] == "docs"
+    assert merged_fields["title"]["attrs"]["sortable"] is True
+    assert "price" not in merged_fields
+    assert merged_fields["category"]["type"] == "tag"
+
+    plan_path = tmp_path / "migration_plan.yaml"
+    planner.write_plan(plan, str(plan_path))
+    written_plan = yaml.safe_load(plan_path.read_text())
+    assert written_plan["mode"] == "drop_recreate"
+    assert written_plan["validation"]["require_doc_count_match"] is True
+    assert written_plan["diff_classification"]["supported"] is True
+
+
+def test_target_schema_vector_datatype_change_is_allowed(monkeypatch, tmp_path):
+    """Changing vector datatype (quantization) is allowed - executor will re-encode."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "path": "$.title",
+                        "attrs": {"sortable": False},
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "flat",  # Same algorithm
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float16",  # Changed from float32
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    # Datatype change (quantization) should now be ALLOWED
+    assert plan.diff_classification.supported is True
+    assert len(plan.diff_classification.blocked_reasons) == 0
+
+    # Verify datatype changes are detected for the executor
+    datatype_changes = MigrationPlanner.get_vector_datatype_changes(
+        plan.source.schema_snapshot, plan.merged_target_schema
+    )
+    assert "embedding" in datatype_changes
+    assert datatype_changes["embedding"]["source"] == "float32"
+    assert datatype_changes["embedding"]["target"] == "float16"
+
+
+def test_target_schema_vector_algorithm_change_is_allowed(monkeypatch, tmp_path):
+    """Changing vector algorithm is allowed (index-only change)."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "path": "$.title",
+                        "attrs": {"sortable": False},
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "hnsw",  # Changed from flat
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float32",  # Same datatype
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    # Algorithm change should be ALLOWED
+    assert plan.diff_classification.supported is True
+    assert len(plan.diff_classification.blocked_reasons) == 0
+
+
+# =============================================================================
+# BLOCKED CHANGES (Document-Dependent) - require iterative_shadow
+# =============================================================================
+
+
+def test_target_schema_prefix_change_is_supported(monkeypatch, tmp_path):
+    """Prefix change is now supported via key rename operations."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs_v2",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": source_schema.to_dict()["fields"],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    # Prefix change is now supported
+    assert plan.diff_classification.supported is True
+    # Verify rename operation is populated
+    assert plan.rename_operations.change_prefix == "docs_v2"
+    # Verify warning is present
+    assert any("Prefix change" in w for w in plan.warnings)
+
+
+def test_key_separator_change_is_blocked(monkeypatch, tmp_path):
+    """Key separator change is blocked: document keys don't match new pattern."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": "/",  # Changed from ":"
+                    "storage_type": "json",
+                },
+                "fields": source_schema.to_dict()["fields"],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is False
+    assert any(
+        "key_separator" in reason.lower() or "separator" in reason.lower()
+        for reason in plan.diff_classification.blocked_reasons
+    )
+
+
+def test_storage_type_change_is_blocked(monkeypatch, tmp_path):
+    """Storage type change is blocked: documents are in wrong format."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "hash",  # Changed from "json"
+                },
+                "fields": [
+                    {"name": "title", "type": "text", "attrs": {"sortable": False}},
+                    {"name": "price", "type": "numeric", "attrs": {"sortable": True}},
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "attrs": {
+                            "algorithm": "flat",
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float32",
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is False
+    assert any(
+        "storage" in reason.lower()
+        for reason in plan.diff_classification.blocked_reasons
+    )
+
+
+def test_vector_dimension_change_is_blocked(monkeypatch, tmp_path):
+    """Vector dimension change is blocked: stored vectors have wrong size."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "path": "$.title",
+                        "attrs": {"sortable": False},
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "flat",
+                            "dims": 768,  # Changed from 3
+                            "distance_metric": "cosine",
+                            "datatype": "float32",
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is False
+    assert any(
+        "dims" in reason and "document migration" in reason
+        for reason in plan.diff_classification.blocked_reasons
+    )
+
+
+def test_field_path_change_is_blocked(monkeypatch, tmp_path):
+    """JSON path change is blocked: stored data is at wrong path."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "path": "$.metadata.title",  # Changed from $.title
+                        "attrs": {"sortable": False},
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "flat",
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float32",
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is False
+    assert any(
+        "path" in reason.lower() for reason in plan.diff_classification.blocked_reasons
+    )
+
+
+def test_field_type_change_is_blocked(monkeypatch, tmp_path):
+    """Field type change is blocked: index expects different data format."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "tag",  # Changed from text
+                        "path": "$.title",
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "flat",
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float32",
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is False
+    assert any(
+        "type" in reason.lower() for reason in plan.diff_classification.blocked_reasons
+    )
+
+
+def test_field_rename_is_detected_and_blocked(monkeypatch, tmp_path):
+    """Field rename is blocked: stored data uses old field name."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "document_title",  # Renamed from "title"
+                        "type": "text",
+                        "path": "$.title",
+                        "attrs": {"sortable": False},
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "flat",
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float32",
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is False
+    assert any(
+        "rename" in reason.lower()
+        for reason in plan.diff_classification.blocked_reasons
+    )
+
+
+# =============================================================================
+# ALLOWED CHANGES (Index-Only)
+# =============================================================================
+
+
+def test_add_non_vector_field_is_allowed(monkeypatch, tmp_path):
+    """Adding a non-vector field is allowed."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    patch_path = tmp_path / "schema_patch.yaml"
+    patch_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "changes": {
+                    "add_fields": [
+                        {"name": "category", "type": "tag", "path": "$.category"}
+                    ]
+                },
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        schema_patch_path=str(patch_path),
+    )
+
+    assert plan.diff_classification.supported is True
+
+
+def test_remove_field_is_allowed(monkeypatch, tmp_path):
+    """Removing a field from the index is allowed."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    patch_path = tmp_path / "schema_patch.yaml"
+    patch_path.write_text(
+        yaml.safe_dump(
+            {"version": 1, "changes": {"remove_fields": ["price"]}},
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        schema_patch_path=str(patch_path),
+    )
+
+    assert plan.diff_classification.supported is True
+
+
+def test_change_field_sortable_is_allowed(monkeypatch, tmp_path):
+    """Changing field sortable option is allowed."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    patch_path = tmp_path / "schema_patch.yaml"
+    patch_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "changes": {
+                    "update_fields": [{"name": "title", "options": {"sortable": True}}]
+                },
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        schema_patch_path=str(patch_path),
+    )
+
+    assert plan.diff_classification.supported is True
+
+
+def test_change_vector_distance_metric_is_allowed(monkeypatch, tmp_path):
+    """Changing vector distance metric is allowed (index-only)."""
+    source_schema = _make_source_schema()
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "path": "$.title",
+                        "attrs": {"sortable": False},
+                    },
+                    {
+                        "name": "price",
+                        "type": "numeric",
+                        "path": "$.price",
+                        "attrs": {"sortable": True},
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "flat",
+                            "dims": 3,
+                            "distance_metric": "L2",  # Changed from cosine
+                            "datatype": "float32",
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is True
+    assert len(plan.diff_classification.blocked_reasons) == 0
+
+
+def test_change_hnsw_tuning_params_is_allowed(monkeypatch, tmp_path):
+    """Changing HNSW tuning parameters is allowed (index-only)."""
+    source_schema = IndexSchema.from_dict(
+        {
+            "index": {
+                "name": "docs",
+                "prefix": "docs",
+                "key_separator": ":",
+                "storage_type": "json",
+            },
+            "fields": [
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "path": "$.embedding",
+                    "attrs": {
+                        "algorithm": "hnsw",
+                        "dims": 3,
+                        "distance_metric": "cosine",
+                        "datatype": "float32",
+                        "m": 16,
+                        "ef_construction": 200,
+                    },
+                },
+            ],
+        }
+    )
+    dummy_index = DummyIndex(source_schema, {"num_docs": 2}, [b"docs:1"])
+    monkeypatch.setattr(
+        "redisvl.migration.planner.SearchIndex.from_existing",
+        lambda *args, **kwargs: dummy_index,
+    )
+
+    target_schema_path = tmp_path / "target_schema.yaml"
+    target_schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "index": {
+                    "name": "docs",
+                    "prefix": "docs",
+                    "key_separator": ":",
+                    "storage_type": "json",
+                },
+                "fields": [
+                    {
+                        "name": "embedding",
+                        "type": "vector",
+                        "path": "$.embedding",
+                        "attrs": {
+                            "algorithm": "hnsw",
+                            "dims": 3,
+                            "distance_metric": "cosine",
+                            "datatype": "float32",
+                            "m": 32,  # Changed from 16
+                            "ef_construction": 400,  # Changed from 200
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    planner = MigrationPlanner()
+    plan = planner.create_plan(
+        "docs",
+        redis_url="redis://localhost:6379",
+        target_schema_path=str(target_schema_path),
+    )
+
+    assert plan.diff_classification.supported is True
+    assert len(plan.diff_classification.blocked_reasons) == 0


### PR DESCRIPTION
## Summary

Foundation layer for the index migration feature. Defines all data models, the sync migration planner, validation logic, and shared utilities.

## PR Stack

| PR | Branch | Description |
|----|--------|-------------|
| **PR0** | `feat/migrate-design` | **Design and base models (this PR)** |
| PR1 | `feat/migrate-core` | Core sync executor and basic CLI |
| PR2 | `feat/migrate-wizard` | Interactive migration wizard |
| PR3 | `feat/migrate-async` | Async executor, planner, validator |
| PR4 | `feat/migrate-batch` | Batch migration with multi-index support |
| PR5 | `feat/migrate-docs` | Documentation and benchmarks |

## What is included

- `redisvl/migration/models.py`: Pydantic models for migration plans, schema patches, field diffs, and batch state
- `redisvl/migration/planner.py`: Sync migration planner that diffs source vs target schemas and generates migration plans
- `redisvl/migration/validation.py`: Post-migration validator with configurable policy (key sampling, field checks, doc count)
- `redisvl/migration/utils.py`: Shared utilities (YAML I/O, disk estimation, index listing, AOF detection)
- `redisvl/redis/connection.py`: Patch to support HNSW parameters in schema parsing
- `tests/unit/test_migration_planner.py`: 15 unit tests for planner logic

## Usage

```python
from redisvl.migration import MigrationPlanner, MigrationValidator

planner = MigrationPlanner()
plan = planner.plan("my_index", redis_url="redis://localhost:6379", schema_patch_path="patch.yaml")
planner.write_plan(plan, "migration_plan.yaml")
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new migration planning/validation logic that will influence how indexes are dropped/recreated and how compatibility is determined; mistakes could lead to unsupported migrations being attempted or false validation results.
> 
> **Overview**
> Adds a new `redisvl.migration` package with Pydantic models for schema patches, migration plans/reports, rename operations, validation policy/results, and batch-migration state, plus disk-space estimation primitives for vector datatype (quantization) changes.
> 
> Implements `MigrationPlanner` to snapshot a live index, load/derive a schema patch, merge it into a target schema, classify supported vs blocked changes (including explicit support for index renames, prefix changes, and vector datatype changes), and emit warnings including SVS-VAMANA compatibility checks.
> 
> Adds `MigrationValidator` to compare the live post-migration schema (with excluded attrs stripped), validate doc counts/indexing failures/key-sample existence (accounting for prefix renames), and run automatic + user-specified query checks. Also extends `convert_index_info_to_schema` parsing to capture HNSW params (`m`, `ef_construction`) and adds unit coverage for planner behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea33dc25fe92ff9ffd1bd4860865ab1f62810dc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->