### PR TITLE
chore(release): bump version to 0.17.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "redisvl"
 # NOTE: This version value is automatically incremented by the release workflow - do not manually adjust it.
-version = "0.17.0"
+version = "0.17.1"
 description = "Python client library and CLI for using Redis as a vector database"
 authors = [{ name = "Redis Inc.", email = "applied.ai@redis.com" }]
 requires-python = ">=3.9.2,<3.15"


### PR DESCRIPTION
Bump pyproject.toml version from 0.17.0 to 0.17.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version in `pyproject.toml` with no functional or runtime behavior changes.
> 
> **Overview**
> **Release housekeeping:** updates `pyproject.toml` to bump the `redisvl` project version from `0.17.0` to `0.17.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b62bf9d09bb238b52c1ba6555bb19cd9855149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->