### PR TITLE
Remove empty cell from 11_advanced_queries.ipynb

### DIFF
--- a/docs/user_guide/11_advanced_queries.ipynb
+++ b/docs/user_guide/11_advanced_queries.ipynb
@@ -1282,13 +1282,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Reciprocal Rank Fusion (RRF)\n",
     "\n",
     "In addition to combining scores using a linear combination, `HybridQuery` also supports reciprocal rank fusion (RRF) for combining scores. This method is useful when you want to combine scores giving more weight to the top results from each query.\n",


### PR DESCRIPTION
This empty cell breaks the redisvl automation that generates the markdown documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that only deletes a stray notebook cell and does not affect library/runtime behavior.
> 
> **Overview**
> Removes a stray empty markdown cell (containing only `##`) from `docs/user_guide/11_advanced_queries.ipynb`, preventing the notebook-to-markdown documentation automation from breaking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0be9c9b67562b75b544346aa8690d0e71b1cb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->