### PR TITLE
Normalize Redis connection handling and CLI URL resolution

### DIFF
--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -98,13 +98,12 @@ class Index:
     def _connect_to_index(self, args: Namespace) -> SearchIndex:
         # connect to redis
         redis_url = create_redis_url(args)
-        conn = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
 
         if args.index:
             schema = IndexSchema.from_dict({"index": {"name": args.index}})
             index = SearchIndex(schema=schema, redis_url=redis_url)
         elif args.schema:
-            index = SearchIndex.from_yaml(args.schema, redis_client=conn)
+            index = SearchIndex.from_yaml(args.schema, redis_url=redis_url)
         else:
             print("Index name or schema must be provided")
             exit(1)

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -32,9 +32,7 @@ class Index:
         parser.add_argument("command", help="Subcommand to run")
         parser = add_index_parsing_options(parser)
 
-        argv = sys.argv[2:]
-        args = parser.parse_args(argv)
-        args._argv = tuple(argv)
+        args = parser.parse_args(sys.argv[2:])
         if not hasattr(self, args.command):
             parser.print_help()
             exit(0)

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -97,12 +97,8 @@ class Index:
 
     def _connect_to_index(self, args: Namespace) -> SearchIndex:
         # connect to redis
-        try:
-            redis_url = create_redis_url(args)
-            conn = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
-        except ValueError:
-            print("Must set REDIS_URL environment variable or provide host and port")
-            exit(1)
+        redis_url = create_redis_url(args)
+        conn = RedisConnectionFactory.get_redis_connection(redis_url=redis_url)
 
         if args.index:
             schema = IndexSchema.from_dict({"index": {"name": args.index}})

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -32,7 +32,9 @@ class Index:
         parser.add_argument("command", help="Subcommand to run")
         parser = add_index_parsing_options(parser)
 
-        args = parser.parse_args(sys.argv[2:])
+        argv = sys.argv[2:]
+        args = parser.parse_args(argv)
+        args._argv = tuple(argv)
         if not hasattr(self, args.command):
             parser.print_help()
             exit(0)

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -60,13 +60,7 @@ class Stats:
 
     def _connect_to_index(self, args: Namespace) -> SearchIndex:
         # connect to redis
-        try:
-            redis_url = create_redis_url(args)
-        except ValueError:
-            logger.error(
-                "Must set REDIS_ADDRESS environment variable or provide host and port"
-            )
-            exit(0)
+        redis_url = create_redis_url(args)
 
         if args.index:
             schema = IndexSchema.from_dict({"index": {"name": args.index}})

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -42,9 +42,7 @@ class Stats:
     def __init__(self):
         parser = argparse.ArgumentParser(usage=self.usage)
         parser = add_index_parsing_options(parser)
-        argv = sys.argv[2:]
-        args = parser.parse_args(argv)
-        args._argv = tuple(argv)
+        args = parser.parse_args(sys.argv[2:])
         try:
             self.stats(args)
         except Exception as e:

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -42,7 +42,9 @@ class Stats:
     def __init__(self):
         parser = argparse.ArgumentParser(usage=self.usage)
         parser = add_index_parsing_options(parser)
-        args = parser.parse_args(sys.argv[2:])
+        argv = sys.argv[2:]
+        args = parser.parse_args(argv)
+        args._argv = tuple(argv)
         try:
             self.stats(args)
         except Exception as e:

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,6 +1,6 @@
 import os
 from argparse import ArgumentParser, Namespace
-from collections.abc import Sequence
+from typing import Optional
 
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
@@ -8,58 +8,22 @@ from redisvl.utils.log import get_logger
 logger = get_logger("[RedisVL]")
 DEFAULT_REDIS_HOST = "localhost"
 DEFAULT_REDIS_PORT = 6379
-_HOST_FLAGS = ("--host",)
-_PORT_FLAGS = ("-p", "--port")
-_USER_FLAGS = ("--user",)
-_PASSWORD_FLAGS = ("-a", "--password")
-_SSL_FLAGS = ("--ssl",)
-_ALL_CONNECTION_FLAGS = (
-    _HOST_FLAGS,
-    _PORT_FLAGS,
-    _USER_FLAGS,
-    _PASSWORD_FLAGS,
-    _SSL_FLAGS,
-)
-
-
-def _get_cli_argv(args: Namespace) -> tuple[str, ...]:
-    raw_argv = getattr(args, "_argv", ())
-    return tuple(raw_argv) if isinstance(raw_argv, Sequence) else ()
-
-
-def _argv_has_flag(argv: Sequence[str], *flags: str) -> bool:
-    return any(flag in argv for flag in flags)
 
 
 def _has_explicit_connection_options(args: Namespace) -> bool:
-    argv = _get_cli_argv(args)
-    if argv:
-        return any(_argv_has_flag(argv, *flags) for flags in _ALL_CONNECTION_FLAGS)
-
     return any(
         (
-            getattr(args, "host", None) not in (None, DEFAULT_REDIS_HOST),
-            getattr(args, "port", None) not in (None, DEFAULT_REDIS_PORT),
-            getattr(args, "user", None) not in (None, "", "default"),
+            getattr(args, "host", None) is not None,
+            getattr(args, "port", None) is not None,
+            getattr(args, "user", None) is not None,
             bool(getattr(args, "password", None)),
             bool(getattr(args, "ssl", False)),
         )
     )
 
 
-def _get_auth_credentials(args: Namespace) -> tuple[str | None, str | None]:
-    argv = _get_cli_argv(args)
-    if argv:
-        user = args.user if _argv_has_flag(argv, *_USER_FLAGS) else None
-        password = args.password if _argv_has_flag(argv, *_PASSWORD_FLAGS) else None
-        return user, password
-
-    user = getattr(args, "user", None)
-    if user in (None, "", "default"):
-        user = None
-
-    password = getattr(args, "password", None) or None
-    return user, password
+def _get_auth_credentials(args: Namespace) -> tuple[Optional[str], Optional[str]]:
+    return getattr(args, "user", None), getattr(args, "password", None)
 
 
 def _build_redis_url(args: Namespace) -> str:
@@ -102,19 +66,15 @@ def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
         "-s", "--schema", help="Path to schema file", type=str, required=False
     )
     parser.add_argument("-u", "--url", help="Redis URL", type=str, required=False)
-    parser.add_argument(
-        "--host", help="Redis host", type=str, default=DEFAULT_REDIS_HOST
-    )
-    parser.add_argument(
-        "-p", "--port", help="Redis port", type=int, default=DEFAULT_REDIS_PORT
-    )
-    parser.add_argument("--user", help="Redis username", type=str, default="default")
+    parser.add_argument("--host", help="Redis host", type=str, default=None)
+    parser.add_argument("-p", "--port", help="Redis port", type=int, default=None)
+    parser.add_argument("--user", help="Redis username", type=str, default=None)
     parser.add_argument("--ssl", help="Use SSL", action="store_true")
     parser.add_argument(
         "-a",
         "--password",
         help="Redis password",
         type=str,
-        default="",
+        default=None,
     )
     return parser

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,7 +1,7 @@
 import os
 from argparse import ArgumentParser, Namespace
 from typing import Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
@@ -39,12 +39,12 @@ def _build_redis_url(args: Namespace) -> str:
 
     auth = ""
     if user:
-        auth = user
+        auth = quote(user, safe="")
         if password:
-            auth += f":{password}"
+            auth += f":{quote(password, safe='')}"
         auth += "@"
     elif password:
-        auth = f":{password}@"
+        auth = f":{quote(password, safe='')}@"
 
     return f"{scheme}://{auth}{host}:{port}"
 

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,5 +1,6 @@
 import os
-from argparse import Action, ArgumentParser, Namespace
+from argparse import ArgumentParser, Namespace
+from collections.abc import Sequence
 
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
@@ -7,69 +8,58 @@ from redisvl.utils.log import get_logger
 logger = get_logger("[RedisVL]")
 DEFAULT_REDIS_HOST = "localhost"
 DEFAULT_REDIS_PORT = 6379
-_TRACKED_CONNECTION_OPTIONS_ATTR = "_tracked_connection_options"
-_TRACK_CONNECTION_OPTIONS_ATTR = "_track_connection_options"
+_HOST_FLAGS = ("--host",)
+_PORT_FLAGS = ("-p", "--port")
+_USER_FLAGS = ("--user",)
+_PASSWORD_FLAGS = ("-a", "--password")
+_SSL_FLAGS = ("--ssl",)
+_ALL_CONNECTION_FLAGS = (
+    _HOST_FLAGS,
+    _PORT_FLAGS,
+    _USER_FLAGS,
+    _PASSWORD_FLAGS,
+    _SSL_FLAGS,
+)
 
 
-def _get_tracked_connection_options(args: Namespace) -> set[str]:
-    return set(getattr(args, _TRACKED_CONNECTION_OPTIONS_ATTR, ()))
+def _get_cli_argv(args: Namespace) -> tuple[str, ...]:
+    raw_argv = getattr(args, "_argv", ())
+    return tuple(raw_argv) if isinstance(raw_argv, Sequence) else ()
 
 
-def _is_tracking_connection_options(args: Namespace) -> bool:
-    return bool(getattr(args, _TRACK_CONNECTION_OPTIONS_ATTR, False))
-
-
-def _mark_connection_option(args: Namespace, option: str) -> None:
-    tracked_options = _get_tracked_connection_options(args)
-    tracked_options.add(option)
-    setattr(args, _TRACKED_CONNECTION_OPTIONS_ATTR, tracked_options)
-
-
-class _StoreTrackedOption(Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        _mark_connection_option(namespace, self.dest)
-        setattr(namespace, self.dest, values)
-
-
-class _StoreTrackedTrue(Action):
-    def __init__(self, option_strings, dest, default=False, required=False, help=None):
-        super().__init__(
-            option_strings,
-            dest,
-            nargs=0,
-            default=default,
-            required=required,
-            help=help,
-        )
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        _mark_connection_option(namespace, self.dest)
-        setattr(namespace, self.dest, True)
+def _argv_has_flag(argv: Sequence[str], *flags: str) -> bool:
+    return any(flag in argv for flag in flags)
 
 
 def _has_explicit_connection_options(args: Namespace) -> bool:
-    if _is_tracking_connection_options(args):
-        return bool(
-            _get_tracked_connection_options(args)
-            & {"host", "port", "user", "password", "ssl"}
-        )
+    argv = _get_cli_argv(args)
+    if argv:
+        return any(_argv_has_flag(argv, *flags) for flags in _ALL_CONNECTION_FLAGS)
 
     return any(
-        getattr(args, attribute, None) is not None
-        for attribute in ("host", "port", "user", "password")
-    ) or bool(getattr(args, "ssl", False))
+        (
+            getattr(args, "host", None) not in (None, DEFAULT_REDIS_HOST),
+            getattr(args, "port", None) not in (None, DEFAULT_REDIS_PORT),
+            getattr(args, "user", None) not in (None, "", "default"),
+            bool(getattr(args, "password", None)),
+            bool(getattr(args, "ssl", False)),
+        )
+    )
 
 
 def _get_auth_credentials(args: Namespace) -> tuple[str | None, str | None]:
-    if _is_tracking_connection_options(args):
-        tracked_options = _get_tracked_connection_options(args)
-        user = getattr(args, "user", None) if "user" in tracked_options else None
-        password = (
-            getattr(args, "password", None) if "password" in tracked_options else None
-        )
+    argv = _get_cli_argv(args)
+    if argv:
+        user = args.user if _argv_has_flag(argv, *_USER_FLAGS) else None
+        password = args.password if _argv_has_flag(argv, *_PASSWORD_FLAGS) else None
         return user, password
 
-    return getattr(args, "user", None), getattr(args, "password", None)
+    user = getattr(args, "user", None)
+    if user in (None, "", "default"):
+        user = None
+
+    password = getattr(args, "password", None) or None
+    return user, password
 
 
 def _build_redis_url(args: Namespace) -> str:
@@ -107,46 +97,24 @@ def create_redis_url(args: Namespace) -> str:
 
 
 def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
-    parser.set_defaults(
-        **{
-            _TRACK_CONNECTION_OPTIONS_ATTR: True,
-            _TRACKED_CONNECTION_OPTIONS_ATTR: (),
-        }
-    )
     parser.add_argument("-i", "--index", help="Index name", type=str, required=False)
     parser.add_argument(
         "-s", "--schema", help="Path to schema file", type=str, required=False
     )
     parser.add_argument("-u", "--url", help="Redis URL", type=str, required=False)
     parser.add_argument(
-        "--host",
-        help="Redis host",
-        type=str,
-        default=DEFAULT_REDIS_HOST,
-        action=_StoreTrackedOption,
+        "--host", help="Redis host", type=str, default=DEFAULT_REDIS_HOST
     )
     parser.add_argument(
-        "-p",
-        "--port",
-        help="Redis port",
-        type=int,
-        default=DEFAULT_REDIS_PORT,
-        action=_StoreTrackedOption,
+        "-p", "--port", help="Redis port", type=int, default=DEFAULT_REDIS_PORT
     )
-    parser.add_argument(
-        "--user",
-        help="Redis username",
-        type=str,
-        default="default",
-        action=_StoreTrackedOption,
-    )
-    parser.add_argument("--ssl", help="Use SSL", action=_StoreTrackedTrue)
+    parser.add_argument("--user", help="Redis username", type=str, default="default")
+    parser.add_argument("--ssl", help="Use SSL", action="store_true")
     parser.add_argument(
         "-a",
         "--password",
         help="Redis password",
         type=str,
         default="",
-        action=_StoreTrackedOption,
     )
     return parser

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,6 +1,7 @@
 import os
 from argparse import ArgumentParser, Namespace
 from typing import Optional
+from urllib.parse import urlparse, urlunparse
 
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
@@ -17,7 +18,6 @@ def _has_explicit_connection_options(args: Namespace) -> bool:
             getattr(args, "port", None) is not None,
             bool(getattr(args, "user", None)),
             bool(getattr(args, "password", None)),
-            bool(getattr(args, "ssl", False)),
         )
     )
 
@@ -49,6 +49,13 @@ def _build_redis_url(args: Namespace) -> str:
     return f"{scheme}://{auth}{host}:{port}"
 
 
+def _apply_ssl_scheme(url: str) -> str:
+    parsed_url = urlparse(url)
+    if parsed_url.scheme == "rediss":
+        return url
+    return urlunparse(parsed_url._replace(scheme="rediss"))
+
+
 def create_redis_url(args: Namespace) -> str:
     if args.url:
         return args.url
@@ -60,6 +67,8 @@ def create_redis_url(args: Namespace) -> str:
         logger.info(
             f"Using Redis address from environment variable, {REDIS_URL_ENV_VAR}"
         )
+        if getattr(args, "ssl", False):
+            return _apply_ssl_scheme(env_address)
         return env_address
 
     return _build_redis_url(args)

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,5 +1,5 @@
 import os
-from argparse import ArgumentParser, Namespace
+from argparse import Action, ArgumentParser, Namespace
 
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
@@ -7,21 +7,76 @@ from redisvl.utils.log import get_logger
 logger = get_logger("[RedisVL]")
 DEFAULT_REDIS_HOST = "localhost"
 DEFAULT_REDIS_PORT = 6379
+_TRACKED_CONNECTION_OPTIONS_ATTR = "_tracked_connection_options"
+_TRACK_CONNECTION_OPTIONS_ATTR = "_track_connection_options"
+
+
+def _get_tracked_connection_options(args: Namespace) -> set[str]:
+    return set(getattr(args, _TRACKED_CONNECTION_OPTIONS_ATTR, ()))
+
+
+def _is_tracking_connection_options(args: Namespace) -> bool:
+    return bool(getattr(args, _TRACK_CONNECTION_OPTIONS_ATTR, False))
+
+
+def _mark_connection_option(args: Namespace, option: str) -> None:
+    tracked_options = _get_tracked_connection_options(args)
+    tracked_options.add(option)
+    setattr(args, _TRACKED_CONNECTION_OPTIONS_ATTR, tracked_options)
+
+
+class _StoreTrackedOption(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        _mark_connection_option(namespace, self.dest)
+        setattr(namespace, self.dest, values)
+
+
+class _StoreTrackedTrue(Action):
+    def __init__(self, option_strings, dest, default=False, required=False, help=None):
+        super().__init__(
+            option_strings,
+            dest,
+            nargs=0,
+            default=default,
+            required=required,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        _mark_connection_option(namespace, self.dest)
+        setattr(namespace, self.dest, True)
 
 
 def _has_explicit_connection_options(args: Namespace) -> bool:
+    if _is_tracking_connection_options(args):
+        return bool(
+            _get_tracked_connection_options(args)
+            & {"host", "port", "user", "password", "ssl"}
+        )
+
     return any(
         getattr(args, attribute, None) is not None
         for attribute in ("host", "port", "user", "password")
     ) or bool(getattr(args, "ssl", False))
 
 
+def _get_auth_credentials(args: Namespace) -> tuple[str | None, str | None]:
+    if _is_tracking_connection_options(args):
+        tracked_options = _get_tracked_connection_options(args)
+        user = getattr(args, "user", None) if "user" in tracked_options else None
+        password = (
+            getattr(args, "password", None) if "password" in tracked_options else None
+        )
+        return user, password
+
+    return getattr(args, "user", None), getattr(args, "password", None)
+
+
 def _build_redis_url(args: Namespace) -> str:
     scheme = "rediss" if getattr(args, "ssl", False) else "redis"
     host = getattr(args, "host", None) or DEFAULT_REDIS_HOST
     port = getattr(args, "port", None) or DEFAULT_REDIS_PORT
-    user = getattr(args, "user", None)
-    password = getattr(args, "password", None)
+    user, password = _get_auth_credentials(args)
 
     auth = ""
     if user:
@@ -52,16 +107,46 @@ def create_redis_url(args: Namespace) -> str:
 
 
 def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
+    parser.set_defaults(
+        **{
+            _TRACK_CONNECTION_OPTIONS_ATTR: True,
+            _TRACKED_CONNECTION_OPTIONS_ATTR: (),
+        }
+    )
     parser.add_argument("-i", "--index", help="Index name", type=str, required=False)
     parser.add_argument(
         "-s", "--schema", help="Path to schema file", type=str, required=False
     )
     parser.add_argument("-u", "--url", help="Redis URL", type=str, required=False)
-    parser.add_argument("--host", help="Redis host", type=str, default=None)
-    parser.add_argument("-p", "--port", help="Redis port", type=int, default=None)
-    parser.add_argument("--user", help="Redis username", type=str, default=None)
-    parser.add_argument("--ssl", help="Use SSL", action="store_true")
     parser.add_argument(
-        "-a", "--password", help="Redis password", type=str, default=None
+        "--host",
+        help="Redis host",
+        type=str,
+        default=DEFAULT_REDIS_HOST,
+        action=_StoreTrackedOption,
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        help="Redis port",
+        type=int,
+        default=DEFAULT_REDIS_PORT,
+        action=_StoreTrackedOption,
+    )
+    parser.add_argument(
+        "--user",
+        help="Redis username",
+        type=str,
+        default="default",
+        action=_StoreTrackedOption,
+    )
+    parser.add_argument("--ssl", help="Use SSL", action=_StoreTrackedTrue)
+    parser.add_argument(
+        "-a",
+        "--password",
+        help="Redis password",
+        type=str,
+        default="",
+        action=_StoreTrackedOption,
     )
     return parser

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -15,7 +15,7 @@ def _has_explicit_connection_options(args: Namespace) -> bool:
         (
             getattr(args, "host", None) is not None,
             getattr(args, "port", None) is not None,
-            getattr(args, "user", None) is not None,
+            bool(getattr(args, "user", None)),
             bool(getattr(args, "password", None)),
             bool(getattr(args, "ssl", False)),
         )
@@ -23,7 +23,7 @@ def _has_explicit_connection_options(args: Namespace) -> bool:
 
 
 def _get_auth_credentials(args: Namespace) -> tuple[Optional[str], Optional[str]]:
-    return getattr(args, "user", None), getattr(args, "password", None)
+    return getattr(args, "user", None) or None, getattr(args, "password", None) or None
 
 
 def _build_redis_url(args: Namespace) -> str:

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -28,8 +28,13 @@ def _get_auth_credentials(args: Namespace) -> tuple[Optional[str], Optional[str]
 
 def _build_redis_url(args: Namespace) -> str:
     scheme = "rediss" if getattr(args, "ssl", False) else "redis"
-    host = getattr(args, "host", None) or DEFAULT_REDIS_HOST
-    port = getattr(args, "port", None) or DEFAULT_REDIS_PORT
+    host = getattr(args, "host", None)
+    if host is None:
+        host = DEFAULT_REDIS_HOST
+
+    port = getattr(args, "port", None)
+    if port is None:
+        port = DEFAULT_REDIS_PORT
     user, password = _get_auth_credentials(args)
 
     auth = ""

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,29 +1,54 @@
 import os
 from argparse import ArgumentParser, Namespace
 
+from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
 
 logger = get_logger("[RedisVL]")
+DEFAULT_REDIS_HOST = "localhost"
+DEFAULT_REDIS_PORT = 6379
+
+
+def _has_explicit_connection_options(args: Namespace) -> bool:
+    return any(
+        getattr(args, attribute, None) is not None
+        for attribute in ("host", "port", "user", "password")
+    ) or bool(getattr(args, "ssl", False))
+
+
+def _build_redis_url(args: Namespace) -> str:
+    scheme = "rediss" if getattr(args, "ssl", False) else "redis"
+    host = getattr(args, "host", None) or DEFAULT_REDIS_HOST
+    port = getattr(args, "port", None) or DEFAULT_REDIS_PORT
+    user = getattr(args, "user", None)
+    password = getattr(args, "password", None)
+
+    auth = ""
+    if user:
+        auth = user
+        if password:
+            auth += f":{password}"
+        auth += "@"
+    elif password:
+        auth = f":{password}@"
+
+    return f"{scheme}://{auth}{host}:{port}"
 
 
 def create_redis_url(args: Namespace) -> str:
-    env_address = os.getenv("REDIS_URL")
-    if env_address:
-        logger.info(f"Using Redis address from environment variable, REDIS_URL")
-        return env_address
-    elif args.url:
+    if args.url:
         return args.url
-    else:
-        url = "redis://"
-        if args.ssl:
-            url += "rediss://"
-        if args.user:
-            url += args.user
-            if args.password:
-                url += ":" + args.password
-            url += "@"
-        url += args.host + ":" + str(args.port)
-        return url
+    if _has_explicit_connection_options(args):
+        return _build_redis_url(args)
+
+    env_address = os.getenv(REDIS_URL_ENV_VAR)
+    if env_address:
+        logger.info(
+            f"Using Redis address from environment variable, {REDIS_URL_ENV_VAR}"
+        )
+        return env_address
+
+    return _build_redis_url(args)
 
 
 def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
@@ -32,9 +57,11 @@ def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
         "-s", "--schema", help="Path to schema file", type=str, required=False
     )
     parser.add_argument("-u", "--url", help="Redis URL", type=str, required=False)
-    parser.add_argument("--host", help="Redis host", type=str, default="localhost")
-    parser.add_argument("-p", "--port", help="Redis port", type=int, default=6379)
-    parser.add_argument("--user", help="Redis username", type=str, default="default")
+    parser.add_argument("--host", help="Redis host", type=str, default=None)
+    parser.add_argument("-p", "--port", help="Redis port", type=int, default=None)
+    parser.add_argument("--user", help="Redis username", type=str, default=None)
     parser.add_argument("--ssl", help="Use SSL", action="store_true")
-    parser.add_argument("-a", "--password", help="Redis password", type=str, default="")
+    parser.add_argument(
+        "-a", "--password", help="Redis password", type=str, default=None
+    )
     return parser

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -115,7 +115,20 @@ class BaseCache:
             # Create new Redis client
             url = self.redis_kwargs["redis_url"]
             kwargs = self.redis_kwargs["connection_kwargs"]
-            self._redis_client = Redis.from_url(url, **kwargs)  # type: ignore
+            if url is not None and not isinstance(url, str):
+                raise TypeError(
+                    "Expected `redis_url` to be a string (e.g. 'redis://localhost:6379'), "
+                    f"but got type: {type(url).__name__}"
+                )
+            if not isinstance(kwargs, Mapping):
+                raise TypeError(
+                    "Expected `connection_kwargs` to be a dictionary (e.g. {'decode_responses': True}), "
+                    f"but got type: {type(kwargs).__name__}"
+                )
+            self._redis_client = RedisConnectionFactory.get_redis_connection(
+                redis_url=url,
+                **kwargs,
+            )
         return self._redis_client
 
     async def _get_async_redis_client(self) -> AsyncRedisClient:

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -5,7 +5,7 @@ specific cache types such as LLM caches and embedding caches.
 """
 
 from collections.abc import Mapping
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from redis import Redis  # For backwards compatibility in type checking
 from redis.cluster import RedisCluster
@@ -113,18 +113,8 @@ class BaseCache:
         """
         if self._redis_client is None:
             # Create new Redis client
-            url = self.redis_kwargs["redis_url"]
-            kwargs = self.redis_kwargs["connection_kwargs"]
-            if url is not None and not isinstance(url, str):
-                raise TypeError(
-                    "Expected `redis_url` to be a string (e.g. 'redis://localhost:6379'), "
-                    f"but got type: {type(url).__name__}"
-                )
-            if not isinstance(kwargs, Mapping):
-                raise TypeError(
-                    "Expected `connection_kwargs` to be a dictionary (e.g. {'decode_responses': True}), "
-                    f"but got type: {type(kwargs).__name__}"
-                )
+            url = cast(Optional[str], self.redis_kwargs["redis_url"])
+            kwargs = cast(Dict[str, Any], self.redis_kwargs["connection_kwargs"])
             self._redis_client = RedisConnectionFactory.get_redis_connection(
                 redis_url=url,
                 **kwargs,
@@ -145,15 +135,12 @@ class BaseCache:
                     client
                 )
             else:
-                url = str(self.redis_kwargs["redis_url"])
-                kwargs = self.redis_kwargs.get("connection_kwargs", {})
-                if not isinstance(kwargs, Mapping):
-                    raise TypeError(
-                        "Expected `connection_kwargs` to be a dictionary (e.g. {'decode_responses': True}), "
-                        f"but got type: {type(kwargs).__name__}"
-                    )
+                url = cast(Optional[str], self.redis_kwargs["redis_url"])
+                kwargs = cast(Dict[str, Any], self.redis_kwargs["connection_kwargs"])
                 self._async_redis_client = (
-                    RedisConnectionFactory.get_async_redis_connection(url, **kwargs)
+                    RedisConnectionFactory.get_async_redis_connection(
+                        redis_url=url, **kwargs
+                    )
                 )
         return self._async_redis_client
 

--- a/redisvl/extensions/cache/llm/semantic.py
+++ b/redisvl/extensions/cache/llm/semantic.py
@@ -141,7 +141,7 @@ class SemanticCache(BaseLLMCache):
             schema=schema,
             redis_client=self._redis_client,
             redis_url=self.redis_kwargs["redis_url"],
-            **self.redis_kwargs["connection_kwargs"],
+            connection_kwargs=self.redis_kwargs["connection_kwargs"] or None,
         )
         self._aindex = None
 
@@ -211,7 +211,7 @@ class SemanticCache(BaseLLMCache):
                 schema=self._index.schema,
                 redis_client=async_client,
                 redis_url=self.redis_kwargs["redis_url"],
-                **self.redis_kwargs["connection_kwargs"],
+                connection_kwargs=self.redis_kwargs["connection_kwargs"] or None,
             )
         return self._aindex
 

--- a/redisvl/extensions/message_history/message_history.py
+++ b/redisvl/extensions/message_history/message_history.py
@@ -61,7 +61,7 @@ class MessageHistory(BaseMessageHistory):
             schema=schema,
             redis_client=redis_client,
             redis_url=redis_url,
-            **connection_kwargs,
+            connection_kwargs=connection_kwargs or None,
         )
 
         self._index.create(overwrite=False)

--- a/redisvl/extensions/message_history/semantic_history.py
+++ b/redisvl/extensions/message_history/semantic_history.py
@@ -103,7 +103,7 @@ class SemanticMessageHistory(BaseMessageHistory):
             schema=schema,
             redis_client=redis_client,
             redis_url=redis_url,
-            **connection_kwargs,
+            connection_kwargs=connection_kwargs or None,
         )
 
         # Check for existing message history index

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -72,6 +72,7 @@ class SemanticRouter(BaseModel):
                 for the redis client. Defaults to empty {}.
         """
         dtype = kwargs.pop("dtype", None)
+        index_kwargs = kwargs.pop("_index_kwargs", None)
 
         # Validate a provided vectorizer or set the default
         if vectorizer:
@@ -104,7 +105,13 @@ class SemanticRouter(BaseModel):
             redis_client=redis_client,
         )
 
-        self._initialize_index(redis_client, redis_url, overwrite, **connection_kwargs)
+        self._initialize_index(
+            redis_client,
+            redis_url,
+            overwrite,
+            connection_kwargs=connection_kwargs or None,
+            index_kwargs=index_kwargs,
+        )
 
         self._index.client.json().set(f"{self.name}:route_config", f".", self.to_dict())  # type: ignore
 
@@ -117,29 +124,55 @@ class SemanticRouter(BaseModel):
         **kwargs,
     ) -> "SemanticRouter":
         """Return SemanticRouter instance from existing index."""
-        resolved_redis_url: Optional[str] = redis_url
+        connection_kwargs = dict(kwargs.pop("connection_kwargs", {}) or {})
+        lib_name = kwargs.pop("lib_name", None)
+        connection_kwargs.update(kwargs)
+        index_kwargs: Dict[str, Any] = {}
+        created_redis_client = False
+
         if redis_client:
             # Just validate client type and set lib name
-            RedisConnectionFactory.validate_sync_redis(redis_client)
-            resolved_redis_url = None
+            RedisConnectionFactory.validate_sync_redis(redis_client, lib_name)
+            index_kwargs["_client_validated"] = True
         else:
+            factory_kwargs = {**connection_kwargs}
+            if lib_name is not None:
+                factory_kwargs["lib_name"] = lib_name
             redis_client = RedisConnectionFactory.get_redis_connection(
                 redis_url=redis_url,
-                **kwargs,
+                **factory_kwargs,
             )
-        if redis_client is None:
-            raise ValueError(
-                "Creating Redis client failed. Please check the redis_url and connection_kwargs."
-            )
+            index_kwargs["_client_validated"] = True
+            index_kwargs["_owns_redis_client"] = True
+            if lib_name is not None:
+                index_kwargs["lib_name"] = lib_name
+            created_redis_client = True
 
-        router_dict = redis_client.json().get(f"{name}:route_config")
+        try:
+            router_dict = redis_client.json().get(f"{name}:route_config")
+        except Exception:
+            if created_redis_client and redis_client is not None:
+                redis_client.close()
+            raise
         if not isinstance(router_dict, dict):
+            if created_redis_client and redis_client is not None:
+                redis_client.close()
             raise ValueError(
                 f"No valid router config found for {name}. Received: {router_dict!r}"
             )
-        return cls.from_dict(
-            router_dict, redis_url=resolved_redis_url, redis_client=redis_client
-        )
+        resolved_redis_url = redis_url if created_redis_client else None
+        try:
+            return cls.from_dict(
+                router_dict,
+                redis_url=resolved_redis_url,
+                redis_client=redis_client,
+                connection_kwargs=connection_kwargs or None,
+                _index_kwargs=index_kwargs or None,
+            )
+        except Exception:
+            if created_redis_client and redis_client is not None:
+                redis_client.close()
+            raise
 
     @deprecated_argument("dtype")
     def _initialize_index(
@@ -148,7 +181,8 @@ class SemanticRouter(BaseModel):
         redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
         dtype: str = "float32",
-        **connection_kwargs,
+        connection_kwargs: Optional[Dict[str, Any]] = None,
+        index_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the search index and handle Redis connection."""
 
@@ -160,7 +194,8 @@ class SemanticRouter(BaseModel):
             schema=schema,
             redis_client=redis_client,
             redis_url=redis_url,
-            **connection_kwargs,
+            connection_kwargs=connection_kwargs,
+            **(index_kwargs or {}),
         )
 
         # Check for existing router index

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -18,7 +18,7 @@ from redisvl.extensions.router.schema import (
 from redisvl.index import SearchIndex
 from redisvl.query import FilterQuery, VectorRangeQuery
 from redisvl.query.filter import Tag
-from redisvl.redis.connection import RedisConnectionFactory
+from redisvl.redis.connection import RedisConnectionFactory, _split_from_existing_kwargs
 from redisvl.redis.utils import convert_bytes, hashify, make_dict
 from redisvl.types import SyncRedisClient
 from redisvl.utils.log import get_logger
@@ -124,9 +124,11 @@ class SemanticRouter(BaseModel):
         **kwargs,
     ) -> "SemanticRouter":
         """Return SemanticRouter instance from existing index."""
-        connection_kwargs = dict(kwargs.pop("connection_kwargs", {}) or {})
-        lib_name = kwargs.pop("lib_name", None)
-        connection_kwargs.update(kwargs)
+        init_kwargs, connection_kwargs = _split_from_existing_kwargs(
+            dict(kwargs),
+            nested_connection_keys=("connection_kwargs",),
+        )
+        lib_name = init_kwargs.get("lib_name")
         index_kwargs: Dict[str, Any] = {}
         created_redis_client = False
 
@@ -167,7 +169,7 @@ class SemanticRouter(BaseModel):
                 redis_url=resolved_redis_url,
                 redis_client=redis_client,
                 connection_kwargs=connection_kwargs or None,
-                _index_kwargs=index_kwargs or None,
+                _index_kwargs={**init_kwargs, **index_kwargs} or None,
             )
         except Exception:
             if created_redis_client and redis_client is not None:

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -117,14 +117,14 @@ class SemanticRouter(BaseModel):
         **kwargs,
     ) -> "SemanticRouter":
         """Return SemanticRouter instance from existing index."""
-        if redis_url:
+        if redis_client:
+            # Just validate client type and set lib name
+            RedisConnectionFactory.validate_sync_redis(redis_client)
+        else:
             redis_client = RedisConnectionFactory.get_redis_connection(
                 redis_url=redis_url,
                 **kwargs,
             )
-        elif redis_client:
-            # Just validate client type and set lib name
-            RedisConnectionFactory.validate_sync_redis(redis_client)
         if redis_client is None:
             raise ValueError(
                 "Creating Redis client failed. Please check the redis_url and connection_kwargs."

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -117,9 +117,11 @@ class SemanticRouter(BaseModel):
         **kwargs,
     ) -> "SemanticRouter":
         """Return SemanticRouter instance from existing index."""
+        resolved_redis_url: Optional[str] = redis_url
         if redis_client:
             # Just validate client type and set lib name
             RedisConnectionFactory.validate_sync_redis(redis_client)
+            resolved_redis_url = None
         else:
             redis_client = RedisConnectionFactory.get_redis_connection(
                 redis_url=redis_url,
@@ -136,7 +138,7 @@ class SemanticRouter(BaseModel):
                 f"No valid router config found for {name}. Received: {router_dict!r}"
             )
         return cls.from_dict(
-            router_dict, redis_url=redis_url, redis_client=redis_client
+            router_dict, redis_url=resolved_redis_url, redis_client=redis_client
         )
 
     @deprecated_argument("dtype")

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -88,6 +88,7 @@ from redisvl.query.aggregate import AggregateHybridQuery
 from redisvl.query.filter import FilterExpression
 from redisvl.redis.connection import (
     RedisConnectionFactory,
+    _split_from_existing_kwargs,
     convert_index_info_to_schema,
     supports_svs,
     supports_svs_async,
@@ -111,30 +112,6 @@ REQUIRED_MODULES_FOR_INTROSPECTION = [
     {"name": "search", "ver": 20810},
     {"name": "searchlight", "ver": 20810},
 ]
-
-
-def _split_from_existing_kwargs(
-    kwargs: Dict[str, Any], *, nested_connection_keys: Sequence[str]
-) -> tuple[Dict[str, Any], Dict[str, Any]]:
-    init_kwargs: Dict[str, Any] = {}
-    connection_kwargs: Dict[str, Any] = {}
-
-    for key in ("validate_on_load", "lib_name"):
-        if key in kwargs:
-            init_kwargs[key] = kwargs.pop(key)
-
-    for key in list(kwargs):
-        if key.startswith("_"):
-            init_kwargs[key] = kwargs.pop(key)
-
-    for key in nested_connection_keys:
-        nested_kwargs = kwargs.pop(key, None)
-        if nested_kwargs is not None:
-            connection_kwargs.update(nested_kwargs)
-
-    connection_kwargs.update(kwargs)
-    return init_kwargs, connection_kwargs
-
 
 SearchParams = Union[
     Tuple[

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -531,16 +531,16 @@ class SearchIndex(BaseSearchIndex):
         Raises:
             ValueError: If redis_url or redis_client is not provided.
         """
-        if redis_url:
-            redis_client = RedisConnectionFactory.get_redis_connection(
-                redis_url=redis_url,
-                **kwargs,
-            )
-        elif redis_client:
+        if redis_client:
             # Validate client type and set lib name
             RedisConnectionFactory.validate_sync_redis(redis_client)
             # Mark that client was already validated to avoid duplicate calls
             kwargs["_client_validated"] = True
+        elif redis_url:
+            redis_client = RedisConnectionFactory.get_redis_connection(
+                redis_url=redis_url,
+                **kwargs,
+            )
 
         if not redis_client:
             raise ValueError("Must provide either a redis_url or redis_client")
@@ -1437,16 +1437,16 @@ class AsyncSearchIndex(BaseSearchIndex):
                 "Must provide either a redis_url or redis_client to fetch Redis index info."
             )
 
-        if redis_url:
-            redis_client = await RedisConnectionFactory._get_aredis_connection(
-                redis_url=redis_url,
-                **kwargs,
-            )
-        elif redis_client:
+        if redis_client:
             # Validate client type and set lib name
             await RedisConnectionFactory.validate_async_redis(redis_client)
             # Mark that client was already validated to avoid duplicate calls
             kwargs["_client_validated"] = True
+        elif redis_url:
+            redis_client = await RedisConnectionFactory._get_aredis_connection(
+                redis_url=redis_url,
+                **kwargs,
+            )
 
         if redis_client is None:
             raise ValueError(

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -57,12 +57,12 @@ from redisvl.utils.redis_protocol import get_protocol_version
 
 # Redis 5.x compatibility (6 fixed the import path)
 if redis_version.startswith("5"):
-    from redis.commands.search.indexDefinition import (  # type: ignore[import-untyped]
-        IndexDefinition,
+    from redis.commands.search.indexDefinition import (
+        IndexDefinition,  # type: ignore[import-untyped]
     )
 else:
-    from redis.commands.search.index_definition import (  # type: ignore[no-redef]
-        IndexDefinition,
+    from redis.commands.search.index_definition import (
+        IndexDefinition,  # type: ignore[no-redef]
     )
 
 # Need Result outside TYPE_CHECKING for cast
@@ -111,6 +111,30 @@ REQUIRED_MODULES_FOR_INTROSPECTION = [
     {"name": "search", "ver": 20810},
     {"name": "searchlight", "ver": 20810},
 ]
+
+
+def _split_from_existing_kwargs(
+    kwargs: Dict[str, Any], *, nested_connection_keys: Sequence[str]
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    init_kwargs: Dict[str, Any] = {}
+    connection_kwargs: Dict[str, Any] = {}
+
+    for key in ("validate_on_load", "lib_name"):
+        if key in kwargs:
+            init_kwargs[key] = kwargs.pop(key)
+
+    for key in list(kwargs):
+        if key.startswith("_"):
+            init_kwargs[key] = kwargs.pop(key)
+
+    for key in nested_connection_keys:
+        nested_kwargs = kwargs.pop(key, None)
+        if nested_kwargs is not None:
+            connection_kwargs.update(nested_kwargs)
+
+    connection_kwargs.update(kwargs)
+    return init_kwargs, connection_kwargs
+
 
 SearchParams = Union[
     Tuple[
@@ -496,7 +520,7 @@ class SearchIndex(BaseSearchIndex):
         self._sql_executors: Dict[str, Any] = {}
 
         self._validated_client = kwargs.pop("_client_validated", False)
-        self._owns_redis_client = redis_client is None
+        self._owns_redis_client = kwargs.pop("_owns_redis_client", redis_client is None)
         if self._owns_redis_client:
             weakref.finalize(self, self.disconnect)
 
@@ -531,16 +555,28 @@ class SearchIndex(BaseSearchIndex):
         Raises:
             ValueError: If redis_url or redis_client is not provided.
         """
+        init_kwargs, connection_kwargs = _split_from_existing_kwargs(
+            dict(kwargs),
+            nested_connection_keys=("connection_kwargs", "connection_args"),
+        )
+        lib_name = cast(Optional[str], init_kwargs.get("lib_name"))
+        created_redis_client = False
+
         if redis_client:
             # Validate client type and set lib name
-            RedisConnectionFactory.validate_sync_redis(redis_client)
+            RedisConnectionFactory.validate_sync_redis(redis_client, lib_name)
             # Mark that client was already validated to avoid duplicate calls
-            kwargs["_client_validated"] = True
+            init_kwargs["_client_validated"] = True
         elif redis_url:
+            factory_kwargs = {**connection_kwargs}
+            if lib_name is not None:
+                factory_kwargs["lib_name"] = lib_name
             redis_client = RedisConnectionFactory.get_redis_connection(
                 redis_url=redis_url,
-                **kwargs,
+                **factory_kwargs,
             )
+            init_kwargs["_client_validated"] = True
+            created_redis_client = True
 
         if not redis_client:
             raise ValueError("Must provide either a redis_url or redis_client")
@@ -549,7 +585,16 @@ class SearchIndex(BaseSearchIndex):
         index_info = cls._info(name, redis_client)
         schema_dict = convert_index_info_to_schema(index_info)
         schema = IndexSchema.from_dict(schema_dict)
-        return cls(schema, redis_client, **kwargs)
+        if created_redis_client:
+            init_kwargs["_owns_redis_client"] = True
+            return cls(
+                schema,
+                redis_client=redis_client,
+                redis_url=redis_url,
+                connection_kwargs=connection_kwargs or None,
+                **init_kwargs,
+            )
+        return cls(schema, redis_client=redis_client, **init_kwargs)
 
     @property
     def client(self) -> Optional[SyncRedisClient]:
@@ -1410,7 +1455,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         self._sql_executors: Dict[str, Any] = {}
 
         self._validated_client = kwargs.pop("_client_validated", False)
-        self._owns_redis_client = redis_client is None
+        self._owns_redis_client = kwargs.pop("_owns_redis_client", redis_client is None)
         if self._owns_redis_client:
             weakref.finalize(self, sync_wrapper(self.disconnect))
 
@@ -1437,16 +1482,28 @@ class AsyncSearchIndex(BaseSearchIndex):
                 "Must provide either a redis_url or redis_client to fetch Redis index info."
             )
 
+        init_kwargs, connection_kwargs = _split_from_existing_kwargs(
+            dict(kwargs),
+            nested_connection_keys=("connection_kwargs", "redis_kwargs"),
+        )
+        lib_name = cast(Optional[str], init_kwargs.get("lib_name"))
+        created_redis_client = False
+
         if redis_client:
             # Validate client type and set lib name
-            await RedisConnectionFactory.validate_async_redis(redis_client)
+            await RedisConnectionFactory.validate_async_redis(redis_client, lib_name)
             # Mark that client was already validated to avoid duplicate calls
-            kwargs["_client_validated"] = True
+            init_kwargs["_client_validated"] = True
         elif redis_url:
+            factory_kwargs = {**connection_kwargs}
+            if lib_name is not None:
+                factory_kwargs["lib_name"] = lib_name
             redis_client = await RedisConnectionFactory._get_aredis_connection(
                 redis_url=redis_url,
-                **kwargs,
+                **factory_kwargs,
             )
+            init_kwargs["_client_validated"] = True
+            created_redis_client = True
 
         if redis_client is None:
             raise ValueError(
@@ -1458,7 +1515,16 @@ class AsyncSearchIndex(BaseSearchIndex):
         index_info = await cls._info(name, redis_client)
         schema_dict = convert_index_info_to_schema(index_info)
         schema = IndexSchema.from_dict(schema_dict)
-        return cls(schema, redis_client=redis_client, **kwargs)
+        if created_redis_client:
+            init_kwargs["_owns_redis_client"] = True
+            return cls(
+                schema,
+                redis_client=redis_client,
+                redis_url=redis_url,
+                connection_kwargs=connection_kwargs or None,
+                **init_kwargs,
+            )
+        return cls(schema, redis_client=redis_client, **init_kwargs)
 
     @property
     def client(self) -> Optional[AsyncRedisClient]:

--- a/redisvl/query/sql.py
+++ b/redisvl/query/sql.py
@@ -3,6 +3,8 @@
 import re
 from typing import Any, Dict, Optional
 
+from redisvl.redis.connection import RedisConnectionFactory
+
 
 class SQLQuery:
     """A query class that translates SQL-like syntax into Redis queries.
@@ -168,9 +170,9 @@ class SQLQuery:
 
         # Get or create Redis client
         if redis_client is None:
-            from redis import Redis
-
-            redis_client = Redis.from_url(redis_url)
+            redis_client = RedisConnectionFactory.get_redis_connection(
+                redis_url=redis_url
+            )
 
         sql_redis_options = {
             "schema_cache_strategy": "lazy",

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -1,5 +1,16 @@
 import os
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from warnings import warn
 
@@ -27,6 +38,29 @@ from redisvl.utils.log import get_logger
 from redisvl.utils.utils import deprecated_argument, deprecated_function
 
 logger = get_logger(__name__)
+
+
+def _split_from_existing_kwargs(
+    kwargs: Dict[str, Any], *, nested_connection_keys: Sequence[str]
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    init_kwargs: Dict[str, Any] = {}
+    connection_kwargs: Dict[str, Any] = {}
+
+    for key in ("validate_on_load", "lib_name"):
+        if key in kwargs:
+            init_kwargs[key] = kwargs.pop(key)
+
+    for key in list(kwargs):
+        if key.startswith("_"):
+            init_kwargs[key] = kwargs.pop(key)
+
+    for key in nested_connection_keys:
+        nested_kwargs = kwargs.pop(key, None)
+        if nested_kwargs is not None:
+            connection_kwargs.update(nested_kwargs)
+
+    connection_kwargs.update(kwargs)
+    return init_kwargs, connection_kwargs
 
 
 def _strip_cluster_from_url_and_kwargs(

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -49,6 +49,12 @@ def test_parser_leaves_connection_options_unset_by_default(parse_args):
             id="ssl-with-auth",
         ),
         pytest.param(
+            ["--host=cache.local", "--user=alice", "--password=p@ss:w/rd?#"],
+            None,
+            "redis://alice:p%40ss%3Aw%2Frd%3F%23@cache.local:6379",
+            id="encodes-reserved-auth-characters",
+        ),
+        pytest.param(
             ["--ssl"],
             "redis://production-host:6380/0",
             "rediss://production-host:6380/0",

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -6,11 +6,12 @@ from redisvl.cli.utils import add_index_parsing_options, create_redis_url
 def _args(**overrides) -> Namespace:
     values = {
         "url": None,
-        "host": None,
-        "port": None,
-        "user": None,
-        "password": None,
+        "host": "localhost",
+        "port": 6379,
+        "user": "default",
+        "password": "",
         "ssl": False,
+        "_argv": (),
     }
     values.update(overrides)
     return Namespace(**values)
@@ -30,7 +31,13 @@ def test_create_redis_url_prefers_explicit_connection_flags_over_env(monkeypatch
     monkeypatch.setenv("REDIS_URL", "redis://env:6379")
 
     assert (
-        create_redis_url(_args(host="cache.local", port=6380))
+        create_redis_url(
+            _args(
+                host="cache.local",
+                port=6380,
+                _argv=("--host", "cache.local", "-p", "6380"),
+            )
+        )
         == "redis://cache.local:6380"
     )
 
@@ -61,6 +68,17 @@ def test_create_redis_url_builds_ssl_url_without_double_scheme(monkeypatch):
                 user="alice",
                 password="secret",
                 ssl=True,
+                _argv=(
+                    "--host",
+                    "cache.local",
+                    "-p",
+                    "6380",
+                    "--user",
+                    "alice",
+                    "-a",
+                    "secret",
+                    "--ssl",
+                ),
             )
         )
         == "rediss://alice:secret@cache.local:6380"
@@ -81,7 +99,13 @@ def test_create_redis_url_supports_password_only_auth(monkeypatch):
     monkeypatch.delenv("REDIS_URL", raising=False)
 
     assert (
-        create_redis_url(_args(host="cache.local", password="secret"))
+        create_redis_url(
+            _args(
+                host="cache.local",
+                password="secret",
+                _argv=("--host", "cache.local", "-a", "secret"),
+            )
+        )
         == "redis://:secret@cache.local:6379"
     )
 
@@ -92,7 +116,20 @@ def test_parser_defaults_do_not_override_env(monkeypatch):
     monkeypatch.setenv("REDIS_URL", "redis://env:6379")
 
     args = parser.parse_args([])
+    args._argv = ()
 
     assert args.host == "localhost"
     assert args.port == 6379
     assert create_redis_url(args) == "redis://env:6379"
+
+
+def test_explicit_default_host_still_overrides_env(monkeypatch):
+    """Treat an explicitly provided default host as higher priority than REDIS_URL."""
+    parser = add_index_parsing_options(ArgumentParser())
+    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
+
+    argv = ["--host", "localhost"]
+    args = parser.parse_args(argv)
+    args._argv = tuple(argv)
+
+    assert create_redis_url(args) == "redis://localhost:6379"

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -55,6 +55,12 @@ def test_parser_leaves_connection_options_unset_by_default(parse_args):
             id="password-only-auth",
         ),
         pytest.param(
+            ["--user="],
+            "redis://env:6379",
+            "redis://env:6379",
+            id="empty-user-does-not-override-env",
+        ),
+        pytest.param(
             ["--host=localhost"],
             "redis://env:6379",
             "redis://localhost:6379",

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,135 +1,86 @@
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
+from typing import Optional
+
+import pytest
 
 from redisvl.cli.utils import add_index_parsing_options, create_redis_url
 
 
-def _args(**overrides) -> Namespace:
-    values = {
-        "url": None,
-        "host": "localhost",
-        "port": 6379,
-        "user": "default",
-        "password": "",
-        "ssl": False,
-        "_argv": (),
-    }
-    values.update(overrides)
-    return Namespace(**values)
-
-
-def test_create_redis_url_prefers_explicit_url(monkeypatch):
-    """Use the explicit Redis URL before any other connection source."""
-    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
-
-    assert (
-        create_redis_url(_args(url="redis://explicit:6380")) == "redis://explicit:6380"
-    )
-
-
-def test_create_redis_url_prefers_explicit_connection_flags_over_env(monkeypatch):
-    """Use explicit host and port flags before the REDIS_URL environment variable."""
-    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
-
-    assert (
-        create_redis_url(
-            _args(
-                host="cache.local",
-                port=6380,
-                _argv=("--host", "cache.local", "-p", "6380"),
-            )
-        )
-        == "redis://cache.local:6380"
-    )
-
-
-def test_create_redis_url_uses_env_when_no_cli_connection_options(monkeypatch):
-    """Use REDIS_URL when no explicit CLI connection options are provided."""
-    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
-
-    assert create_redis_url(_args()) == "redis://env:6379"
-
-
-def test_create_redis_url_falls_back_to_local_default(monkeypatch):
-    """Fall back to the local Redis default when no other connection source is set."""
-    monkeypatch.delenv("REDIS_URL", raising=False)
-
-    assert create_redis_url(_args()) == "redis://localhost:6379"
-
-
-def test_create_redis_url_builds_ssl_url_without_double_scheme(monkeypatch):
-    """Build a valid rediss URL when SSL is enabled."""
-    monkeypatch.delenv("REDIS_URL", raising=False)
-
-    assert (
-        create_redis_url(
-            _args(
-                host="cache.local",
-                port=6380,
-                user="alice",
-                password="secret",
-                ssl=True,
-                _argv=(
-                    "--host",
-                    "cache.local",
-                    "-p",
-                    "6380",
-                    "--user",
-                    "alice",
-                    "-a",
-                    "secret",
-                    "--ssl",
-                ),
-            )
-        )
-        == "rediss://alice:secret@cache.local:6380"
-    )
-
-
-def test_create_redis_url_omits_default_username_for_local_connections(monkeypatch):
-    """Omit implicit auth when building the default local Redis URL."""
-    monkeypatch.delenv("REDIS_URL", raising=False)
-
-    assert (
-        create_redis_url(_args(host="localhost", port=6379)) == "redis://localhost:6379"
-    )
-
-
-def test_create_redis_url_supports_password_only_auth(monkeypatch):
-    """Allow password-only Redis auth without injecting a username."""
-    monkeypatch.delenv("REDIS_URL", raising=False)
-
-    assert (
-        create_redis_url(
-            _args(
-                host="cache.local",
-                password="secret",
-                _argv=("--host", "cache.local", "-a", "secret"),
-            )
-        )
-        == "redis://:secret@cache.local:6379"
-    )
-
-
-def test_parser_defaults_do_not_override_env(monkeypatch):
-    """Preserve parser defaults without letting them outrank REDIS_URL."""
+@pytest.fixture
+def parse_args():
     parser = add_index_parsing_options(ArgumentParser())
-    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
 
-    args = parser.parse_args([])
-    args._argv = ()
+    def _parse(argv: list[str]):
+        return parser.parse_args(argv)
 
-    assert args.host == "localhost"
-    assert args.port == 6379
-    assert create_redis_url(args) == "redis://env:6379"
+    return _parse
 
 
-def test_explicit_default_host_still_overrides_env(monkeypatch):
-    """Treat an explicitly provided default host as higher priority than REDIS_URL."""
-    parser = add_index_parsing_options(ArgumentParser())
-    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
+def test_parser_leaves_connection_options_unset_by_default(parse_args):
+    """Leave connection options unset so URL resolution can apply precedence."""
+    args = parse_args([])
 
-    argv = ["--host", "localhost"]
-    args = parser.parse_args(argv)
-    args._argv = tuple(argv)
+    assert args.host is None
+    assert args.port is None
+    assert args.user is None
+    assert args.password is None
+    assert args.ssl is False
 
-    assert create_redis_url(args) == "redis://localhost:6379"
+
+@pytest.mark.parametrize(
+    ("argv", "env_url", "expected"),
+    [
+        pytest.param(
+            ["--url=redis://explicit:6380"],
+            "redis://env:6379",
+            "redis://explicit:6380",
+            id="explicit-url",
+        ),
+        pytest.param(
+            ["--host=cache.local", "--port=6380"],
+            "redis://env:6379",
+            "redis://cache.local:6380",
+            id="explicit-host-port",
+        ),
+        pytest.param(
+            ["--host=cache.local", "--user=alice", "--password=secret", "--ssl"],
+            None,
+            "rediss://alice:secret@cache.local:6379",
+            id="ssl-with-auth",
+        ),
+        pytest.param(
+            ["--host=cache.local", "-a", "secret"],
+            None,
+            "redis://:secret@cache.local:6379",
+            id="password-only-auth",
+        ),
+        pytest.param(
+            ["--host=localhost"],
+            "redis://env:6379",
+            "redis://localhost:6379",
+            id="explicit-default-host",
+        ),
+        pytest.param(
+            [],
+            "redis://env:6379",
+            "redis://env:6379",
+            id="environment-fallback",
+        ),
+        pytest.param(
+            [],
+            None,
+            "redis://localhost:6379",
+            id="local-default",
+        ),
+    ],
+)
+def test_create_redis_url_resolves_connection_sources(
+    parse_args, monkeypatch, argv: list[str], env_url: Optional[str], expected: str
+):
+    """Resolve Redis URLs from CLI args, environment, and local defaults."""
+    if env_url is None:
+        monkeypatch.delenv("REDIS_URL", raising=False)
+    else:
+        monkeypatch.setenv("REDIS_URL", env_url)
+
+    assert create_redis_url(parse_args(argv)) == expected

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,0 +1,79 @@
+from argparse import Namespace
+
+from redisvl.cli.utils import create_redis_url
+
+
+def _args(**overrides) -> Namespace:
+    values = {
+        "url": None,
+        "host": None,
+        "port": None,
+        "user": None,
+        "password": None,
+        "ssl": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_create_redis_url_prefers_explicit_url(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
+
+    assert (
+        create_redis_url(_args(url="redis://explicit:6380")) == "redis://explicit:6380"
+    )
+
+
+def test_create_redis_url_prefers_explicit_connection_flags_over_env(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
+
+    assert (
+        create_redis_url(_args(host="cache.local", port=6380))
+        == "redis://cache.local:6380"
+    )
+
+
+def test_create_redis_url_uses_env_when_no_cli_connection_options(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
+
+    assert create_redis_url(_args()) == "redis://env:6379"
+
+
+def test_create_redis_url_falls_back_to_local_default(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    assert create_redis_url(_args()) == "redis://localhost:6379"
+
+
+def test_create_redis_url_builds_ssl_url_without_double_scheme(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    assert (
+        create_redis_url(
+            _args(
+                host="cache.local",
+                port=6380,
+                user="alice",
+                password="secret",
+                ssl=True,
+            )
+        )
+        == "rediss://alice:secret@cache.local:6380"
+    )
+
+
+def test_create_redis_url_omits_default_username_for_local_connections(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    assert (
+        create_redis_url(_args(host="localhost", port=6379)) == "redis://localhost:6379"
+    )
+
+
+def test_create_redis_url_supports_password_only_auth(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    assert (
+        create_redis_url(_args(host="cache.local", password="secret"))
+        == "redis://:secret@cache.local:6379"
+    )

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -49,6 +49,12 @@ def test_parser_leaves_connection_options_unset_by_default(parse_args):
             id="ssl-with-auth",
         ),
         pytest.param(
+            ["--ssl"],
+            "redis://production-host:6380/0",
+            "rediss://production-host:6380/0",
+            id="ssl-modifies-environment-url",
+        ),
+        pytest.param(
             ["--host=cache.local", "-a", "secret"],
             None,
             "redis://:secret@cache.local:6379",

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,6 +1,6 @@
-from argparse import Namespace
+from argparse import ArgumentParser, Namespace
 
-from redisvl.cli.utils import create_redis_url
+from redisvl.cli.utils import add_index_parsing_options, create_redis_url
 
 
 def _args(**overrides) -> Namespace:
@@ -17,6 +17,7 @@ def _args(**overrides) -> Namespace:
 
 
 def test_create_redis_url_prefers_explicit_url(monkeypatch):
+    """Use the explicit Redis URL before any other connection source."""
     monkeypatch.setenv("REDIS_URL", "redis://env:6379")
 
     assert (
@@ -25,6 +26,7 @@ def test_create_redis_url_prefers_explicit_url(monkeypatch):
 
 
 def test_create_redis_url_prefers_explicit_connection_flags_over_env(monkeypatch):
+    """Use explicit host and port flags before the REDIS_URL environment variable."""
     monkeypatch.setenv("REDIS_URL", "redis://env:6379")
 
     assert (
@@ -34,18 +36,21 @@ def test_create_redis_url_prefers_explicit_connection_flags_over_env(monkeypatch
 
 
 def test_create_redis_url_uses_env_when_no_cli_connection_options(monkeypatch):
+    """Use REDIS_URL when no explicit CLI connection options are provided."""
     monkeypatch.setenv("REDIS_URL", "redis://env:6379")
 
     assert create_redis_url(_args()) == "redis://env:6379"
 
 
 def test_create_redis_url_falls_back_to_local_default(monkeypatch):
+    """Fall back to the local Redis default when no other connection source is set."""
     monkeypatch.delenv("REDIS_URL", raising=False)
 
     assert create_redis_url(_args()) == "redis://localhost:6379"
 
 
 def test_create_redis_url_builds_ssl_url_without_double_scheme(monkeypatch):
+    """Build a valid rediss URL when SSL is enabled."""
     monkeypatch.delenv("REDIS_URL", raising=False)
 
     assert (
@@ -63,6 +68,7 @@ def test_create_redis_url_builds_ssl_url_without_double_scheme(monkeypatch):
 
 
 def test_create_redis_url_omits_default_username_for_local_connections(monkeypatch):
+    """Omit implicit auth when building the default local Redis URL."""
     monkeypatch.delenv("REDIS_URL", raising=False)
 
     assert (
@@ -71,9 +77,22 @@ def test_create_redis_url_omits_default_username_for_local_connections(monkeypat
 
 
 def test_create_redis_url_supports_password_only_auth(monkeypatch):
+    """Allow password-only Redis auth without injecting a username."""
     monkeypatch.delenv("REDIS_URL", raising=False)
 
     assert (
         create_redis_url(_args(host="cache.local", password="secret"))
         == "redis://:secret@cache.local:6379"
     )
+
+
+def test_parser_defaults_do_not_override_env(monkeypatch):
+    """Preserve parser defaults without letting them outrank REDIS_URL."""
+    parser = add_index_parsing_options(ArgumentParser())
+    monkeypatch.setenv("REDIS_URL", "redis://env:6379")
+
+    args = parser.parse_args([])
+
+    assert args.host == "localhost"
+    assert args.port == 6379
+    assert create_redis_url(args) == "redis://env:6379"

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -50,12 +50,59 @@ def test_search_index_from_existing_prefers_provided_client():
             "search-index",
             redis_client=provided_client,
             redis_url="redis://should-not-be-used:6379",
+            lib_name="search-index-lib",
         )
 
-    mock_validate.assert_called_once_with(provided_client)
+    mock_validate.assert_called_once_with(provided_client, "search-index-lib")
     mock_get_connection.assert_not_called()
     mock_info.assert_called_once_with("search-index", provided_client)
     assert index.client is provided_client
+
+
+def test_search_index_from_existing_owns_factory_created_client():
+    """Reuse a single sync client created internally from redis_url."""
+    created_client = MagicMock()
+
+    with (
+        patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+            return_value=created_client,
+        ) as mock_get_connection,
+        patch.object(SearchIndex, "_info", return_value={}) as mock_info,
+        patch(
+            "redisvl.index.index.convert_index_info_to_schema",
+            return_value=_schema_dict("search-index"),
+        ),
+    ):
+        index = SearchIndex.from_existing(
+            "search-index",
+            redis_url="redis://localhost:6380",
+            connection_kwargs={"decode_responses": True},
+            socket_timeout=5.0,
+            lib_name="search-index-lib",
+        )
+
+    mock_get_connection.assert_called_once_with(
+        redis_url="redis://localhost:6380",
+        decode_responses=True,
+        socket_timeout=5.0,
+        lib_name="search-index-lib",
+    )
+    mock_info.assert_called_once_with("search-index", created_client)
+    created_client.close.assert_not_called()
+    assert index.client is created_client
+    assert index._owns_redis_client is True
+    assert index._redis_url == "redis://localhost:6380"
+    assert index._connection_kwargs == {
+        "decode_responses": True,
+        "socket_timeout": 5.0,
+    }
+    assert index._lib_name == "search-index-lib"
+    assert index._validated_client is True
+
+    index.disconnect()
+
+    created_client.close.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -84,12 +131,62 @@ async def test_async_search_index_from_existing_prefers_provided_client():
             "async-search-index",
             redis_client=provided_client,
             redis_url="redis://should-not-be-used:6379",
+            lib_name="async-search-index-lib",
         )
 
-    mock_validate.assert_awaited_once_with(provided_client)
+    mock_validate.assert_awaited_once_with(provided_client, "async-search-index-lib")
     mock_get_connection.assert_not_awaited()
     mock_info.assert_awaited_once_with("async-search-index", provided_client)
     assert index.client is provided_client
+
+
+@pytest.mark.asyncio
+async def test_async_search_index_from_existing_owns_factory_created_client():
+    """Reuse a single async client created internally from redis_url."""
+    created_client = AsyncMock()
+
+    with (
+        patch(
+            "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+            new=AsyncMock(return_value=created_client),
+        ) as mock_get_connection,
+        patch.object(
+            AsyncSearchIndex, "_info", new=AsyncMock(return_value={})
+        ) as mock_info,
+        patch(
+            "redisvl.index.index.convert_index_info_to_schema",
+            return_value=_schema_dict("async-search-index"),
+        ),
+    ):
+        index = await AsyncSearchIndex.from_existing(
+            "async-search-index",
+            redis_url="redis://localhost:6380",
+            connection_kwargs={"decode_responses": True},
+            socket_timeout=5.0,
+            lib_name="async-search-index-lib",
+        )
+
+    mock_get_connection.assert_awaited_once_with(
+        redis_url="redis://localhost:6380",
+        decode_responses=True,
+        socket_timeout=5.0,
+        lib_name="async-search-index-lib",
+    )
+    mock_info.assert_awaited_once_with("async-search-index", created_client)
+    created_client.aclose.assert_not_awaited()
+    assert index.client is created_client
+    assert index._owns_redis_client is True
+    assert index._redis_url == "redis://localhost:6380"
+    assert index._connection_kwargs == {
+        "decode_responses": True,
+        "socket_timeout": 5.0,
+    }
+    assert index._lib_name == "async-search-index-lib"
+    assert index._validated_client is True
+
+    await index.disconnect()
+
+    created_client.aclose.assert_awaited_once_with()
 
 
 def test_semantic_router_from_existing_prefers_provided_client():
@@ -124,12 +221,63 @@ def test_semantic_router_from_existing_prefers_provided_client():
             redis_url="redis://should-not-be-used:6379",
         )
 
-    mock_validate.assert_called_once_with(provided_client)
+    mock_validate.assert_called_once_with(provided_client, None)
     mock_get_connection.assert_not_called()
     provided_client.json.return_value.get.assert_called_once_with("router:route_config")
     assert mock_from_dict.call_args.args[0] == router_dict
     assert mock_from_dict.call_args.kwargs["redis_url"] is None
     assert mock_from_dict.call_args.kwargs["redis_client"] is provided_client
+    assert result is loaded_router
+
+
+def test_semantic_router_from_existing_rebuilds_from_redis_url():
+    """Reuse a single Redis client when loading a router from redis_url."""
+    created_client = MagicMock()
+    router_dict = {
+        "name": "router",
+        "routes": [],
+        "vectorizer": {
+            "type": "hf",
+            "model": "sentence-transformers/all-mpnet-base-v2",
+        },
+        "routing_config": {},
+    }
+    created_client.json.return_value.get.return_value = router_dict
+    loaded_router = SimpleNamespace(name="router")
+
+    with (
+        patch(
+            "redisvl.extensions.router.semantic.RedisConnectionFactory.get_redis_connection",
+            return_value=created_client,
+        ) as mock_get_connection,
+        patch.object(
+            SemanticRouter, "from_dict", return_value=loaded_router
+        ) as mock_from_dict,
+    ):
+        result = SemanticRouter.from_existing(
+            "router",
+            redis_url="redis://localhost:6380",
+            connection_kwargs={"decode_responses": True},
+            socket_timeout=5.0,
+        )
+
+    mock_get_connection.assert_called_once_with(
+        redis_url="redis://localhost:6380",
+        decode_responses=True,
+        socket_timeout=5.0,
+    )
+    created_client.close.assert_not_called()
+    assert mock_from_dict.call_args.args[0] == router_dict
+    assert mock_from_dict.call_args.kwargs["redis_url"] == "redis://localhost:6380"
+    assert mock_from_dict.call_args.kwargs["redis_client"] is created_client
+    assert mock_from_dict.call_args.kwargs["connection_kwargs"] == {
+        "decode_responses": True,
+        "socket_timeout": 5.0,
+    }
+    assert mock_from_dict.call_args.kwargs["_index_kwargs"] == {
+        "_client_validated": True,
+        "_owns_redis_client": True,
+    }
     assert result is loaded_router
 
 

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -1,0 +1,195 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redisvl.extensions.cache.embeddings import EmbeddingsCache
+from redisvl.extensions.router.semantic import SemanticRouter
+from redisvl.index import AsyncSearchIndex, SearchIndex
+from redisvl.query.sql import SQLQuery
+
+
+def _schema_dict(name: str = "idx") -> dict:
+    return {
+        "index": {
+            "name": name,
+            "prefix": f"{name}:",
+            "storage_type": "hash",
+        },
+        "fields": [],
+    }
+
+
+def test_search_index_from_existing_prefers_provided_client():
+    provided_client = MagicMock()
+
+    with (
+        patch(
+            "redisvl.index.index.RedisConnectionFactory.validate_sync_redis"
+        ) as mock_validate,
+        patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection"
+        ) as mock_get_connection,
+        patch.object(SearchIndex, "_info", return_value={}) as mock_info,
+        patch(
+            "redisvl.index.index.convert_index_info_to_schema",
+            return_value=_schema_dict("search-index"),
+        ),
+    ):
+        index = SearchIndex.from_existing(
+            "search-index",
+            redis_client=provided_client,
+            redis_url="redis://should-not-be-used:6379",
+        )
+
+    mock_validate.assert_called_once_with(provided_client)
+    mock_get_connection.assert_not_called()
+    mock_info.assert_called_once_with("search-index", provided_client)
+    assert index.client is provided_client
+
+
+@pytest.mark.asyncio
+async def test_async_search_index_from_existing_prefers_provided_client():
+    provided_client = AsyncMock()
+
+    with (
+        patch(
+            "redisvl.index.index.RedisConnectionFactory.validate_async_redis",
+            new=AsyncMock(),
+        ) as mock_validate,
+        patch(
+            "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+            new=AsyncMock(),
+        ) as mock_get_connection,
+        patch.object(
+            AsyncSearchIndex, "_info", new=AsyncMock(return_value={})
+        ) as mock_info,
+        patch(
+            "redisvl.index.index.convert_index_info_to_schema",
+            return_value=_schema_dict("async-search-index"),
+        ),
+    ):
+        index = await AsyncSearchIndex.from_existing(
+            "async-search-index",
+            redis_client=provided_client,
+            redis_url="redis://should-not-be-used:6379",
+        )
+
+    mock_validate.assert_awaited_once_with(provided_client)
+    mock_get_connection.assert_not_awaited()
+    mock_info.assert_awaited_once_with("async-search-index", provided_client)
+    assert index.client is provided_client
+
+
+def test_semantic_router_from_existing_prefers_provided_client():
+    provided_client = MagicMock()
+    router_dict = {
+        "name": "router",
+        "routes": [],
+        "vectorizer": {
+            "type": "hf",
+            "model": "sentence-transformers/all-mpnet-base-v2",
+        },
+        "routing_config": {},
+    }
+    provided_client.json.return_value.get.return_value = router_dict
+    loaded_router = SimpleNamespace(name="router")
+
+    with (
+        patch(
+            "redisvl.extensions.router.semantic.RedisConnectionFactory.validate_sync_redis"
+        ) as mock_validate,
+        patch(
+            "redisvl.extensions.router.semantic.RedisConnectionFactory.get_redis_connection"
+        ) as mock_get_connection,
+        patch.object(
+            SemanticRouter, "from_dict", return_value=loaded_router
+        ) as mock_from_dict,
+    ):
+        result = SemanticRouter.from_existing(
+            "router",
+            redis_client=provided_client,
+            redis_url="redis://should-not-be-used:6379",
+        )
+
+    mock_validate.assert_called_once_with(provided_client)
+    mock_get_connection.assert_not_called()
+    provided_client.json.return_value.get.assert_called_once_with("router:route_config")
+    assert mock_from_dict.call_args.args[0] == router_dict
+    assert mock_from_dict.call_args.kwargs["redis_client"] is provided_client
+    assert result is loaded_router
+
+
+def test_base_cache_sync_client_creation_uses_connection_factory():
+    cache = EmbeddingsCache(redis_url="redis+sentinel://localhost:26379/mymaster")
+    mock_client = MagicMock()
+
+    with patch(
+        "redisvl.extensions.cache.base.RedisConnectionFactory.get_redis_connection",
+        return_value=mock_client,
+    ) as mock_get_connection:
+        client = cache._get_redis_client()
+
+    mock_get_connection.assert_called_once_with(
+        redis_url="redis+sentinel://localhost:26379/mymaster"
+    )
+    assert client is mock_client
+
+
+def test_sql_query_uses_connection_factory_for_redis_url():
+    translated = MagicMock()
+    translated.to_command_string.return_value = "FT.SEARCH idx *"
+    executor = MagicMock()
+    executor._translator.translate.return_value = translated
+    fake_sql_redis_module = SimpleNamespace(
+        create_executor=MagicMock(return_value=executor)
+    )
+    mock_client = MagicMock()
+
+    with (
+        patch.dict("sys.modules", {"sql_redis": fake_sql_redis_module}),
+        patch(
+            "redisvl.query.sql.RedisConnectionFactory.get_redis_connection",
+            return_value=mock_client,
+        ) as mock_get_connection,
+    ):
+        command = SQLQuery("SELECT * FROM idx").redis_query_string(
+            redis_url="redis://localhost:6379?cluster=true"
+        )
+
+    mock_get_connection.assert_called_once_with(
+        redis_url="redis://localhost:6379?cluster=true"
+    )
+    fake_sql_redis_module.create_executor.assert_called_once_with(
+        mock_client,
+        schema_cache_strategy="lazy",
+    )
+    assert command == "FT.SEARCH idx *"
+
+
+def test_sql_query_does_not_create_new_connection_when_client_provided():
+    translated = MagicMock()
+    translated.to_command_string.return_value = "FT.SEARCH idx *"
+    executor = MagicMock()
+    executor._translator.translate.return_value = translated
+    fake_sql_redis_module = SimpleNamespace(
+        create_executor=MagicMock(return_value=executor)
+    )
+    provided_client = MagicMock()
+
+    with (
+        patch.dict("sys.modules", {"sql_redis": fake_sql_redis_module}),
+        patch(
+            "redisvl.query.sql.RedisConnectionFactory.get_redis_connection"
+        ) as mock_get_connection,
+    ):
+        command = SQLQuery("SELECT * FROM idx").redis_query_string(
+            redis_client=provided_client
+        )
+
+    mock_get_connection.assert_not_called()
+    fake_sql_redis_module.create_executor.assert_called_once_with(
+        provided_client,
+        schema_cache_strategy="lazy",
+    )
+    assert command == "FT.SEARCH idx *"

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -20,6 +20,15 @@ def _schema_dict(name: str = "idx") -> dict:
     }
 
 
+def _fake_sql_redis_module(command: str = "FT.SEARCH idx *"):
+    translated = MagicMock()
+    translated.to_command_string.return_value = command
+    executor = MagicMock()
+    executor._translator.translate.return_value = translated
+    module = SimpleNamespace(create_executor=MagicMock(return_value=executor))
+    return module
+
+
 def test_search_index_from_existing_prefers_provided_client():
     provided_client = MagicMock()
 
@@ -138,13 +147,7 @@ def test_base_cache_sync_client_creation_uses_connection_factory():
 
 
 def test_sql_query_uses_connection_factory_for_redis_url():
-    translated = MagicMock()
-    translated.to_command_string.return_value = "FT.SEARCH idx *"
-    executor = MagicMock()
-    executor._translator.translate.return_value = translated
-    fake_sql_redis_module = SimpleNamespace(
-        create_executor=MagicMock(return_value=executor)
-    )
+    fake_sql_redis_module = _fake_sql_redis_module()
     mock_client = MagicMock()
 
     with (
@@ -169,13 +172,7 @@ def test_sql_query_uses_connection_factory_for_redis_url():
 
 
 def test_sql_query_does_not_create_new_connection_when_client_provided():
-    translated = MagicMock()
-    translated.to_command_string.return_value = "FT.SEARCH idx *"
-    executor = MagicMock()
-    executor._translator.translate.return_value = translated
-    fake_sql_redis_module = SimpleNamespace(
-        create_executor=MagicMock(return_value=executor)
-    )
+    fake_sql_redis_module = _fake_sql_redis_module()
     provided_client = MagicMock()
 
     with (

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -30,6 +30,7 @@ def _fake_sql_redis_module(command: str = "FT.SEARCH idx *"):
 
 
 def test_search_index_from_existing_prefers_provided_client():
+    """Use the provided sync Redis client instead of constructing a new one."""
     provided_client = MagicMock()
 
     with (
@@ -59,6 +60,7 @@ def test_search_index_from_existing_prefers_provided_client():
 
 @pytest.mark.asyncio
 async def test_async_search_index_from_existing_prefers_provided_client():
+    """Use the provided async Redis client instead of constructing a new one."""
     provided_client = AsyncMock()
 
     with (
@@ -91,6 +93,7 @@ async def test_async_search_index_from_existing_prefers_provided_client():
 
 
 def test_semantic_router_from_existing_prefers_provided_client():
+    """Reuse the provided Redis client when loading a semantic router."""
     provided_client = MagicMock()
     router_dict = {
         "name": "router",
@@ -131,6 +134,7 @@ def test_semantic_router_from_existing_prefers_provided_client():
 
 
 def test_base_cache_sync_client_creation_uses_connection_factory():
+    """Create cache Redis clients through the shared connection factory."""
     cache = EmbeddingsCache(redis_url="redis+sentinel://localhost:26379/mymaster")
     mock_client = MagicMock()
 
@@ -147,6 +151,7 @@ def test_base_cache_sync_client_creation_uses_connection_factory():
 
 
 def test_sql_query_uses_connection_factory_for_redis_url():
+    """Build SQL query helper connections through the shared connection factory."""
     fake_sql_redis_module = _fake_sql_redis_module()
     mock_client = MagicMock()
 
@@ -172,6 +177,7 @@ def test_sql_query_uses_connection_factory_for_redis_url():
 
 
 def test_sql_query_does_not_create_new_connection_when_client_provided():
+    """Reuse a provided SQL query client instead of creating a new connection."""
     fake_sql_redis_module = _fake_sql_redis_module()
     provided_client = MagicMock()
 

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -231,7 +231,7 @@ def test_semantic_router_from_existing_prefers_provided_client():
 
 
 def test_semantic_router_from_existing_rebuilds_from_redis_url():
-    """Reuse a single Redis client when loading a router from redis_url."""
+    """Keep internal kwargs out of the connection factory when loading a router."""
     created_client = MagicMock()
     router_dict = {
         "name": "router",
@@ -259,6 +259,7 @@ def test_semantic_router_from_existing_rebuilds_from_redis_url():
             redis_url="redis://localhost:6380",
             connection_kwargs={"decode_responses": True},
             socket_timeout=5.0,
+            _internal_flag=True,
         )
 
     mock_get_connection.assert_called_once_with(
@@ -275,6 +276,7 @@ def test_semantic_router_from_existing_rebuilds_from_redis_url():
         "socket_timeout": 5.0,
     }
     assert mock_from_dict.call_args.kwargs["_index_kwargs"] == {
+        "_internal_flag": True,
         "_client_validated": True,
         "_owns_redis_client": True,
     }

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -116,6 +116,7 @@ def test_semantic_router_from_existing_prefers_provided_client():
     mock_get_connection.assert_not_called()
     provided_client.json.return_value.get.assert_called_once_with("router:route_config")
     assert mock_from_dict.call_args.args[0] == router_dict
+    assert mock_from_dict.call_args.kwargs["redis_url"] is None
     assert mock_from_dict.call_args.kwargs["redis_client"] is provided_client
     assert result is loaded_router
 

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -176,11 +176,11 @@ class TestCrossSlotErrorHandling:
 
 
 class TestConnectionKwargsValidation:
-    """Test improved connection_kwargs validation in BaseCache."""
+    """Test BaseCache behavior for valid and invalid connection kwargs."""
 
     @pytest.mark.asyncio
     async def test_connection_kwargs_type_error(self):
-        """Test that invalid connection_kwargs type raises TypeError with helpful message."""
+        """Raise TypeError when invalid connection_kwargs reach the client factory."""
         cache = BaseCache(
             name="test_cache",
             connection_kwargs="not_a_dict",  # type: ignore
@@ -190,9 +190,7 @@ class TestConnectionKwargsValidation:
             await cache._get_async_redis_client()
 
         error_msg = str(exc_info.value)
-        assert "Expected `connection_kwargs` to be a dictionary" in error_msg
-        assert "{'decode_responses': True}" in error_msg
-        assert "got type: str" in error_msg
+        assert "argument after ** must be a mapping" in error_msg
 
     @pytest.mark.asyncio
     async def test_connection_kwargs_valid_dict(self):


### PR DESCRIPTION
# Summary

This PR makes Redis connection behavior more consistent across the SDK and CLI. It fixes cases where different surfaces created Redis clients differently, dropped connection kwargs, or treated internally-created clients as externally owned.

On the SDK side, `from_existing()` paths for `SearchIndex`, `AsyncSearchIndex`, and `SemanticRouter` now consistently prefer a caller-provided client, preserve normalized connection kwargs, and correctly mark internally-created clients as owned so disconnect behavior works as expected. The shared kwargs splitting used by these entry points is now centralized in `redisvl/redis/connection.py` so internal _-prefixed kwargs do not leak into Redis
client construction.

This PR also routes more connection creation through `RedisConnectionFactory` instead of ad hoc client creation. That includes cache and SQL helper paths, and it fixes several extension surfaces that were passing connection kwargs incorrectly into SearchIndex.

On the CLI side, Redis URL resolution is simplified and made more predictable. The helper now cleanly resolves between explicit `--url`, explicit connection flags, `REDIS_URL`, and the local default, while also avoiding malformed URL assembly and accidental empty-auth behavior. The CLI entrypoints were simplified accordingly.

The net effect is a smaller and more uniform connection model: explicit clients are respected, factory-based connection behavior is reused across surfaces, reconnect/disconnect semantics are correct, and the CLI no longer has several connection-resolution edge cases that previously produced the wrong URL.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection creation/ownership paths across `SearchIndex`, caches, routers, and CLI URL parsing; behavior changes could affect how clients are constructed and when connections are closed.
> 
> **Overview**
> **Normalizes Redis connection behavior across the SDK and CLI.** CLI commands now resolve Redis endpoints deterministically (explicit `--url` > explicit flags > `REDIS_URL` > localhost defaults), properly URL-encode auth, and only override env URLs with SSL via scheme rewriting.
> 
> **Unifies client creation and ownership semantics.** `SearchIndex.from_existing`/`AsyncSearchIndex.from_existing` and `SemanticRouter.from_existing` now prefer caller-provided clients, split/forward only connection kwargs to `RedisConnectionFactory`, track whether internally-created clients are owned (so `disconnect()` closes them), and ensure temporary clients are closed on load failures. Several extensions (`SemanticCache`, message histories, router init) now pass `connection_kwargs` explicitly (instead of splatting), and SQL query helper/client creation is routed through `RedisConnectionFactory`.
> 
> Adds unit tests covering CLI URL precedence/encoding and connection normalization (client preference, kwargs forwarding, and ownership/cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 517d281df676a432e008f9b1aa4e0aa328ee4700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->