### PR TITLE
refactor(python): drop Python 3.9 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Only lint on the minimum supported Python version and a representative
-        # set of newer releases. Lint issues that differ by minor version are
-        # extremely unlikely to appear only on an untested intermediate version.
-        #
-        # GitHub rate-limits how many jobs can be running at any one time.
-        # Starting new jobs is also relatively slow,
-        # so linting on fewer versions makes CI faster.
         python-version:
           - "3.10"
           - "3.11"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,19 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Only lint on the min and max supported Python versions.
-        # It's extremely unlikely that there's a lint issue on any version in between
-        # that doesn't show up on the min or max versions.
+        # Only lint on the minimum supported Python version and a representative
+        # set of newer releases. Lint issues that differ by minor version are
+        # extremely unlikely to appear only on an untested intermediate version.
         #
         # GitHub rate-limits how many jobs can be running at any one time.
         # Starting new jobs is also relatively slow,
         # so linting on fewer versions makes CI faster.
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
     - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         redis-py-version: ["5.x", "6.x", "7.x"]
         redis-image: ["redis:8.2", "redis:8.4", "redis:latest"]
     steps:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Perfect for building **RAG pipelines** with real-time retrieval, **AI agents** w
 
 ## Installation
 
-Install `redisvl` into your Python (>=3.9) environment using `pip`:
+Install `redisvl` into your Python (>=3.10) environment using `pip`:
 
 ```bash
 pip install redisvl
@@ -57,7 +57,7 @@ Install the MCP server extra when you want to expose an existing Redis index thr
 pip install redisvl[mcp]
 ```
 
-The `redisvl[mcp]` extra requires Python 3.10 or newer.
+The `redisvl[mcp]` extra requires Python 3.10 or newer, matching the package minimum.
 
 > For more detailed instructions, visit the [installation guide](https://docs.redisvl.com/en/latest/user_guide/installation.html).
 > For MCP concepts and setup, see the [RedisVL MCP docs](https://docs.redisvl.com/en/latest/concepts/mcp.html) and the [MCP how-to guide](https://docs.redisvl.com/en/latest/user_guide/how_to_guides/mcp.html).

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ Install the MCP server extra when you want to expose an existing Redis index thr
 pip install redisvl[mcp]
 ```
 
-The `redisvl[mcp]` extra requires Python 3.10 or newer, matching the package minimum.
-
 > For more detailed instructions, visit the [installation guide](https://docs.redisvl.com/en/latest/user_guide/installation.html).
 > For MCP concepts and setup, see the [RedisVL MCP docs](https://docs.redisvl.com/en/latest/concepts/mcp.html) and the [MCP how-to guide](https://docs.redisvl.com/en/latest/user_guide/how_to_guides/mcp.html).
 

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -9,7 +9,7 @@ It currently exists for maintainers of the pydata-sphinx-theme, but might be
 abstracted into a standalone package if it proves useful.
 """
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -54,7 +54,7 @@ class GalleryDirective(SphinxDirective):
         "class-card": directives.unchanged,
     }
 
-    def run(self) -> List[nodes.Node]:
+    def run(self) -> list[nodes.Node]:
         if self.arguments:
             # If an argument is given, assume it's a path to a YAML file
             # Parse it and load it into the directive content
@@ -145,7 +145,7 @@ class GalleryDirective(SphinxDirective):
         return [container]
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, Any]:
     """Add custom configuration to sphinx app.
 
     Args:

--- a/docs/user_guide/13_langcache_semantic_cache.ipynb
+++ b/docs/user_guide/13_langcache_semantic_cache.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "Before you begin, ensure you have:\n",
     "- Installed RedisVL with the LangCache extra: `pip install redisvl[langcache]`\n",
-    "- Python 3.9+ (same as RedisVL)\n",
+    "- Python 3.10+ (same as RedisVL)\n",
     "- A LangCache service with a **cache ID** and **API key**. You can set up a LangCache service in Redis Cloud [here](https://cloud.redis.io/#/)\n",
     "- Optionally: **attributes** configured on your LangCache cache if you plan to pass `metadata` / `attributes` from RedisVL\n",
     "\n",

--- a/docs/user_guide/how_to_guides/mcp.md
+++ b/docs/user_guide/how_to_guides/mcp.md
@@ -436,10 +436,6 @@ pip install redisvl[mcp]
 
 If the configured vectorizer needs a provider SDK, install that provider extra too.
 
-### Unsupported Python Runtime
-
-RedisVL MCP requires Python 3.10 or newer. Use a compatible interpreter for the MCP server process.
-
 ### Configured Redis Index Does Not Exist
 
 The server only binds to an existing index. Create the index first, then point `indexes.<id>.redis_name` at that index name.

--- a/docs/user_guide/how_to_guides/mcp.md
+++ b/docs/user_guide/how_to_guides/mcp.md
@@ -438,7 +438,7 @@ If the configured vectorizer needs a provider SDK, install that provider extra t
 
 ### Unsupported Python Runtime
 
-RedisVL MCP requires Python 3.10 or newer even though the core package supports Python 3.9. Use a newer interpreter for the MCP server process.
+RedisVL MCP requires Python 3.10 or newer. Use a compatible interpreter for the MCP server process.
 
 ### Configured Redis Index Does Not Exist
 

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -54,10 +54,6 @@ To install **all** optional dependencies at once:
 $ pip install redisvl[all]
 ```
 
-```{note}
-The core RedisVL package and the `redisvl[mcp]` extra both require Python 3.10 or newer.
-```
-
 ## Install RedisVL from Source
 
 To install RedisVL from source, clone the repository and install the package using `pip`:

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -11,7 +11,7 @@ There are a few ways to install RedisVL. The easiest way is to use pip.
 
 ## Install RedisVL with Pip
 
-Install `redisvl` into your Python (>=3.9) environment using `pip`:
+Install `redisvl` into your Python (>=3.10) environment using `pip`:
 
 ```bash
 $ pip install -U redisvl
@@ -55,7 +55,7 @@ $ pip install redisvl[all]
 ```
 
 ```{note}
-The core RedisVL package supports Python 3.9+, but the `redisvl[mcp]` extra requires Python 3.10 or newer because the MCP server depends on `fastmcp`.
+The core RedisVL package and the `redisvl[mcp]` extra both require Python 3.10 or newer.
 ```
 
 ## Install RedisVL from Source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "redisvl"
 version = "0.17.1"
 description = "Python client library and CLI for using Redis as a vector database"
 authors = [{ name = "Redis Inc.", email = "applied.ai@redis.com" }]
-requires-python = ">=3.9.2,<3.15"
+requires-python = ">=3.10,<3.15"
 readme = "README.md"
 license = "MIT"
 keywords = [
@@ -15,7 +15,6 @@ keywords = [
     "vector-search",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -36,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = [
-    "fastmcp>=2.0.0 ; python_version >= '3.10'",
+    "fastmcp>=2.0.0",
     "pydantic-settings>=2.0",
 ]
 mistralai = ["mistralai>=1.0.0"]
@@ -102,7 +101,7 @@ dev = [
     "types-pyyaml",
     "types-pyopenssl",
     "testcontainers>=4.3.1,<5",
-    "cryptography>=44.0.1 ; python_version > '3.9.1'",
+    "cryptography>=44.0.1",
     "codespell>=2.4.1,<3",
     "langcache>=0.9.0",
 ]
@@ -124,7 +123,7 @@ default-groups = [
 ]
 
 [tool.black]
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 exclude = '''
 (
   | \.egg

--- a/redisvl/cli/mcp.py
+++ b/redisvl/cli/mcp.py
@@ -73,7 +73,6 @@ class MCP:
     def _run(self, args):
         """Validate the environment, build the server, and serve stdio requests."""
         try:
-            self._ensure_supported_python()
             settings_cls, server_cls = self._load_mcp_components()
             settings = settings_cls.from_env(
                 config=args.config,
@@ -93,20 +92,6 @@ class MCP:
         except Exception as exc:
             self._print_error(str(exc))
             raise SystemExit(1)
-
-    @staticmethod
-    def _ensure_supported_python():
-        """Fail fast when the current interpreter cannot support MCP extras."""
-        if sys.version_info < (3, 10):
-            version = "%s.%s.%s" % (
-                sys.version_info.major,
-                sys.version_info.minor,
-                sys.version_info.micro,
-            )
-            raise RuntimeError(
-                "RedisVL MCP CLI requires Python 3.10 or newer. "
-                "Current runtime is Python %s." % version
-            )
 
     @staticmethod
     def _load_mcp_components():

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,6 +1,5 @@
 import os
 from argparse import ArgumentParser, Namespace
-from typing import Optional
 from urllib.parse import quote, urlparse, urlunparse
 
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
@@ -22,7 +21,7 @@ def _has_explicit_connection_options(args: Namespace) -> bool:
     )
 
 
-def _get_auth_credentials(args: Namespace) -> tuple[Optional[str], Optional[str]]:
+def _get_auth_credentials(args: Namespace) -> tuple[str | None, str | None]:
     return getattr(args, "user", None) or None, getattr(args, "password", None) or None
 
 

--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -5,7 +5,7 @@ specific cache types such as LLM caches and embedding caches.
 """
 
 from collections.abc import Mapping
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 from redis import Redis  # For backwards compatibility in type checking
 from redis.cluster import RedisCluster
@@ -21,17 +21,17 @@ class BaseCache:
     including TTL management, connection handling, and basic cache operations.
     """
 
-    _redis_client: Optional[SyncRedisClient]
-    _async_redis_client: Optional[AsyncRedisClient]
+    _redis_client: SyncRedisClient | None
+    _async_redis_client: AsyncRedisClient | None
 
     def __init__(
         self,
         name: str,
-        ttl: Optional[int] = None,
-        redis_client: Optional[SyncRedisClient] = None,
-        async_redis_client: Optional[AsyncRedisClient] = None,
+        ttl: int | None = None,
+        redis_client: SyncRedisClient | None = None,
+        async_redis_client: AsyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: Dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] = {},
     ):
         """Initialize a base cache.
 
@@ -46,7 +46,7 @@ class BaseCache:
                 for the redis client. Defaults to empty {}.
         """
         self.name = name
-        self._ttl: Optional[int] = None
+        self._ttl: int | None = None
         self.set_ttl(ttl)
 
         self.redis_kwargs = {
@@ -84,11 +84,11 @@ class BaseCache:
         return f"{self._get_prefix()}{entry_id}"
 
     @property
-    def ttl(self) -> Optional[int]:
+    def ttl(self) -> int | None:
         """The default TTL, in seconds, for entries in the cache."""
         return self._ttl
 
-    def set_ttl(self, ttl: Optional[int] = None) -> None:
+    def set_ttl(self, ttl: int | None = None) -> None:
         """Set the default TTL, in seconds, for entries in the cache.
 
         Args:
@@ -113,8 +113,8 @@ class BaseCache:
         """
         if self._redis_client is None:
             # Create new Redis client
-            url = cast(Optional[str], self.redis_kwargs["redis_url"])
-            kwargs = cast(Dict[str, Any], self.redis_kwargs["connection_kwargs"])
+            url = cast(str | None, self.redis_kwargs["redis_url"])
+            kwargs = cast(dict[str, Any], self.redis_kwargs["connection_kwargs"])
             self._redis_client = RedisConnectionFactory.get_redis_connection(
                 redis_url=url,
                 **kwargs,
@@ -135,8 +135,8 @@ class BaseCache:
                     client
                 )
             else:
-                url = cast(Optional[str], self.redis_kwargs["redis_url"])
-                kwargs = cast(Dict[str, Any], self.redis_kwargs["connection_kwargs"])
+                url = cast(str | None, self.redis_kwargs["redis_url"])
+                kwargs = cast(dict[str, Any], self.redis_kwargs["connection_kwargs"])
                 self._async_redis_client = (
                     RedisConnectionFactory.get_async_redis_connection(
                         redis_url=url, **kwargs
@@ -144,7 +144,7 @@ class BaseCache:
                 )
         return self._async_redis_client
 
-    def expire(self, key: str, ttl: Optional[int] = None) -> None:
+    def expire(self, key: str, ttl: int | None = None) -> None:
         """Set or refresh the expiration time for a key in the cache.
 
         Args:
@@ -162,7 +162,7 @@ class BaseCache:
             client = self._get_redis_client()
             client.expire(key, _ttl)
 
-    async def aexpire(self, key: str, ttl: Optional[int] = None) -> None:
+    async def aexpire(self, key: str, ttl: int | None = None) -> None:
         """Asynchronously set or refresh the expiration time for a key in the cache.
 
         Args:

--- a/redisvl/extensions/cache/embeddings/embeddings.py
+++ b/redisvl/extensions/cache/embeddings/embeddings.py
@@ -1,6 +1,6 @@
 """Embeddings cache implementation for RedisVL."""
 
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable
 
 from redisvl.extensions.cache.base import BaseCache
 from redisvl.extensions.cache.embeddings.schema import CacheEntry
@@ -19,11 +19,11 @@ class EmbeddingsCache(BaseCache):
     def __init__(
         self,
         name: str = "embedcache",
-        ttl: Optional[int] = None,
-        redis_client: Optional[SyncRedisClient] = None,
-        async_redis_client: Optional[AsyncRedisClient] = None,
+        ttl: int | None = None,
+        redis_client: SyncRedisClient | None = None,
+        async_redis_client: AsyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: Dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] = {},
     ):
         """Initialize an embeddings cache.
 
@@ -54,7 +54,7 @@ class EmbeddingsCache(BaseCache):
             connection_kwargs=connection_kwargs,
         )
 
-    def _make_entry_id(self, content: Union[bytes, str], model_name: str) -> str:
+    def _make_entry_id(self, content: bytes | str, model_name: str) -> str:
         """Generate a deterministic entry ID for the given content and model name.
 
         Args:
@@ -68,7 +68,7 @@ class EmbeddingsCache(BaseCache):
             content = content.hex()
         return hashify(f"{content}:{model_name}")
 
-    def _make_cache_key(self, content: Union[bytes, str], model_name: str) -> str:
+    def _make_cache_key(self, content: bytes | str, model_name: str) -> str:
         """Generate a full Redis key for the given content and model name.
 
         Args:
@@ -83,11 +83,11 @@ class EmbeddingsCache(BaseCache):
 
     def _prepare_entry_data(
         self,
-        content: Union[bytes, str],
+        content: bytes | str,
         model_name: str,
-        embedding: List[float],
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[str, Dict[str, Any]]:
+        embedding: list[float],
+        metadata: dict[str, Any] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
         """Prepare data for storage in Redis
 
         Args:
@@ -111,9 +111,7 @@ class EmbeddingsCache(BaseCache):
         )
         return key, entry.to_dict()
 
-    def _process_cache_data(
-        self, data: Optional[Dict[str, Any]]
-    ) -> Optional[Dict[str, Any]]:
+    def _process_cache_data(self, data: dict[str, Any] | None) -> dict[str, Any] | None:
         """Process Redis hash data into a cache entry response.
 
         Args:
@@ -138,9 +136,9 @@ class EmbeddingsCache(BaseCache):
 
     def get(
         self,
-        content: Union[bytes, str],
+        content: bytes | str,
         model_name: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Get embedding by content and model name.
 
         Retrieves a cached embedding for the given content and model name.
@@ -163,7 +161,7 @@ class EmbeddingsCache(BaseCache):
         key = self._make_cache_key(content, model_name)
         return self.get_by_key(key)
 
-    def get_by_key(self, key: str) -> Optional[Dict[str, Any]]:
+    def get_by_key(self, key: str) -> dict[str, Any] | None:
         """Get embedding by its full Redis key.
 
         Retrieves a cached embedding for the given Redis key.
@@ -198,7 +196,7 @@ class EmbeddingsCache(BaseCache):
 
         return self._process_cache_data(data)  # type: ignore
 
-    def mget_by_keys(self, keys: List[str]) -> List[Optional[Dict[str, Any]]]:
+    def mget_by_keys(self, keys: list[str]) -> list[dict[str, Any] | None]:
         """Get multiple embeddings by their Redis keys.
 
         Efficiently retrieves multiple cached embeddings in a single network roundtrip.
@@ -248,8 +246,8 @@ class EmbeddingsCache(BaseCache):
         return processed_results
 
     def mget(
-        self, contents: Iterable[Union[bytes, str]], model_name: str
-    ) -> List[Optional[Dict[str, Any]]]:
+        self, contents: Iterable[bytes | str], model_name: str
+    ) -> list[dict[str, Any] | None]:
         """Get multiple embeddings by their content and model name.
 
         Efficiently retrieves multiple cached embeddings in a single operation.
@@ -281,11 +279,11 @@ class EmbeddingsCache(BaseCache):
 
     def set(
         self,
-        content: Union[bytes, str],
+        content: bytes | str,
         model_name: str,
-        embedding: List[float],
-        metadata: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        embedding: list[float],
+        metadata: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Store an embedding with its content and model name.
 
@@ -332,9 +330,9 @@ class EmbeddingsCache(BaseCache):
 
     def mset(
         self,
-        items: List[Dict[str, Any]],
-        ttl: Optional[int] = None,
-    ) -> List[str]:
+        items: list[dict[str, Any]],
+        ttl: int | None = None,
+    ) -> list[str]:
         """Store multiple embeddings in a batch operation.
 
         Each item in the input list should be a dictionary with the following fields:
@@ -398,7 +396,7 @@ class EmbeddingsCache(BaseCache):
 
         return keys
 
-    def exists(self, content: Union[bytes, str], model_name: str) -> bool:
+    def exists(self, content: bytes | str, model_name: str) -> bool:
         """Check if an embedding exists for the given content and model.
 
         Args:
@@ -434,7 +432,7 @@ class EmbeddingsCache(BaseCache):
         client = self._get_redis_client()
         return bool(client.exists(key))
 
-    def mexists_by_keys(self, keys: List[str]) -> List[bool]:
+    def mexists_by_keys(self, keys: list[str]) -> list[bool]:
         """Check if multiple embeddings exist by their Redis keys.
 
         Efficiently checks existence of multiple keys in a single operation.
@@ -465,9 +463,7 @@ class EmbeddingsCache(BaseCache):
         # Convert to boolean values
         return [bool(result) for result in results]
 
-    def mexists(
-        self, contents: Iterable[Union[bytes, str]], model_name: str
-    ) -> List[bool]:
+    def mexists(self, contents: Iterable[bytes | str], model_name: str) -> list[bool]:
         """Check if multiple embeddings exist by their contents and model name.
 
         Efficiently checks existence of multiple embeddings in a single operation.
@@ -496,7 +492,7 @@ class EmbeddingsCache(BaseCache):
         # Use the key-based batch operation
         return self.mexists_by_keys(keys)
 
-    def drop(self, content: Union[bytes, str], model_name: str) -> None:
+    def drop(self, content: bytes | str, model_name: str) -> None:
         """Remove an embedding from the cache.
 
         Args:
@@ -526,7 +522,7 @@ class EmbeddingsCache(BaseCache):
         client = self._get_redis_client()
         client.delete(key)
 
-    def mdrop_by_keys(self, keys: List[str]) -> None:
+    def mdrop_by_keys(self, keys: list[str]) -> None:
         """Remove multiple embeddings from the cache by their Redis keys.
 
         Efficiently removes multiple embeddings in a single operation.
@@ -549,7 +545,7 @@ class EmbeddingsCache(BaseCache):
                 pipeline.delete(key)
             pipeline.execute()
 
-    def mdrop(self, contents: Iterable[Union[bytes, str]], model_name: str) -> None:
+    def mdrop(self, contents: Iterable[bytes | str], model_name: str) -> None:
         """Remove multiple embeddings from the cache by their contents and model name.
 
         Efficiently removes multiple embeddings in a single operation.
@@ -577,9 +573,9 @@ class EmbeddingsCache(BaseCache):
 
     async def aget(
         self,
-        content: Union[bytes, str],
+        content: bytes | str,
         model_name: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Async get embedding by content and model name.
 
         Asynchronously retrieves a cached embedding for the given content and model name.
@@ -602,7 +598,7 @@ class EmbeddingsCache(BaseCache):
         key = self._make_cache_key(content, model_name)
         return await self.aget_by_key(key)
 
-    async def aget_by_key(self, key: str) -> Optional[Dict[str, Any]]:
+    async def aget_by_key(self, key: str) -> dict[str, Any] | None:
         """Async get embedding by its full Redis key.
 
         Asynchronously retrieves a cached embedding for the given Redis key.
@@ -629,7 +625,7 @@ class EmbeddingsCache(BaseCache):
 
         return self._process_cache_data(data)
 
-    async def amget_by_keys(self, keys: List[str]) -> List[Optional[Dict[str, Any]]]:
+    async def amget_by_keys(self, keys: list[str]) -> list[dict[str, Any] | None]:
         """Async get multiple embeddings by their Redis keys.
 
         Asynchronously retrieves multiple cached embeddings in a single network roundtrip.
@@ -672,8 +668,8 @@ class EmbeddingsCache(BaseCache):
         return processed_results
 
     async def amget(
-        self, contents: Iterable[Union[bytes, str]], model_name: str
-    ) -> List[Optional[Dict[str, Any]]]:
+        self, contents: Iterable[bytes | str], model_name: str
+    ) -> list[dict[str, Any] | None]:
         """Async get multiple embeddings by their contents and model name.
 
         Asynchronously retrieves multiple cached embeddings in a single operation.
@@ -705,11 +701,11 @@ class EmbeddingsCache(BaseCache):
 
     async def aset(
         self,
-        content: Union[bytes, str],
+        content: bytes | str,
         model_name: str,
-        embedding: List[float],
-        metadata: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        embedding: list[float],
+        metadata: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Async store an embedding with its content and model name.
 
@@ -750,9 +746,9 @@ class EmbeddingsCache(BaseCache):
 
     async def amset(
         self,
-        items: List[Dict[str, Any]],
-        ttl: Optional[int] = None,
-    ) -> List[str]:
+        items: list[dict[str, Any]],
+        ttl: int | None = None,
+    ) -> list[str]:
         """Async store multiple embeddings in a batch operation.
 
         Each item in the input list should be a dictionary with the following fields:
@@ -808,7 +804,7 @@ class EmbeddingsCache(BaseCache):
 
         return keys
 
-    async def amexists_by_keys(self, keys: List[str]) -> List[bool]:
+    async def amexists_by_keys(self, keys: list[str]) -> list[bool]:
         """Async check if multiple embeddings exist by their Redis keys.
 
         Asynchronously checks existence of multiple keys in a single operation.
@@ -840,8 +836,8 @@ class EmbeddingsCache(BaseCache):
         return [bool(result) for result in results]
 
     async def amexists(
-        self, contents: Iterable[Union[bytes, str]], model_name: str
-    ) -> List[bool]:
+        self, contents: Iterable[bytes | str], model_name: str
+    ) -> list[bool]:
         """Async check if multiple embeddings exist by their contents and model name.
 
         Asynchronously checks existence of multiple embeddings in a single operation.
@@ -870,7 +866,7 @@ class EmbeddingsCache(BaseCache):
         # Use the key-based batch operation
         return await self.amexists_by_keys(keys)
 
-    async def amdrop_by_keys(self, keys: List[str]) -> None:
+    async def amdrop_by_keys(self, keys: list[str]) -> None:
         """Async remove multiple embeddings from the cache by their Redis keys.
 
         Asynchronously removes multiple embeddings in a single operation.
@@ -889,9 +885,7 @@ class EmbeddingsCache(BaseCache):
         client = await self._get_async_redis_client()
         await client.delete(*keys)
 
-    async def amdrop(
-        self, contents: Iterable[Union[bytes, str]], model_name: str
-    ) -> None:
+    async def amdrop(self, contents: Iterable[bytes | str], model_name: str) -> None:
         """Async remove multiple embeddings from the cache by their contents and model name.
 
         Asynchronously removes multiple embeddings in a single operation.
@@ -917,7 +911,7 @@ class EmbeddingsCache(BaseCache):
         # Use the key-based batch operation
         await self.amdrop_by_keys(keys)
 
-    async def aexists(self, content: Union[bytes, str], model_name: str) -> bool:
+    async def aexists(self, content: bytes | str, model_name: str) -> bool:
         """Async check if an embedding exists.
 
         Asynchronously checks if an embedding exists for the given content and model.
@@ -956,7 +950,7 @@ class EmbeddingsCache(BaseCache):
         client = await self._get_async_redis_client()
         return bool(await client.exists(key))
 
-    async def adrop(self, content: Union[bytes, str], model_name: str) -> None:
+    async def adrop(self, content: bytes | str, model_name: str) -> None:
         """Async remove an embedding from the cache.
 
         Asynchronously removes an embedding from the cache.

--- a/redisvl/extensions/cache/embeddings/schema.py
+++ b/redisvl/extensions/cache/embeddings/schema.py
@@ -4,7 +4,7 @@ This module defines the Pydantic models used for embedding cache entries and
 related data structures.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -19,20 +19,20 @@ class CacheEntry(BaseModel):
 
     entry_id: str
     """Cache entry identifier"""
-    content: Union[bytes, str]
+    content: bytes | str
     """The input that was embedded"""
     model_name: str
     """The name of the embedding model used"""
-    embedding: List[float]
+    embedding: list[float]
     """The embedding vector representation"""
     inserted_at: float = Field(default_factory=current_timestamp)
     """Timestamp of when the entry was added to the cache"""
-    metadata: Optional[Dict[str, Any]] = Field(default=None)
+    metadata: dict[str, Any] | None = Field(default=None)
     """Optional metadata stored on the cache entry"""
 
     @model_validator(mode="before")
     @classmethod
-    def deserialize_cache_entry(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def deserialize_cache_entry(cls, values: dict[str, Any]) -> dict[str, Any]:
         # Deserialize metadata if necessary
         if METADATA_FIELD_NAME in values and isinstance(
             values[METADATA_FIELD_NAME], str
@@ -46,7 +46,7 @@ class CacheEntry(BaseModel):
 
         return values
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert the cache entry to a dictionary for storage"""
         data = self.model_dump(exclude_none=True)
         data[EMBEDDING_FIELD_NAME] = serialize(self.embedding)

--- a/redisvl/extensions/cache/llm/base.py
+++ b/redisvl/extensions/cache/llm/base.py
@@ -4,7 +4,7 @@ This module defines the abstract base interface for LLM caches, which store
 prompt-response pairs with semantic retrieval capabilities.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from redisvl.extensions.cache.base import BaseCache
 from redisvl.query.filter import FilterExpression
@@ -17,7 +17,7 @@ class BaseLLMCache(BaseCache):
     with semantic similarity search capabilities.
     """
 
-    def __init__(self, name: str, ttl: Optional[int] = None, **kwargs):
+    def __init__(self, name: str, ttl: int | None = None, **kwargs):
         """Initialize an LLM cache.
 
         Args:
@@ -37,13 +37,13 @@ class BaseLLMCache(BaseCache):
 
     def check(
         self,
-        prompt: Optional[str] = None,
-        vector: Optional[List[float]] = None,
+        prompt: str | None = None,
+        vector: list[float] | None = None,
         num_results: int = 1,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[FilterExpression] = None,
-        distance_threshold: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        return_fields: list[str] | None = None,
+        filter_expression: FilterExpression | None = None,
+        distance_threshold: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Check the cache for semantically similar prompts.
 
         Args:
@@ -61,13 +61,13 @@ class BaseLLMCache(BaseCache):
 
     async def acheck(
         self,
-        prompt: Optional[str] = None,
-        vector: Optional[List[float]] = None,
+        prompt: str | None = None,
+        vector: list[float] | None = None,
         num_results: int = 1,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[FilterExpression] = None,
-        distance_threshold: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        return_fields: list[str] | None = None,
+        filter_expression: FilterExpression | None = None,
+        distance_threshold: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Async check the cache for semantically similar prompts."""
         raise NotImplementedError
 
@@ -75,10 +75,10 @@ class BaseLLMCache(BaseCache):
         self,
         prompt: str,
         response: str,
-        vector: Optional[List[float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        vector: list[float] | None = None,
+        metadata: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Store a prompt-response pair in the cache.
 
@@ -99,10 +99,10 @@ class BaseLLMCache(BaseCache):
         self,
         prompt: str,
         response: str,
-        vector: Optional[List[float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        vector: list[float] | None = None,
+        metadata: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Async store a prompt-response pair in the cache."""
         raise NotImplementedError

--- a/redisvl/extensions/cache/llm/langcache.py
+++ b/redisvl/extensions/cache/llm/langcache.py
@@ -4,7 +4,7 @@ This module provides an LLM cache implementation that uses the LangCache
 managed service via the langcache Python SDK.
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 from urllib.parse import quote, unquote
 
 from redisvl.extensions.cache.llm.base import BaseLLMCache
@@ -16,7 +16,7 @@ from redisvl.utils.utils import denorm_cosine_distance, norm_cosine_distance
 logger = get_logger(__name__)
 
 
-def _encode_attributes_for_langcache(attributes: Dict[str, Any]) -> Dict[str, Any]:
+def _encode_attributes_for_langcache(attributes: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of *attributes* with string values safely encoded.
 
     Only top-level string values are encoded; non-string values are left
@@ -28,7 +28,7 @@ def _encode_attributes_for_langcache(attributes: Dict[str, Any]) -> Dict[str, An
         return attributes
 
     changed = False
-    safe_attributes: Dict[str, Any] = dict(attributes)
+    safe_attributes: dict[str, Any] = dict(attributes)
     for key, value in attributes.items():
         if isinstance(value, str):
             # Percent-encode all characters (no ``safe`` set) so punctuation and
@@ -42,7 +42,7 @@ def _encode_attributes_for_langcache(attributes: Dict[str, Any]) -> Dict[str, An
     return safe_attributes if changed else attributes
 
 
-def _decode_attributes_from_langcache(attributes: Dict[str, Any]) -> Dict[str, Any]:
+def _decode_attributes_from_langcache(attributes: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of *attributes* with string values safely decoded.
 
     This is the inverse of :func:`_encode_attributes_for_langcache`. Only
@@ -54,7 +54,7 @@ def _decode_attributes_from_langcache(attributes: Dict[str, Any]) -> Dict[str, A
         return attributes
 
     changed = False
-    decoded_attributes: Dict[str, Any] = dict(attributes)
+    decoded_attributes: dict[str, Any] = dict(attributes)
     for key, value in attributes.items():
         if isinstance(value, str):
             decoded = unquote(value)
@@ -100,7 +100,7 @@ class LangCacheSemanticCache(BaseLLMCache):
         server_url: str = "https://aws-us-east-1.langcache.redis.io",
         cache_id: str = "",
         api_key: str = "",
-        ttl: Optional[int] = None,
+        ttl: int | None = None,
         use_exact_search: bool = True,
         use_semantic_search: bool = True,
         distance_scale: Literal["normalized", "redis"] = "normalized",
@@ -177,9 +177,7 @@ class LangCacheSemanticCache(BaseLLMCache):
             api_key=self._api_key,
         )
 
-    def _similarity_threshold(
-        self, distance_threshold: Optional[float]
-    ) -> Optional[float]:
+    def _similarity_threshold(self, distance_threshold: float | None) -> float | None:
         """Convert a distance threshold to a similarity threshold based on scale.
 
         - If distance_scale == "redis": use norm_cosine_distance (0–2 -> 0–1)
@@ -194,9 +192,9 @@ class LangCacheSemanticCache(BaseLLMCache):
     def _build_search_kwargs(
         self,
         prompt: str,
-        similarity_threshold: Optional[float],
-        attributes: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        similarity_threshold: float | None,
+        attributes: dict[str, Any] | None,
+    ) -> dict[str, Any]:
         from langcache.models import SearchStrategy
 
         # Build enum list lazily here instead of during __init__ to avoid
@@ -207,7 +205,7 @@ class LangCacheSemanticCache(BaseLLMCache):
         ]
         # Filter out Nones to avoid sending invalid enum values
         search_strategies = [s for s in search_strategies if s is not None]
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "prompt": prompt,
             "search_strategies": search_strategies,
             "similarity_threshold": similarity_threshold,
@@ -220,9 +218,9 @@ class LangCacheSemanticCache(BaseLLMCache):
 
     def _hits_from_response(
         self, response: Any, num_results: int
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         results = response.data if hasattr(response, "data") else []
-        hits: List[Dict[str, Any]] = []
+        hits: list[dict[str, Any]] = []
         for result in results[:num_results]:
             if hasattr(result, "model_dump"):
                 result_dict = result.model_dump()
@@ -232,7 +230,7 @@ class LangCacheSemanticCache(BaseLLMCache):
             hits.append(hit.to_dict())
         return hits
 
-    def _convert_to_cache_hit(self, result: Dict[str, Any]) -> CacheHit:
+    def _convert_to_cache_hit(self, result: dict[str, Any]) -> CacheHit:
         """Convert a LangCache result to a CacheHit object.
 
         Args:
@@ -268,14 +266,14 @@ class LangCacheSemanticCache(BaseLLMCache):
 
     def check(
         self,
-        prompt: Optional[str] = None,
-        vector: Optional[List[float]] = None,
+        prompt: str | None = None,
+        vector: list[float] | None = None,
         num_results: int = 1,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[FilterExpression] = None,
-        distance_threshold: Optional[float] = None,
-        attributes: Optional[Dict[str, Any]] = None,
-    ) -> List[Dict[str, Any]]:
+        return_fields: list[str] | None = None,
+        filter_expression: FilterExpression | None = None,
+        distance_threshold: float | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
         """Check the cache for semantically similar prompts.
 
         Args:
@@ -342,14 +340,14 @@ class LangCacheSemanticCache(BaseLLMCache):
 
     async def acheck(
         self,
-        prompt: Optional[str] = None,
-        vector: Optional[List[float]] = None,
+        prompt: str | None = None,
+        vector: list[float] | None = None,
         num_results: int = 1,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[FilterExpression] = None,
-        distance_threshold: Optional[float] = None,
-        attributes: Optional[Dict[str, Any]] = None,
-    ) -> List[Dict[str, Any]]:
+        return_fields: list[str] | None = None,
+        filter_expression: FilterExpression | None = None,
+        distance_threshold: float | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
         """Async check the cache for semantically similar prompts.
 
         Args:
@@ -421,10 +419,10 @@ class LangCacheSemanticCache(BaseLLMCache):
         self,
         prompt: str,
         response: str,
-        vector: Optional[List[float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        vector: list[float] | None = None,
+        metadata: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Store a prompt-response pair in the cache.
 
@@ -494,10 +492,10 @@ class LangCacheSemanticCache(BaseLLMCache):
         self,
         prompt: str,
         response: str,
-        vector: Optional[List[float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        vector: list[float] | None = None,
+        metadata: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Async store a prompt-response pair in the cache.
 
@@ -643,7 +641,7 @@ class LangCacheSemanticCache(BaseLLMCache):
         """
         await self._client.delete_by_id_async(entry_id=entry_id)
 
-    def delete_by_attributes(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
+    def delete_by_attributes(self, attributes: dict[str, Any]) -> dict[str, Any]:
         """Delete cache entries matching the given attributes.
 
         Args:
@@ -665,7 +663,7 @@ class LangCacheSemanticCache(BaseLLMCache):
         # Convert DeleteQueryResponse to dict
         return result.model_dump() if hasattr(result, "model_dump") else {}
 
-    async def adelete_by_attributes(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
+    async def adelete_by_attributes(self, attributes: dict[str, Any]) -> dict[str, Any]:
         """Async delete cache entries matching the given attributes.
 
         Args:

--- a/redisvl/extensions/cache/llm/schema.py
+++ b/redisvl/extensions/cache/llm/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -17,21 +17,21 @@ from redisvl.utils.utils import current_timestamp, deserialize, serialize
 class CacheEntry(BaseModel):
     """A single cache entry in Redis"""
 
-    entry_id: Optional[str] = Field(default=None)
+    entry_id: str | None = Field(default=None)
     """Cache entry identifier"""
     prompt: str
     """Input prompt or question cached in Redis"""
     response: str
     """Response or answer to the question, cached in Redis"""
-    prompt_vector: List[float]
+    prompt_vector: list[float]
     """Text embedding representation of the prompt"""
     inserted_at: float = Field(default_factory=current_timestamp)
     """Timestamp of when the entry was added to the cache"""
     updated_at: float = Field(default_factory=current_timestamp)
     """Timestamp of when the entry was updated in the cache"""
-    metadata: Optional[Dict[str, Any]] = Field(default=None)
+    metadata: dict[str, Any] | None = Field(default=None)
     """Optional metadata stored on the cache entry"""
-    filters: Optional[Dict[str, Any]] = Field(default=None)
+    filters: dict[str, Any] | None = Field(default=None)
     """Optional filter data stored on the cache entry for customizing retrieval"""
 
     @model_validator(mode="before")
@@ -49,7 +49,7 @@ class CacheEntry(BaseModel):
             raise TypeError("Metadata must be a dictionary.")
         return v
 
-    def to_dict(self, dtype: str) -> Dict:
+    def to_dict(self, dtype: str) -> dict[str, Any]:
         data = self.model_dump(exclude_none=True)
         data["prompt_vector"] = array_to_buffer(self.prompt_vector, dtype)
         if self.metadata is not None:
@@ -75,9 +75,9 @@ class CacheHit(BaseModel):
     """Timestamp of when the entry was added to the cache"""
     updated_at: float
     """Timestamp of when the entry was updated in the cache"""
-    metadata: Optional[Dict[str, Any]] = Field(default=None)
+    metadata: dict[str, Any] | None = Field(default=None)
     """Optional metadata stored on the cache entry"""
-    filters: Optional[Dict[str, Any]] = Field(default=None)
+    filters: dict[str, Any] | None = Field(default=None)
     """Optional filter data stored on the cache entry for customizing retrieval"""
 
     # Allow extra fields to simplify handling filters
@@ -85,7 +85,7 @@ class CacheHit(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_cache_hit(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_cache_hit(cls, values: dict[str, Any]) -> dict[str, Any]:
         # Deserialize metadata if necessary
         if "metadata" in values and isinstance(values["metadata"], str):
             values["metadata"] = deserialize(values["metadata"])
@@ -101,7 +101,7 @@ class CacheHit(BaseModel):
 
         return values
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert this model to a dictionary, merging filters into the result."""
         data = self.model_dump(exclude_none=True)
         if data.get("filters"):

--- a/redisvl/extensions/cache/llm/semantic.py
+++ b/redisvl/extensions/cache/llm/semantic.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from redis import Redis
 
@@ -40,19 +40,19 @@ class SemanticCache(BaseLLMCache):
     """Semantic Cache for Large Language Models."""
 
     _index: SearchIndex
-    _aindex: Optional[AsyncSearchIndex] = None
+    _aindex: AsyncSearchIndex | None = None
 
     @deprecated_argument("dtype", "vectorizer")
     def __init__(
         self,
         name: str = "llmcache",
         distance_threshold: float = 0.1,
-        ttl: Optional[int] = None,
-        vectorizer: Optional[BaseVectorizer] = None,
-        filterable_fields: Optional[List[Dict[str, Any]]] = None,
-        redis_client: Optional[Redis] = None,
+        ttl: int | None = None,
+        vectorizer: BaseVectorizer | None = None,
+        filterable_fields: list[dict[str, Any]] | None = None,
+        redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: Dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] = {},
         overwrite: bool = False,
         **kwargs,
     ):
@@ -183,7 +183,7 @@ class SemanticCache(BaseLLMCache):
     def _modify_schema(
         self,
         schema: SemanticCacheIndexSchema,
-        filterable_fields: Optional[List[Dict[str, Any]]] = None,
+        filterable_fields: list[dict[str, Any]] | None = None,
     ) -> SemanticCacheIndexSchema:
         """Modify the base cache schema using the provided filterable fields"""
 
@@ -225,7 +225,7 @@ class SemanticCache(BaseLLMCache):
         return self._index
 
     @property
-    def aindex(self) -> Optional[AsyncSearchIndex]:
+    def aindex(self) -> AsyncSearchIndex | None:
         """The underlying AsyncSearchIndex for the cache.
 
         Returns:
@@ -267,9 +267,7 @@ class SemanticCache(BaseLLMCache):
         aindex = await self._get_async_index()
         await aindex.delete(drop=True)
 
-    def drop(
-        self, ids: Optional[List[str]] = None, keys: Optional[List[str]] = None
-    ) -> None:
+    def drop(self, ids: list[str] | None = None, keys: list[str] | None = None) -> None:
         """Drop specific entries from the cache by ID or Redis key.
 
         Args:
@@ -294,7 +292,7 @@ class SemanticCache(BaseLLMCache):
             self._index.drop_keys(keys)
 
     async def adrop(
-        self, ids: Optional[List[str]] = None, keys: Optional[List[str]] = None
+        self, ids: list[str] | None = None, keys: list[str] | None = None
     ) -> None:
         """Async drop specific entries from the cache by ID or Redis key.
 
@@ -321,7 +319,7 @@ class SemanticCache(BaseLLMCache):
         if keys is not None:
             await aindex.drop_keys(keys)
 
-    def _vectorize_prompt(self, prompt: Optional[str]) -> List[float]:
+    def _vectorize_prompt(self, prompt: str | None) -> list[float]:
         """Converts a text prompt to its vector representation using the
         configured vectorizer."""
         if not isinstance(prompt, str):
@@ -330,7 +328,7 @@ class SemanticCache(BaseLLMCache):
         result = self._vectorizer.embed(prompt)
         return result  # type: ignore
 
-    async def _avectorize_prompt(self, prompt: Optional[str]) -> List[float]:
+    async def _avectorize_prompt(self, prompt: str | None) -> list[float]:
         """Converts a text prompt to its vector representation using the
         configured vectorizer."""
         if not isinstance(prompt, str):
@@ -339,7 +337,7 @@ class SemanticCache(BaseLLMCache):
         result = await self._vectorizer.aembed(prompt)
         return result  # type: ignore
 
-    def _check_vector_dims(self, vector: List[float]):
+    def _check_vector_dims(self, vector: list[float]):
         """Checks the size of the provided vector and raises an error if it
         doesn't match the search index vector dimensions."""
         schema_vector_dims = self._index.schema.fields[
@@ -349,13 +347,13 @@ class SemanticCache(BaseLLMCache):
 
     def check(
         self,
-        prompt: Optional[str] = None,
-        vector: Optional[List[float]] = None,
+        prompt: str | None = None,
+        vector: list[float] | None = None,
         num_results: int = 1,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[FilterExpression] = None,
-        distance_threshold: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        return_fields: list[str] | None = None,
+        filter_expression: FilterExpression | None = None,
+        distance_threshold: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Checks the semantic cache for results similar to the specified prompt
         or vector.
 
@@ -440,13 +438,13 @@ class SemanticCache(BaseLLMCache):
 
     async def acheck(
         self,
-        prompt: Optional[str] = None,
-        vector: Optional[List[float]] = None,
+        prompt: str | None = None,
+        vector: list[float] | None = None,
         num_results: int = 1,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[FilterExpression] = None,
-        distance_threshold: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        return_fields: list[str] | None = None,
+        filter_expression: FilterExpression | None = None,
+        distance_threshold: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Async check the semantic cache for results similar to the specified prompt
         or vector.
 
@@ -532,12 +530,12 @@ class SemanticCache(BaseLLMCache):
 
     def _process_cache_results(
         self,
-        cache_search_results: List[Dict[str, Any]],
-        return_fields: Optional[List[str]] = None,
-    ) -> Tuple[List[str], List[Dict[str, Any]]]:
+        cache_search_results: list[dict[str, Any]],
+        return_fields: list[str] | None = None,
+    ) -> tuple[list[str], list[dict[str, Any]]]:
         """Process raw search results into cache hits."""
-        redis_keys: List[str] = []
-        cache_hits: List[Dict[Any, str]] = []
+        redis_keys: list[str] = []
+        cache_hits: list[dict[Any, str]] = []
 
         for cache_search_result in cache_search_results:
             # Pop the redis key from the result
@@ -564,10 +562,10 @@ class SemanticCache(BaseLLMCache):
         self,
         prompt: str,
         response: str,
-        vector: Optional[List[float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        vector: list[float] | None = None,
+        metadata: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Stores the specified key-value pair in the cache along with metadata.
 
@@ -632,10 +630,10 @@ class SemanticCache(BaseLLMCache):
         self,
         prompt: str,
         response: str,
-        vector: Optional[List[float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        ttl: Optional[int] = None,
+        vector: list[float] | None = None,
+        metadata: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
+        ttl: int | None = None,
     ) -> str:
         """Async stores the specified key-value pair in the cache along with metadata.
 
@@ -829,9 +827,7 @@ class SemanticCache(BaseLLMCache):
         # Close the base Redis connections
         await super().adisconnect()
 
-    def _make_entry_id(
-        self, prompt: str, filters: Optional[Dict[str, Any]] = None
-    ) -> str:
+    def _make_entry_id(self, prompt: str, filters: dict[str, Any] | None = None) -> str:
         """Generate a deterministic entry ID for the given prompt and optional filters.
 
         Args:

--- a/redisvl/extensions/message_history/base_history.py
+++ b/redisvl/extensions/message_history/base_history.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from redisvl.extensions.constants import (
     CONTENT_FIELD_NAME,
@@ -16,7 +16,7 @@ class BaseMessageHistory:
     def __init__(
         self,
         name: str,
-        session_tag: Optional[str] = None,
+        session_tag: str | None = None,
     ):
         """Initialize message history with index
 
@@ -41,7 +41,7 @@ class BaseMessageHistory:
         """Clear all conversation history and remove any search indices."""
         raise NotImplementedError
 
-    def drop(self, id_field: Optional[str] = None) -> None:
+    def drop(self, id_field: str | None = None) -> None:
         """Remove a specific exchange from the conversation history.
 
         Args:
@@ -50,7 +50,7 @@ class BaseMessageHistory:
         """
         raise NotImplementedError
 
-    def count(self, session_tag: Optional[str] = None) -> int:
+    def count(self, session_tag: str | None = None) -> int:
         """Count the number of messages in the conversation history.
 
         Args:
@@ -60,7 +60,7 @@ class BaseMessageHistory:
         raise NotImplementedError
 
     @property
-    def messages(self) -> Union[List[str], List[Dict[str, str]]]:
+    def messages(self) -> list[str] | list[dict[str, str]]:
         """Returns the full chat history."""
         raise NotImplementedError
 
@@ -69,9 +69,9 @@ class BaseMessageHistory:
         top_k: int = 5,
         as_text: bool = False,
         raw: bool = False,
-        session_tag: Optional[str] = None,
-        role: Optional[Union[str, List[str]]] = None,
-    ) -> Union[List[str], List[Dict[str, str]]]:
+        session_tag: str | None = None,
+        role: str | list[str] | None = None,
+    ) -> list[str] | list[dict[str, str]]:
         """Retrieve the recent conversation history in sequential order.
 
         Args:
@@ -97,9 +97,7 @@ class BaseMessageHistory:
         """
         raise NotImplementedError
 
-    def _validate_roles(
-        self, role: Optional[Union[str, List[str]]]
-    ) -> Optional[List[str]]:
+    def _validate_roles(self, role: str | list[str] | None) -> list[str] | None:
         """Validate and normalize role parameter.
 
         Args:
@@ -151,8 +149,8 @@ class BaseMessageHistory:
         raise ValueError("role must be a string or list of strings")
 
     def _format_context(
-        self, messages: List[Dict[str, Any]], as_text: bool
-    ) -> Union[List[str], List[Dict[str, str]]]:
+        self, messages: list[dict[str, Any]], as_text: bool
+    ) -> list[str] | list[dict[str, str]]:
         """Extracts the prompt and response fields from the Redis hashes and
            formats them as either flat dictionaries or strings.
 
@@ -189,9 +187,7 @@ class BaseMessageHistory:
 
         return context
 
-    def store(
-        self, prompt: str, response: str, session_tag: Optional[str] = None
-    ) -> None:
+    def store(self, prompt: str, response: str, session_tag: str | None = None) -> None:
         """Insert a prompt:response pair into the message history. A timestamp
         is associated with each exchange so that they can be later sorted
         in sequential ordering after retrieval.
@@ -204,7 +200,7 @@ class BaseMessageHistory:
         raise NotImplementedError
 
     def add_messages(
-        self, messages: List[Dict[str, str]], session_tag: Optional[str] = None
+        self, messages: list[dict[str, str]], session_tag: str | None = None
     ) -> None:
         """Insert a list of prompts and responses into the message history.
         A timestamp is associated with each so that they can be later sorted
@@ -217,7 +213,7 @@ class BaseMessageHistory:
         raise NotImplementedError
 
     def add_message(
-        self, message: Dict[str, str], session_tag: Optional[str] = None
+        self, message: dict[str, str], session_tag: str | None = None
     ) -> None:
         """Insert a single prompt or response into the message history.
         A timestamp is associated with it so that it can be later sorted

--- a/redisvl/extensions/message_history/message_history.py
+++ b/redisvl/extensions/message_history/message_history.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from redis import Redis
 
@@ -24,11 +24,11 @@ class MessageHistory(BaseMessageHistory):
     def __init__(
         self,
         name: str,
-        session_tag: Optional[str] = None,
-        prefix: Optional[str] = None,
-        redis_client: Optional[Redis] = None,
+        session_tag: str | None = None,
+        prefix: str | None = None,
+        redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: Dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] = {},
         **kwargs,
     ):
         """Initialize message history
@@ -79,7 +79,7 @@ class MessageHistory(BaseMessageHistory):
         """Clear all conversation keys and remove the search index."""
         self._index.delete(drop=True)
 
-    def drop(self, id: Optional[str] = None) -> None:
+    def drop(self, id: str | None = None) -> None:
         """Remove a specific exchange from the conversation history.
 
         Args:
@@ -102,7 +102,7 @@ class MessageHistory(BaseMessageHistory):
         return self._index.query(query)
 
     @property
-    def messages(self) -> Union[List[str], List[Dict[str, str]]]:
+    def messages(self) -> list[str] | list[dict[str, str]]:
         """Returns the full message history."""
         # TODO raw or as_text?
         # TODO refactor this method to use get_recent and support other session tags?
@@ -131,9 +131,9 @@ class MessageHistory(BaseMessageHistory):
         top_k: int = 5,
         as_text: bool = False,
         raw: bool = False,
-        session_tag: Optional[str] = None,
-        role: Optional[Union[str, List[str]]] = None,
-    ) -> Union[List[str], List[Dict[str, str]]]:
+        session_tag: str | None = None,
+        role: str | list[str] | None = None,
+    ) -> list[str] | list[dict[str, str]]:
         """Retrieve the recent message history in sequential order.
 
         Args:
@@ -204,9 +204,7 @@ class MessageHistory(BaseMessageHistory):
             return messages[::-1]
         return self._format_context(messages[::-1], as_text)
 
-    def store(
-        self, prompt: str, response: str, session_tag: Optional[str] = None
-    ) -> None:
+    def store(self, prompt: str, response: str, session_tag: str | None = None) -> None:
         """Insert a prompt:response pair into the message history. A timestamp
         is associated with each exchange so that they can be later sorted
         in sequential ordering after retrieval.
@@ -226,7 +224,7 @@ class MessageHistory(BaseMessageHistory):
         )
 
     def add_messages(
-        self, messages: List[Dict[str, str]], session_tag: Optional[str] = None
+        self, messages: list[dict[str, str]], session_tag: str | None = None
     ) -> None:
         """Insert a list of prompts and responses into the message history.
         A timestamp is associated with each so that they can be later sorted
@@ -238,7 +236,7 @@ class MessageHistory(BaseMessageHistory):
                 conversation session. Defaults to instance ULID.
         """
         session_tag = session_tag or self._session_tag
-        chat_messages: List[Dict[str, Any]] = []
+        chat_messages: list[dict[str, Any]] = []
 
         for message in messages:
 
@@ -257,7 +255,7 @@ class MessageHistory(BaseMessageHistory):
         self._index.load(data=chat_messages, id_field=ID_FIELD_NAME)
 
     def add_message(
-        self, message: Dict[str, str], session_tag: Optional[str] = None
+        self, message: dict[str, str], session_tag: str | None = None
     ) -> None:
         """Insert a single prompt or response into the message history.
         A timestamp is associated with it so that it can be later sorted

--- a/redisvl/extensions/message_history/schema.py
+++ b/redisvl/extensions/message_history/schema.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -32,21 +32,21 @@ class ChatRole(str, Enum):
 class ChatMessage(BaseModel):
     """A single chat message exchanged between a user and an LLM."""
 
-    entry_id: Optional[str] = Field(default=None)
+    entry_id: str | None = Field(default=None)
     """A unique identifier for the message."""
-    role: Union[ChatRole, str]  # str allows deprecated values with warning
+    role: ChatRole | str  # str allows deprecated values with warning
     """The role of the message sender (e.g. 'user' or 'assistant')."""
     content: str
     """The content of the message."""
     session_tag: str
     """Tag associated with the current conversation session."""
-    timestamp: Optional[float] = Field(default=None)
+    timestamp: float | None = Field(default=None)
     """The time the message was sent, in UTC, rounded to milliseconds."""
-    tool_call_id: Optional[str] = Field(default=None)
+    tool_call_id: str | None = Field(default=None)
     """An optional identifier for a tool call associated with the message."""
-    vector_field: Optional[List[float]] = Field(default=None)
+    vector_field: list[float] | None = Field(default=None)
     """The vector representation of the message content."""
-    metadata: Optional[str] = Field(default=None)
+    metadata: str | None = Field(default=None)
     """Optional additional data to store alongside the message"""
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -66,7 +66,7 @@ class ChatMessage(BaseModel):
 
     @field_validator("role", mode="before")
     @classmethod
-    def coerce_role(cls, v: Any) -> Union[ChatRole, str]:
+    def coerce_role(cls, v: Any) -> ChatRole | str:
         if isinstance(v, str):
             try:
                 return ChatRole(v)
@@ -78,7 +78,7 @@ class ChatMessage(BaseModel):
                 )
         return v
 
-    def to_dict(self, dtype: Optional[str] = None) -> Dict:
+    def to_dict(self, dtype: str | None = None) -> dict[str, Any]:
         data = self.model_dump(exclude_none=True)
 
         # handle optional fields

--- a/redisvl/extensions/message_history/semantic_history.py
+++ b/redisvl/extensions/message_history/semantic_history.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from redis import Redis
 
@@ -30,13 +30,13 @@ class SemanticMessageHistory(BaseMessageHistory):
     def __init__(
         self,
         name: str,
-        session_tag: Optional[str] = None,
-        prefix: Optional[str] = None,
-        vectorizer: Optional[BaseVectorizer] = None,
+        session_tag: str | None = None,
+        prefix: str | None = None,
+        vectorizer: BaseVectorizer | None = None,
         distance_threshold: float = 0.3,
-        redis_client: Optional[Redis] = None,
+        redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: Dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] = {},
         overwrite: bool = False,
         **kwargs,
     ):
@@ -134,7 +134,7 @@ class SemanticMessageHistory(BaseMessageHistory):
         """Clear all message keys and remove the search index."""
         self._index.delete(drop=True)
 
-    def drop(self, id: Optional[str] = None) -> None:
+    def drop(self, id: str | None = None) -> None:
         """Remove a specific exchange from the message history.
 
         Args:
@@ -157,7 +157,7 @@ class SemanticMessageHistory(BaseMessageHistory):
         return self._index.query(query)
 
     @property
-    def messages(self) -> Union[List[str], List[Dict[str, str]]]:
+    def messages(self) -> list[str] | list[dict[str, str]]:
         """Returns the full message history."""
         # TODO raw or as_text?
         # TODO refactor method to use get_recent and support other session tags
@@ -186,11 +186,11 @@ class SemanticMessageHistory(BaseMessageHistory):
         as_text: bool = False,
         top_k: int = 5,
         fall_back: bool = False,
-        session_tag: Optional[str] = None,
+        session_tag: str | None = None,
         raw: bool = False,
-        distance_threshold: Optional[float] = None,
-        role: Optional[Union[str, List[str]]] = None,
-    ) -> Union[List[str], List[Dict[str, str]]]:
+        distance_threshold: float | None = None,
+        role: str | list[str] | None = None,
+    ) -> list[str] | list[dict[str, str]]:
         """Searches the message history for information semantically related to
         the specified prompt.
 
@@ -287,9 +287,9 @@ class SemanticMessageHistory(BaseMessageHistory):
         top_k: int = 5,
         as_text: bool = False,
         raw: bool = False,
-        session_tag: Optional[str] = None,
-        role: Optional[Union[str, List[str]]] = None,
-    ) -> Union[List[str], List[Dict[str, str]]]:
+        session_tag: str | None = None,
+        role: str | list[str] | None = None,
+    ) -> list[str] | list[dict[str, str]]:
         """Retrieve the recent message history in sequential order.
 
         Args:
@@ -367,9 +367,7 @@ class SemanticMessageHistory(BaseMessageHistory):
     def set_distance_threshold(self, threshold):
         self._distance_threshold = threshold
 
-    def store(
-        self, prompt: str, response: str, session_tag: Optional[str] = None
-    ) -> None:
+    def store(self, prompt: str, response: str, session_tag: str | None = None) -> None:
         """Insert a prompt:response pair into the message history. A timestamp
         is associated with each message so that they can be later sorted
         in sequential ordering after retrieval.
@@ -389,7 +387,7 @@ class SemanticMessageHistory(BaseMessageHistory):
         )
 
     def add_messages(
-        self, messages: List[Dict[str, str]], session_tag: Optional[str] = None
+        self, messages: list[dict[str, str]], session_tag: str | None = None
     ) -> None:
         """Insert a list of prompts and responses into the session memory.
         A timestamp is associated with each so that they can be later sorted
@@ -401,7 +399,7 @@ class SemanticMessageHistory(BaseMessageHistory):
                 conversation session. Defaults to instance ULID.
         """
         session_tag = session_tag or self._session_tag
-        chat_messages: List[Dict[str, Any]] = []
+        chat_messages: list[dict[str, Any]] = []
 
         for message in messages:
             content_vector = self._vectorizer.embed(message[CONTENT_FIELD_NAME])
@@ -427,7 +425,7 @@ class SemanticMessageHistory(BaseMessageHistory):
         self._index.load(data=chat_messages, id_field=ID_FIELD_NAME)
 
     def add_message(
-        self, message: Dict[str, str], session_tag: Optional[str] = None
+        self, message: dict[str, str], session_tag: str | None = None
     ) -> None:
         """Insert a single prompt or response into the message history.
         A timestamp is associated with it so that it can be later sorted

--- a/redisvl/extensions/router/schema.py
+++ b/redisvl/extensions/router/schema.py
@@ -1,9 +1,8 @@
 import warnings
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Annotated
 
 from redisvl.extensions.constants import ROUTE_VECTOR_FIELD_NAME
 from redisvl.schema import IndexSchema
@@ -14,9 +13,9 @@ class Route(BaseModel):
 
     name: str
     """The name of the route."""
-    references: List[str]
+    references: list[str]
     """List of reference phrases for the route."""
-    metadata: Dict[str, Any] = Field(default={})
+    metadata: dict[str, Any] = Field(default={})
     """Metadata associated with the route."""
     distance_threshold: Annotated[float, Field(strict=True, gt=0, le=2)] = 0.5
     """Distance threshold for matching the route."""
@@ -41,9 +40,9 @@ class Route(BaseModel):
 class RouteMatch(BaseModel):
     """Model representing a matched route with distance information."""
 
-    name: Optional[str] = None
+    name: str | None = None
     """The matched route name."""
-    distance: Optional[float] = Field(default=None)
+    distance: float | None = Field(default=None)
     """The vector distance between the statement and the matched route."""
 
 
@@ -72,7 +71,7 @@ class RoutingConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def remove_distance_threshold(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def remove_distance_threshold(cls, values: dict[str, Any]) -> dict[str, Any]:
         if "distance_threshold" in values:
             warnings.warn(
                 "The 'distance_threshold' field is deprecated and will be ignored. Set distance_threshold per Route.",

--- a/redisvl/extensions/router/semantic.py
+++ b/redisvl/extensions/router/semantic.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any
 
 import redis.commands.search.reducers as reducers
 import yaml
@@ -34,7 +34,7 @@ class SemanticRouter(BaseModel):
 
     name: str
     """The name of the semantic router."""
-    routes: List[Route]
+    routes: list[Route]
     """List of Route objects."""
     vectorizer: BaseVectorizer = Field(default_factory=HFTextVectorizer)
     """The vectorizer used to embed route references."""
@@ -49,13 +49,13 @@ class SemanticRouter(BaseModel):
     def __init__(
         self,
         name: str,
-        routes: List[Route],
-        vectorizer: Optional[BaseVectorizer] = None,
-        routing_config: Optional[RoutingConfig] = None,
-        redis_client: Optional[SyncRedisClient] = None,
+        routes: list[Route],
+        vectorizer: BaseVectorizer | None = None,
+        routing_config: RoutingConfig | None = None,
+        redis_client: SyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
-        connection_kwargs: Dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] = {},
         **kwargs,
     ):
         """Initialize the SemanticRouter.
@@ -119,7 +119,7 @@ class SemanticRouter(BaseModel):
     def from_existing(
         cls,
         name: str,
-        redis_client: Optional[SyncRedisClient] = None,
+        redis_client: SyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
         **kwargs,
     ) -> "SemanticRouter":
@@ -129,7 +129,7 @@ class SemanticRouter(BaseModel):
             nested_connection_keys=("connection_kwargs",),
         )
         lib_name = init_kwargs.get("lib_name")
-        index_kwargs: Dict[str, Any] = {}
+        index_kwargs: dict[str, Any] = {}
         created_redis_client = False
 
         if redis_client:
@@ -179,12 +179,12 @@ class SemanticRouter(BaseModel):
     @deprecated_argument("dtype")
     def _initialize_index(
         self,
-        redis_client: Optional[SyncRedisClient] = None,
+        redis_client: SyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
         overwrite: bool = False,
         dtype: str = "float32",
-        connection_kwargs: Optional[Dict[str, Any]] = None,
-        index_kwargs: Optional[Dict[str, Any]] = None,
+        connection_kwargs: dict[str, Any] | None = None,
+        index_kwargs: dict[str, Any] | None = None,
     ):
         """Initialize the search index and handle Redis connection."""
 
@@ -221,7 +221,7 @@ class SemanticRouter(BaseModel):
         return f"SemanticRouter(name={self.name!r}, routes={len(self.routes)})"
 
     @property
-    def route_names(self) -> List[str]:
+    def route_names(self) -> list[str]:
         """Get the list of route names.
 
         Returns:
@@ -230,7 +230,7 @@ class SemanticRouter(BaseModel):
         return [route.name for route in self.routes]
 
     @property
-    def route_thresholds(self) -> Dict[str, Optional[float]]:
+    def route_thresholds(self) -> dict[str, float | None]:
         """Get the distance thresholds for each route.
 
         Returns:
@@ -246,7 +246,7 @@ class SemanticRouter(BaseModel):
         """
         self.routing_config = routing_config
 
-    def update_route_thresholds(self, route_thresholds: Dict[str, Optional[float]]):
+    def update_route_thresholds(self, route_thresholds: dict[str, float | None]):
         """Update the distance thresholds for each route.
 
         Args:
@@ -278,14 +278,14 @@ class SemanticRouter(BaseModel):
         else:
             return f"{route_name}{sep}*"
 
-    def _add_routes(self, routes: List[Route]):
+    def _add_routes(self, routes: list[Route]):
         """Add routes to the router and index.
 
         Args:
             routes (List[Route]): List of routes to be added.
         """
-        route_references: List[Dict[str, Any]] = []
-        keys: List[str] = []
+        route_references: list[dict[str, Any]] = []
+        keys: list[str] = []
 
         for route in routes:
             # embed route references as a single batch
@@ -313,7 +313,7 @@ class SemanticRouter(BaseModel):
 
         self._index.load(route_references, keys=keys)
 
-    def get(self, route_name: str) -> Optional[Route]:
+    def get(self, route_name: str) -> Route | None:
         """Get a route by its name.
 
         Args:
@@ -324,7 +324,7 @@ class SemanticRouter(BaseModel):
         """
         return next((route for route in self.routes if route.name == route_name), None)
 
-    def _process_route(self, result: Dict[str, Any]) -> RouteMatch:
+    def _process_route(self, result: dict[str, Any]) -> RouteMatch:
         """Process resulting route objects and metadata."""
         route_dict = make_dict(convert_bytes(result))
         return RouteMatch(
@@ -349,7 +349,7 @@ class SemanticRouter(BaseModel):
         max_k: int,
     ) -> AggregateRequest:
         """Build the Redis aggregation request."""
-        aggregation_func: Type[Reducer]
+        aggregation_func: type[Reducer]
 
         if aggregation_method == DistanceAggregationMethod.min:
             aggregation_func = reducers.min
@@ -377,10 +377,10 @@ class SemanticRouter(BaseModel):
 
     def _get_route_matches(
         self,
-        vector: List[float],
+        vector: list[float],
         aggregation_method: DistanceAggregationMethod,
         max_k: int = 1,
-    ) -> List[RouteMatch]:
+    ) -> list[RouteMatch]:
         """Get route response from vector db"""
 
         # what's interesting about this is that we only provide one distance_threshold for a range query not multiple
@@ -416,7 +416,7 @@ class SemanticRouter(BaseModel):
 
     def _classify_route(
         self,
-        vector: List[float],
+        vector: list[float],
         aggregation_method: DistanceAggregationMethod,
     ) -> RouteMatch:
         """Classify to a single route using a vector."""
@@ -439,16 +439,16 @@ class SemanticRouter(BaseModel):
 
     def _classify_multi_route(
         self,
-        vector: List[float],
+        vector: list[float],
         max_k: int,
         aggregation_method: DistanceAggregationMethod,
-    ) -> List[RouteMatch]:
+    ) -> list[RouteMatch]:
         """Classify to multiple routes, up to max_k (int), using a vector."""
 
         route_matches = self._get_route_matches(vector, aggregation_method, max_k=max_k)
 
         # process route matches
-        top_route_matches: List[RouteMatch] = []
+        top_route_matches: list[RouteMatch] = []
         if route_matches:
             for route_match in route_matches:
                 if route_match.name is not None:
@@ -463,10 +463,10 @@ class SemanticRouter(BaseModel):
     @deprecated_argument("distance_threshold")
     def __call__(
         self,
-        statement: Optional[str] = None,
-        vector: Optional[List[float]] = None,
-        aggregation_method: Optional[DistanceAggregationMethod] = None,
-        distance_threshold: Optional[float] = None,
+        statement: str | None = None,
+        vector: list[float] | None = None,
+        aggregation_method: DistanceAggregationMethod | None = None,
+        distance_threshold: float | None = None,
     ) -> RouteMatch:
         """Query the semantic router with a given statement or vector.
 
@@ -495,12 +495,12 @@ class SemanticRouter(BaseModel):
     @deprecated_argument("distance_threshold")
     def route_many(
         self,
-        statement: Optional[str] = None,
-        vector: Optional[List[float]] = None,
-        max_k: Optional[int] = None,
-        distance_threshold: Optional[float] = None,
-        aggregation_method: Optional[DistanceAggregationMethod] = None,
-    ) -> List[RouteMatch]:
+        statement: str | None = None,
+        vector: list[float] | None = None,
+        max_k: int | None = None,
+        distance_threshold: float | None = None,
+        aggregation_method: DistanceAggregationMethod | None = None,
+    ) -> list[RouteMatch]:
         """Query the semantic router with a given statement or vector for multiple matches.
 
         Args:
@@ -560,7 +560,7 @@ class SemanticRouter(BaseModel):
     @classmethod
     def from_dict(
         cls,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         **kwargs,
     ) -> "SemanticRouter":
         """Create a SemanticRouter from a dictionary.
@@ -613,7 +613,7 @@ class SemanticRouter(BaseModel):
             **kwargs,
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert the SemanticRouter instance to a dictionary.
 
         Returns:
@@ -705,8 +705,8 @@ class SemanticRouter(BaseModel):
     def add_route_references(
         self,
         route_name: str,
-        references: Union[str, List[str]],
-    ) -> List[str]:
+        references: str | list[str],
+    ) -> list[str]:
         """Add a reference(s) to an existing route.
 
         Args:
@@ -720,8 +720,8 @@ class SemanticRouter(BaseModel):
         if isinstance(references, str):
             references = [references]
 
-        route_references: List[Dict[str, Any]] = []
-        keys: List[str] = []
+        route_references: list[dict[str, Any]] = []
+        keys: list[str] = []
 
         # embed route references as a single batch
         reference_vectors = self.vectorizer.embed_many(references, as_buffer=True)
@@ -750,7 +750,7 @@ class SemanticRouter(BaseModel):
         return keys
 
     @staticmethod
-    def _make_filter_queries(ids: List[str]) -> List[FilterQuery]:
+    def _make_filter_queries(ids: list[str]) -> list[FilterQuery]:
         """Create a filter query for the given ids."""
 
         queries = []
@@ -768,9 +768,9 @@ class SemanticRouter(BaseModel):
     def get_route_references(
         self,
         route_name: str = "",
-        reference_ids: List[str] = [],
-        keys: List[str] = [],
-    ) -> List[Dict[str, Any]]:
+        reference_ids: list[str] = [],
+        keys: list[str] = [],
+    ) -> list[dict[str, Any]]:
         """Get references for an existing route route.
 
         Args:
@@ -804,8 +804,8 @@ class SemanticRouter(BaseModel):
     def delete_route_references(
         self,
         route_name: str = "",
-        reference_ids: List[str] = [],
-        keys: List[str] = [],
+        reference_ids: list[str] = [],
+        keys: list[str] = [],
     ) -> int:
         """Get references for an existing semantic router route.
 

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -10,14 +10,9 @@ from typing import (
     Any,
     AsyncGenerator,
     Callable,
-    Dict,
     Generator,
     Iterable,
-    List,
-    Optional,
     Sequence,
-    Tuple,
-    Union,
     cast,
 )
 
@@ -113,16 +108,12 @@ REQUIRED_MODULES_FOR_INTROSPECTION = [
     {"name": "searchlight", "ver": 20810},
 ]
 
-SearchParams = Union[
-    Tuple[
-        Union[str, BaseQuery],
-        Union[Dict[str, Union[str, int, float, bytes]], None],
-    ],
-    Union[str, BaseQuery],
-]
+SearchParams = tuple[str | BaseQuery, dict[str, str | int | float | bytes] | None] | (
+    str | BaseQuery
+)
 
 
-def _get_sql_redis_options(sql_query: SQLQuery) -> Dict[str, Any]:
+def _get_sql_redis_options(sql_query: SQLQuery) -> dict[str, Any]:
     """Return normalized sql-redis executor options for a SQLQuery."""
     return {
         "schema_cache_strategy": "lazy",
@@ -130,14 +121,14 @@ def _get_sql_redis_options(sql_query: SQLQuery) -> Dict[str, Any]:
     }
 
 
-def _sql_executor_cache_key(sql_redis_options: Dict[str, Any]) -> str:
+def _sql_executor_cache_key(sql_redis_options: dict[str, Any]) -> str:
     """Build a stable cache key for sql-redis executor reuse."""
     return json.dumps(sql_redis_options, sort_keys=True, default=repr)
 
 
 def process_results(
     results: "Result", query: BaseQuery, schema: IndexSchema
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Convert a list of search Result objects into a list of document
     dictionaries.
 
@@ -180,7 +171,7 @@ def process_results(
         norm_fn = None
 
     # Process records
-    def _process(doc: "Document") -> Dict[str, Any]:
+    def _process(doc: "Document") -> dict[str, Any]:
         doc_dict = doc.__dict__
 
         # Unpack and Project JSON fields properly
@@ -208,7 +199,7 @@ def process_results(
 
 def process_aggregate_results(
     results: "AggregateResult", query: AggregationQuery, storage_type: StorageType
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Convert an aggregate result object into a list of document dictionaries.
 
     This function processes results from Redis, handling different storage
@@ -328,7 +319,7 @@ class BaseSearchIndex:
         return prefix[0] if isinstance(prefix, list) else prefix
 
     @property
-    def prefixes(self) -> List[str]:
+    def prefixes(self) -> list[str]:
         """All key prefixes configured for this index."""
         prefix = self.schema.index.prefix
         return prefix if isinstance(prefix, list) else [prefix]
@@ -365,7 +356,7 @@ class BaseSearchIndex:
         return cls(schema=schema, **kwargs)
 
     @classmethod
-    def from_dict(cls, schema_dict: Dict[str, Any], **kwargs):
+    def from_dict(cls, schema_dict: dict[str, Any], **kwargs):
         """Create a SearchIndex from a dictionary.
 
         Args:
@@ -458,9 +449,9 @@ class SearchIndex(BaseSearchIndex):
     def __init__(
         self,
         schema: IndexSchema,
-        redis_client: Optional[SyncRedisClient] = None,
-        redis_url: Optional[str] = None,
-        connection_kwargs: Optional[Dict[str, Any]] = None,
+        redis_client: SyncRedisClient | None = None,
+        redis_url: str | None = None,
+        connection_kwargs: dict[str, Any] | None = None,
         validate_on_load: bool = False,
         **kwargs,
     ):
@@ -487,14 +478,14 @@ class SearchIndex(BaseSearchIndex):
 
         self.schema = schema
         self._validate_on_load = validate_on_load
-        self._lib_name: Optional[str] = kwargs.pop("lib_name", None)
+        self._lib_name: str | None = kwargs.pop("lib_name", None)
 
         # Store connection parameters
         self.__redis_client = redis_client
         self._redis_url = redis_url
         self._connection_kwargs = connection_kwargs or {}
         self._lock = threading.Lock()
-        self._sql_executors: Dict[str, Any] = {}
+        self._sql_executors: dict[str, Any] = {}
 
         self._validated_client = kwargs.pop("_client_validated", False)
         self._owns_redis_client = kwargs.pop("_owns_redis_client", redis_client is None)
@@ -515,8 +506,8 @@ class SearchIndex(BaseSearchIndex):
     def from_existing(
         cls,
         name: str,
-        redis_client: Optional[SyncRedisClient] = None,
-        redis_url: Optional[str] = None,
+        redis_client: SyncRedisClient | None = None,
+        redis_url: str | None = None,
         **kwargs,
     ):
         """
@@ -536,7 +527,7 @@ class SearchIndex(BaseSearchIndex):
             dict(kwargs),
             nested_connection_keys=("connection_kwargs", "connection_args"),
         )
-        lib_name = cast(Optional[str], init_kwargs.get("lib_name"))
+        lib_name = cast(str | None, init_kwargs.get("lib_name"))
         created_redis_client = False
 
         if redis_client:
@@ -574,7 +565,7 @@ class SearchIndex(BaseSearchIndex):
         return cls(schema, redis_client=redis_client, **init_kwargs)
 
     @property
-    def client(self) -> Optional[SyncRedisClient]:
+    def client(self) -> SyncRedisClient | None:
         """The underlying redis-py client object."""
         return self.__redis_client
 
@@ -606,7 +597,7 @@ class SearchIndex(BaseSearchIndex):
         return self.__redis_client
 
     @deprecated_function("connect", "Pass connection parameters in __init__.")
-    def connect(self, redis_url: Optional[str] = None, **kwargs):
+    def connect(self, redis_url: str | None = None, **kwargs):
         """Connect to a Redis instance using the provided `redis_url`, falling
         back to the `REDIS_URL` environment variable (if available).
 
@@ -769,7 +760,7 @@ class SearchIndex(BaseSearchIndex):
         except Exception as e:
             raise RedisSearchError(f"Error while deleting index: {str(e)}") from e
 
-    def _delete_batch(self, batch_keys: List[str]) -> int:
+    def _delete_batch(self, batch_keys: list[str]) -> int:
         """Delete a batch of keys from Redis.
 
         For Redis Cluster, keys are deleted individually due to potential
@@ -832,7 +823,7 @@ class SearchIndex(BaseSearchIndex):
         """Clear cached sql-redis executors and schema state for this index."""
         self._sql_executors.clear()
 
-    def drop_keys(self, keys: Union[str, List[str]]) -> int:
+    def drop_keys(self, keys: str | list[str]) -> int:
         """Remove a specific entry or entries from the index by it's key ID.
 
         Args:
@@ -841,12 +832,12 @@ class SearchIndex(BaseSearchIndex):
         Returns:
             int: Count of records deleted from Redis.
         """
-        if isinstance(keys, List):
+        if isinstance(keys, list):
             return self._redis_client.delete(*keys)  # type: ignore
         else:
             return self._redis_client.delete(keys)  # type: ignore
 
-    def drop_documents(self, ids: Union[str, List[str]]) -> int:
+    def drop_documents(self, ids: str | list[str]) -> int:
         """Remove documents from the index by their document IDs.
 
         This method converts document IDs to Redis keys automatically by applying
@@ -878,9 +869,7 @@ class SearchIndex(BaseSearchIndex):
             key = self.key(ids)
             return self._redis_client.delete(key)  # type: ignore
 
-    def expire_keys(
-        self, keys: Union[str, List[str]], ttl: int
-    ) -> Union[int, List[int]]:
+    def expire_keys(self, keys: str | list[str], ttl: int) -> int | list[int]:
         """Set the expiration time for a specific entry or entries in Redis.
 
         Args:
@@ -898,12 +887,12 @@ class SearchIndex(BaseSearchIndex):
     def load(
         self,
         data: Iterable[Any],
-        id_field: Optional[str] = None,
-        keys: Optional[Iterable[str]] = None,
-        ttl: Optional[int] = None,
-        preprocess: Optional[Callable] = None,
-        batch_size: Optional[int] = None,
-    ) -> List[str]:
+        id_field: str | None = None,
+        keys: Iterable[str] | None = None,
+        ttl: int | None = None,
+        preprocess: Callable | None = None,
+        batch_size: int | None = None,
+    ) -> list[str]:
         """Load objects to the Redis database. Returns the list of keys loaded
         to Redis.
 
@@ -953,7 +942,7 @@ class SearchIndex(BaseSearchIndex):
             logger.exception("Error while loading data to Redis")
             raise RedisVLError(f"Failed to load data: {str(exc)}") from exc
 
-    def fetch(self, id: str) -> Optional[Dict[str, Any]]:
+    def fetch(self, id: str) -> dict[str, Any] | None:
         """Fetch an object from Redis by id.
 
         The id is typically either a unique identifier,
@@ -972,7 +961,7 @@ class SearchIndex(BaseSearchIndex):
             return convert_bytes(obj[0])
         return None
 
-    def _aggregate(self, aggregation_query: AggregationQuery) -> List[Dict[str, Any]]:
+    def _aggregate(self, aggregation_query: AggregationQuery) -> list[dict[str, Any]]:
         """Execute an aggregation query and processes the results."""
         results = self.aggregate(
             aggregation_query,
@@ -984,7 +973,7 @@ class SearchIndex(BaseSearchIndex):
             storage_type=self.schema.index.storage_type,
         )
 
-    def _sql_query(self, sql_query: SQLQuery) -> List[Dict[str, Any]]:
+    def _sql_query(self, sql_query: SQLQuery) -> list[dict[str, Any]]:
         """Execute a SQL query and return results.
 
         Args:
@@ -1043,8 +1032,8 @@ class SearchIndex(BaseSearchIndex):
             ) from e
 
     def batch_search(
-        self, queries: List[SearchParams], batch_size: int = 10
-    ) -> List["Result"]:
+        self, queries: list[SearchParams], batch_size: int = 10
+    ) -> list["Result"]:
         """Perform a search against the index for multiple queries.
 
         This method takes a list of queries and optionally query params and
@@ -1141,7 +1130,7 @@ class SearchIndex(BaseSearchIndex):
         except Exception as e:
             raise RedisSearchError(f"Unexpected error while searching: {str(e)}") from e
 
-    def _hybrid_search(self, query: HybridQuery, **kwargs) -> List[Dict[str, Any]]:
+    def _hybrid_search(self, query: HybridQuery, **kwargs) -> list[dict[str, Any]]:
         """Perform a hybrid search against the index, combining text and vector search.
 
         Args:
@@ -1194,7 +1183,7 @@ class SearchIndex(BaseSearchIndex):
 
     def batch_query(
         self, queries: Sequence[BaseQuery], batch_size: int = 10
-    ) -> List[List[Dict[str, Any]]]:
+    ) -> list[list[dict[str, Any]]]:
         """Execute a batch of queries and process results."""
         results = self.batch_search(
             [(query.query, query.params) for query in queries], batch_size=batch_size
@@ -1208,7 +1197,7 @@ class SearchIndex(BaseSearchIndex):
             all_parsed.append(parsed)
         return all_parsed
 
-    def _query(self, query: BaseQuery) -> List[Dict[str, Any]]:
+    def _query(self, query: BaseQuery) -> list[dict[str, Any]]:
         """Execute a query and process results."""
         try:
             self._validate_query(query)
@@ -1218,8 +1207,8 @@ class SearchIndex(BaseSearchIndex):
         return process_results(results, query=query, schema=self.schema)
 
     def query(
-        self, query: Union[BaseQuery, AggregationQuery, HybridQuery, SQLQuery]
-    ) -> List[Dict[str, Any]]:
+        self, query: BaseQuery | AggregationQuery | HybridQuery | SQLQuery
+    ) -> list[dict[str, Any]]:
         """Execute a query on the index.
 
         This method takes a BaseQuery, AggregationQuery, or HybridQuery object directly, and
@@ -1305,7 +1294,7 @@ class SearchIndex(BaseSearchIndex):
             # Increment the offset for the next batch of pagination
             offset += page_size
 
-    def listall(self) -> List[str]:
+    def listall(self) -> list[str]:
         """List all search indices in Redis database.
 
         Returns:
@@ -1322,7 +1311,7 @@ class SearchIndex(BaseSearchIndex):
         return self.schema.index.name in self.listall()
 
     @staticmethod
-    def _info(name: str, redis_client: SyncRedisClient) -> Dict[str, Any]:
+    def _info(name: str, redis_client: SyncRedisClient) -> dict[str, Any]:
         """Run FT.INFO to fetch information about the index."""
         try:
             if isinstance(redis_client, SyncRedisCluster):
@@ -1339,7 +1328,7 @@ class SearchIndex(BaseSearchIndex):
                 f"Error while fetching {name} index info: {str(e)}"
             ) from e
 
-    def info(self, name: Optional[str] = None) -> Dict[str, Any]:
+    def info(self, name: str | None = None) -> dict[str, Any]:
         """Get information about the index.
 
         Args:
@@ -1394,9 +1383,9 @@ class AsyncSearchIndex(BaseSearchIndex):
         self,
         schema: IndexSchema,
         *,
-        redis_url: Optional[str] = None,
-        redis_client: Optional[AsyncRedisClient] = None,
-        connection_kwargs: Optional[Dict[str, Any]] = None,
+        redis_url: str | None = None,
+        redis_client: AsyncRedisClient | None = None,
+        connection_kwargs: dict[str, Any] | None = None,
         validate_on_load: bool = False,
         **kwargs,
     ):
@@ -1422,14 +1411,14 @@ class AsyncSearchIndex(BaseSearchIndex):
 
         self.schema = schema
         self._validate_on_load = validate_on_load
-        self._lib_name: Optional[str] = kwargs.pop("lib_name", None)
+        self._lib_name: str | None = kwargs.pop("lib_name", None)
 
         # Store connection parameters
         self._redis_client = redis_client
         self._redis_url = redis_url
         self._connection_kwargs = connection_kwargs or {}
         self._lock = asyncio.Lock()
-        self._sql_executors: Dict[str, Any] = {}
+        self._sql_executors: dict[str, Any] = {}
 
         self._validated_client = kwargs.pop("_client_validated", False)
         self._owns_redis_client = kwargs.pop("_owns_redis_client", redis_client is None)
@@ -1440,8 +1429,8 @@ class AsyncSearchIndex(BaseSearchIndex):
     async def from_existing(
         cls,
         name: str,
-        redis_client: Optional[AsyncRedisClient] = None,
-        redis_url: Optional[str] = None,
+        redis_client: AsyncRedisClient | None = None,
+        redis_url: str | None = None,
         **kwargs,
     ):
         """
@@ -1463,7 +1452,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             dict(kwargs),
             nested_connection_keys=("connection_kwargs", "redis_kwargs"),
         )
-        lib_name = cast(Optional[str], init_kwargs.get("lib_name"))
+        lib_name = cast(str | None, init_kwargs.get("lib_name"))
         created_redis_client = False
 
         if redis_client:
@@ -1504,12 +1493,12 @@ class AsyncSearchIndex(BaseSearchIndex):
         return cls(schema, redis_client=redis_client, **init_kwargs)
 
     @property
-    def client(self) -> Optional[AsyncRedisClient]:
+    def client(self) -> AsyncRedisClient | None:
         """The underlying redis-py client object."""
         return self._redis_client
 
     @deprecated_function("connect", "Pass connection parameters in __init__.")
-    async def connect(self, redis_url: Optional[str] = None, **kwargs):
+    async def connect(self, redis_url: str | None = None, **kwargs):
         """[DEPRECATED] Connect to a Redis instance. Use connection parameters in __init__."""
         warnings.warn(
             "connect() is deprecated; pass connection parameters in __init__",
@@ -1522,7 +1511,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         await self.set_client(client)
 
     @deprecated_function("set_client", "Pass connection parameters in __init__.")
-    async def set_client(self, redis_client: Union[AsyncRedisClient, SyncRedisClient]):
+    async def set_client(self, redis_client: AsyncRedisClient | SyncRedisClient):
         """
         [DEPRECATED] Manually set the Redis client to use with the search index.
         This method is deprecated; please provide connection parameters in __init__.
@@ -1559,7 +1548,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         return self._redis_client
 
     async def _validate_client(
-        self, redis_client: Union[AsyncRedisClient, SyncRedisClient]
+        self, redis_client: AsyncRedisClient | SyncRedisClient
     ) -> AsyncRedisClient:
         # Handle deprecated sync client conversion
         if isinstance(redis_client, (Redis, RedisCluster)):
@@ -1583,7 +1572,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         return redis_client
 
     @staticmethod
-    async def _info(name: str, redis_client: AsyncRedisClient) -> Dict[str, Any]:
+    async def _info(name: str, redis_client: AsyncRedisClient) -> dict[str, Any]:
         try:
             if isinstance(redis_client, AsyncRedisCluster):
                 node = redis_client.get_random_node()
@@ -1722,7 +1711,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         except Exception as e:
             raise RedisSearchError(f"Error while deleting index: {str(e)}") from e
 
-    async def _delete_batch(self, batch_keys: List[str]) -> int:
+    async def _delete_batch(self, batch_keys: list[str]) -> int:
         """Delete a batch of keys from Redis.
 
         For Redis Cluster, keys are deleted individually due to potential
@@ -1787,7 +1776,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         """Clear cached sql-redis executors and schema state for this index."""
         self._sql_executors.clear()
 
-    async def drop_keys(self, keys: Union[str, List[str]]) -> int:
+    async def drop_keys(self, keys: str | list[str]) -> int:
         """Remove a specific entry or entries from the index by it's key ID.
 
         Args:
@@ -1802,7 +1791,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         else:
             return await client.delete(keys)
 
-    async def drop_documents(self, ids: Union[str, List[str]]) -> int:
+    async def drop_documents(self, ids: str | list[str]) -> int:
         """Remove documents from the index by their document IDs.
 
         This method converts document IDs to Redis keys automatically by applying
@@ -1833,9 +1822,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             key = self.key(ids)
             return await client.delete(key)
 
-    async def expire_keys(
-        self, keys: Union[str, List[str]], ttl: int
-    ) -> Union[int, List[int]]:
+    async def expire_keys(self, keys: str | list[str], ttl: int) -> int | list[int]:
         """Set the expiration time for a specific entry or entries in Redis.
 
         Args:
@@ -1855,13 +1842,13 @@ class AsyncSearchIndex(BaseSearchIndex):
     async def load(
         self,
         data: Iterable[Any],
-        id_field: Optional[str] = None,
-        keys: Optional[Iterable[str]] = None,
-        ttl: Optional[int] = None,
-        preprocess: Optional[Callable] = None,
-        concurrency: Optional[int] = None,
-        batch_size: Optional[int] = None,
-    ) -> List[str]:
+        id_field: str | None = None,
+        keys: Iterable[str] | None = None,
+        ttl: int | None = None,
+        preprocess: Callable | None = None,
+        concurrency: int | None = None,
+        batch_size: int | None = None,
+    ) -> list[str]:
         """Asynchronously load objects to Redis. Returns the list of keys loaded
         to Redis.
 
@@ -1932,7 +1919,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             logger.exception("Error while loading data to Redis")
             raise RedisVLError(f"Failed to load data: {str(exc)}") from exc
 
-    async def fetch(self, id: str) -> Optional[Dict[str, Any]]:
+    async def fetch(self, id: str) -> dict[str, Any] | None:
         """Asynchronously etch an object from Redis by id. The id is typically
         either a unique identifier, or derived from some domain-specific
         metadata combination (like a document id or chunk id).
@@ -1952,7 +1939,7 @@ class AsyncSearchIndex(BaseSearchIndex):
 
     async def _aggregate(
         self, aggregation_query: AggregationQuery
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Execute an aggregation query and processes the results."""
         results = await self.aggregate(
             aggregation_query,
@@ -1989,8 +1976,8 @@ class AsyncSearchIndex(BaseSearchIndex):
             ) from e
 
     async def batch_search(
-        self, queries: List[SearchParams], batch_size: int = 10
-    ) -> List["Result"]:
+        self, queries: list[SearchParams], batch_size: int = 10
+    ) -> list["Result"]:
         """Asynchronously execute a batch of search queries.
 
         This method takes a list of search queries and executes them in batches
@@ -2098,7 +2085,7 @@ class AsyncSearchIndex(BaseSearchIndex):
 
     async def _hybrid_search(
         self, query: HybridQuery, **kwargs
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Perform a hybrid search against the index, combining text and vector search.
 
         Args:
@@ -2147,8 +2134,8 @@ class AsyncSearchIndex(BaseSearchIndex):
         return [convert_bytes(r) for r in results.results]  # type: ignore[union-attr]
 
     async def batch_query(
-        self, queries: List[BaseQuery], batch_size: int = 10
-    ) -> List[List[Dict[str, Any]]]:
+        self, queries: list[BaseQuery], batch_size: int = 10
+    ) -> list[list[dict[str, Any]]]:
         """Asynchronously execute a batch of queries and process results."""
         results = await self.batch_search(
             [(query.query, query.params) for query in queries], batch_size=batch_size
@@ -2167,7 +2154,7 @@ class AsyncSearchIndex(BaseSearchIndex):
 
         return all_parsed
 
-    async def _query(self, query: BaseQuery) -> List[Dict[str, Any]]:
+    async def _query(self, query: BaseQuery) -> list[dict[str, Any]]:
         """Asynchronously execute a query and process results."""
         try:
             self._validate_query(query)
@@ -2176,7 +2163,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         results = await self.search(query.query, query_params=query.params)
         return process_results(results, query=query, schema=self.schema)
 
-    async def _sql_query(self, sql_query: SQLQuery) -> List[Dict[str, Any]]:
+    async def _sql_query(self, sql_query: SQLQuery) -> list[dict[str, Any]]:
         """Asynchronously execute a SQL query and return results.
 
         Args:
@@ -2220,8 +2207,8 @@ class AsyncSearchIndex(BaseSearchIndex):
         return [convert_bytes(row) for row in result.rows]
 
     async def query(
-        self, query: Union[BaseQuery, AggregationQuery, HybridQuery, SQLQuery]
-    ) -> List[Dict[str, Any]]:
+        self, query: BaseQuery | AggregationQuery | HybridQuery | SQLQuery
+    ) -> list[dict[str, Any]]:
         """Asynchronously execute a query on the index.
 
         This method takes a BaseQuery, AggregationQuery, HybridQuery, or SQLQuery object
@@ -2305,7 +2292,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             yield results
             first += page_size
 
-    async def listall(self) -> List[str]:
+    async def listall(self) -> list[str]:
         """List all search indices in Redis database.
 
         Returns:
@@ -2326,7 +2313,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         """
         return self.schema.index.name in await self.listall()
 
-    async def info(self, name: Optional[str] = None) -> Dict[str, Any]:
+    async def info(self, name: str | None = None) -> dict[str, Any]:
         """Get information about the index.
 
         Args:

--- a/redisvl/index/storage.py
+++ b/redisvl/index/storage.py
@@ -1,5 +1,5 @@
 from collections.abc import Collection
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable
 
 from pydantic import BaseModel, ValidationError
 from redis import __version__ as redis_version
@@ -80,7 +80,7 @@ class BaseStorage(BaseModel):
                 # If prefix was only separators, just return the id
                 return id
 
-    def _create_key(self, obj: Dict[str, Any], id_field: Optional[str] = None) -> str:
+    def _create_key(self, obj: dict[str, Any], id_field: str | None = None) -> str:
         """Construct a Redis key for a given object, optionally using a
         specified field from the object as the key.
 
@@ -114,7 +114,7 @@ class BaseStorage(BaseModel):
         )
 
     @staticmethod
-    def _preprocess(obj: Any, preprocess: Optional[Callable] = None) -> Dict[str, Any]:
+    def _preprocess(obj: Any, preprocess: Callable | None = None) -> dict[str, Any]:
         """Apply a preprocessing function to the object if provided.
 
         Args:
@@ -132,8 +132,8 @@ class BaseStorage(BaseModel):
 
     @staticmethod
     def _set(
-        client: RedisClientOrPipeline, key: str, obj: Dict[str, Any]
-    ) -> Union[SyncRedisPipeline, Dict[str, Any]]:
+        client: RedisClientOrPipeline, key: str, obj: dict[str, Any]
+    ) -> SyncRedisPipeline | dict[str, Any]:
         """Synchronously set the value in Redis for the given key.
 
         Args:
@@ -145,22 +145,22 @@ class BaseStorage(BaseModel):
 
     @staticmethod
     async def _aset(
-        client: AsyncRedisClientOrPipeline, key: str, obj: Dict[str, Any]
-    ) -> Union[AsyncRedisPipeline, Dict[str, Any]]:
+        client: AsyncRedisClientOrPipeline, key: str, obj: dict[str, Any]
+    ) -> AsyncRedisPipeline | dict[str, Any]:
         """Asynchronously set data in Redis using the provided client or pipeline."""
         raise NotImplementedError
 
     @staticmethod
     def _get(
         client: RedisClientOrPipeline, key: str
-    ) -> Union[SyncRedisPipeline, Dict[str, Any]]:
+    ) -> SyncRedisPipeline | dict[str, Any]:
         """Synchronously get data from Redis using the provided client or pipeline."""
         raise NotImplementedError
 
     @staticmethod
     async def _aget(
         client: AsyncRedisClientOrPipeline, key: str
-    ) -> Union[AsyncRedisPipeline, Dict[str, Any]]:
+    ) -> AsyncRedisPipeline | dict[str, Any]:
         """Asynchronously get data from Redis using the provided client or pipeline."""
         raise NotImplementedError
 
@@ -178,7 +178,7 @@ class BaseStorage(BaseModel):
         else:
             await client.expire(key, ttl)
 
-    def _validate(self, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate(self, obj: dict[str, Any]) -> dict[str, Any]:
         """
         Validate an object against the schema using Pydantic-based validation.
 
@@ -196,12 +196,12 @@ class BaseStorage(BaseModel):
 
     def _get_keys(
         self,
-        objects: List[Any],
-        keys: Optional[Iterable[str]] = None,
-        id_field: Optional[str] = None,
-    ) -> List[str]:
+        objects: list[Any],
+        keys: Iterable[str] | None = None,
+        id_field: str | None = None,
+    ) -> list[str]:
         """Generate Redis keys for a list of objects."""
-        generated_keys: List[str] = []
+        generated_keys: list[str] = []
         keys_iterator = iter(keys) if keys else None
 
         if keys and len(list(keys)) != len(objects):
@@ -218,7 +218,7 @@ class BaseStorage(BaseModel):
         return generated_keys
 
     def _create_readable_validation_error_message(
-        self, validation_error: ValidationError, obj_index: int, obj: Dict[str, Any]
+        self, validation_error: ValidationError, obj_index: int, obj: dict[str, Any]
     ) -> str:
         """
         Create a human-readable error message from a Pydantic ValidationError.
@@ -294,11 +294,11 @@ class BaseStorage(BaseModel):
     def _preprocess_and_validate_objects(
         self,
         objects: Iterable[Any],
-        id_field: Optional[str] = None,
-        keys: Optional[Iterable[str]] = None,
-        preprocess: Optional[Callable] = None,
+        id_field: str | None = None,
+        keys: Iterable[str] | None = None,
+        preprocess: Callable | None = None,
         validate: bool = False,
-    ) -> List[Tuple[str, Dict[str, Any]]]:
+    ) -> list[tuple[str, dict[str, Any]]]:
         """
         Preprocess and validate a list of objects with fail-fast approach.
 
@@ -357,13 +357,13 @@ class BaseStorage(BaseModel):
         self,
         redis_client: SyncRedisClient,
         objects: Iterable[Any],
-        id_field: Optional[str] = None,
-        keys: Optional[Iterable[str]] = None,
-        ttl: Optional[int] = None,
-        preprocess: Optional[Callable] = None,
-        batch_size: Optional[int] = None,
+        id_field: str | None = None,
+        keys: Iterable[str] | None = None,
+        ttl: int | None = None,
+        preprocess: Callable | None = None,
+        batch_size: int | None = None,
         validate: bool = False,
-    ) -> List[str]:
+    ) -> list[str]:
         """Write a batch of objects to Redis as hash entries. This method
         returns a list of Redis keys written to the database.
 
@@ -432,13 +432,13 @@ class BaseStorage(BaseModel):
         self,
         redis_client: AsyncRedisClient,
         objects: Iterable[Any],
-        id_field: Optional[str] = None,
-        keys: Optional[Iterable[str]] = None,
-        ttl: Optional[int] = None,
-        batch_size: Optional[int] = None,
-        preprocess: Optional[Callable] = None,
+        id_field: str | None = None,
+        keys: Iterable[str] | None = None,
+        ttl: int | None = None,
+        batch_size: int | None = None,
+        preprocess: Callable | None = None,
         validate: bool = False,
-    ) -> List[str]:
+    ) -> list[str]:
         """Asynchronously write objects to Redis as hash entries using pipeline batching.
         The method returns a list of keys written to the database.
 
@@ -511,8 +511,8 @@ class BaseStorage(BaseModel):
         self,
         redis_client: SyncRedisClient,
         keys: Collection[str],
-        batch_size: Optional[int] = None,
-    ) -> List[Dict[str, Any]]:
+        batch_size: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Retrieve objects from Redis by keys.
 
         Args:
@@ -525,7 +525,7 @@ class BaseStorage(BaseModel):
         Returns:
             List[Dict[str, Any]]: List of objects pulled from redis.
         """
-        results: List = []
+        results: list[Any] = []
 
         if not isinstance(keys, Collection):
             raise TypeError("Keys must be a collection of strings")
@@ -552,8 +552,8 @@ class BaseStorage(BaseModel):
         self,
         redis_client: AsyncRedisClient,
         keys: Collection[str],
-        batch_size: Optional[int] = None,
-    ) -> List[Dict[str, Any]]:
+        batch_size: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Asynchronously retrieve objects from Redis by keys.
 
         Args:
@@ -567,7 +567,7 @@ class BaseStorage(BaseModel):
             Dict[str, Any]: Dictionary with keys and their corresponding
                 objects.
         """
-        results: List = []
+        results: list[Any] = []
 
         if not isinstance(keys, Collection):
             raise TypeError("Keys must be a collection of strings")
@@ -603,7 +603,7 @@ class HashStorage(BaseStorage):
     """Hash data type for the index"""
 
     @staticmethod
-    def _set(client: RedisClientOrPipeline, key: str, obj: Dict[str, Any]):
+    def _set(client: RedisClientOrPipeline, key: str, obj: dict[str, Any]):
         """Synchronously set a hash value in Redis for the given key.
 
         Args:
@@ -614,7 +614,7 @@ class HashStorage(BaseStorage):
         client.hset(name=key, mapping=obj)
 
     @staticmethod
-    async def _aset(client: AsyncRedisClientOrPipeline, key: str, obj: Dict[str, Any]):
+    async def _aset(client: AsyncRedisClientOrPipeline, key: str, obj: dict[str, Any]):
         """Asynchronously set a hash value in Redis for the given key.
 
         Args:
@@ -628,7 +628,7 @@ class HashStorage(BaseStorage):
             await client.hset(name=key, mapping=obj)  # type: ignore
 
     @staticmethod
-    def _get(client: SyncRedisClient, key: str) -> Dict[str, Any]:
+    def _get(client: SyncRedisClient, key: str) -> dict[str, Any]:
         """Synchronously retrieve a hash value from Redis for the given key.
 
         Args:
@@ -643,7 +643,7 @@ class HashStorage(BaseStorage):
     @staticmethod
     async def _aget(
         client: AsyncRedisClientOrPipeline, key: str
-    ) -> Union[AsyncRedisPipeline, Dict[str, Any]]:
+    ) -> AsyncRedisPipeline | dict[str, Any]:
         """Asynchronously retrieve a hash value from Redis for the given key.
 
         Args:
@@ -671,7 +671,7 @@ class JsonStorage(BaseStorage):
     """JSON data type for the index"""
 
     @staticmethod
-    def _set(client: RedisClientOrPipeline, key: str, obj: Dict[str, Any]):
+    def _set(client: RedisClientOrPipeline, key: str, obj: dict[str, Any]):
         """Synchronously set a JSON obj in Redis for the given key.
 
         Args:
@@ -682,7 +682,7 @@ class JsonStorage(BaseStorage):
         client.json().set(key, "$", obj)
 
     @staticmethod
-    async def _aset(client: AsyncRedisClientOrPipeline, key: str, obj: Dict[str, Any]):
+    async def _aset(client: AsyncRedisClientOrPipeline, key: str, obj: dict[str, Any]):
         """Asynchronously set a JSON obj in Redis for the given key.
 
         Args:
@@ -696,7 +696,7 @@ class JsonStorage(BaseStorage):
             await client.json().set(key, "$", obj)  # type: ignore[return-value, misc]
 
     @staticmethod
-    def _get(client: RedisClientOrPipeline, key: str) -> Dict[str, Any]:
+    def _get(client: RedisClientOrPipeline, key: str) -> dict[str, Any]:
         """Synchronously retrieve a JSON obj from Redis for the given key.
 
         Args:
@@ -709,7 +709,7 @@ class JsonStorage(BaseStorage):
         return client.json().get(key)  # type: ignore[return-value, misc]
 
     @staticmethod
-    async def _aget(client: AsyncRedisClientOrPipeline, key: str) -> Dict[str, Any]:
+    async def _aget(client: AsyncRedisClientOrPipeline, key: str) -> dict[str, Any]:
         """Asynchronously retrieve a JSON object from Redis for the given key.
 
         Args:

--- a/redisvl/mcp/config.py
+++ b/redisvl/mcp/config.py
@@ -2,7 +2,7 @@ import os
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -81,11 +81,11 @@ class MCPVectorizerConfig(BaseModel):
     model: str = Field(..., min_length=1)
 
     @property
-    def extra_kwargs(self) -> Dict[str, Any]:
+    def extra_kwargs(self) -> dict[str, Any]:
         """Return vectorizer kwargs other than the normalized `class` and `model`."""
         return dict(self.model_extra or {})
 
-    def to_init_kwargs(self) -> Dict[str, Any]:
+    def to_init_kwargs(self) -> dict[str, Any]:
         """Build kwargs suitable for directly instantiating the vectorizer."""
         return {"model": self.model, **self.extra_kwargs}
 
@@ -105,7 +105,7 @@ class MCPIndexSearchConfig(BaseModel):
     """
 
     type: Literal["vector", "fulltext", "hybrid"]
-    params: Dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_params(self) -> "MCPIndexSearchConfig":
@@ -155,7 +155,7 @@ class MCPIndexSearchConfig(BaseModel):
             )
         return self
 
-    def to_query_params(self) -> Dict[str, Any]:
+    def to_query_params(self) -> dict[str, Any]:
         """Return normalized query kwargs exactly as configured."""
         return dict(self.params)
 
@@ -195,8 +195,8 @@ class MCPSchemaOverrideField(BaseModel):
 
     name: str = Field(..., min_length=1)
     type: str = Field(..., min_length=1)
-    path: Optional[str] = None
-    attrs: Dict[str, Any] = Field(default_factory=dict)
+    path: str | None = None
+    attrs: dict[str, Any] = Field(default_factory=dict)
 
 
 class MCPSchemaOverrides(BaseModel):
@@ -219,7 +219,7 @@ class MCPConfig(BaseModel):
     """Validated MCP server configuration loaded from YAML."""
 
     server: MCPServerConfig
-    indexes: Dict[str, MCPIndexBindingConfig]
+    indexes: dict[str, MCPIndexBindingConfig]
 
     @model_validator(mode="after")
     def _validate_bindings(self) -> "MCPConfig":
@@ -265,8 +265,8 @@ class MCPConfig(BaseModel):
         return self.binding.redis_name
 
     def inspected_schema_from_index_info(
-        self, index_info: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, index_info: dict[str, Any]
+    ) -> dict[str, Any]:
         """Build a schema dict from FT.INFO while preserving discovered field identity.
 
         RedisVL's generic FT.INFO conversion omits vector fields when their attrs are
@@ -301,8 +301,8 @@ class MCPConfig(BaseModel):
         return schema_dict
 
     def merge_schema_overrides(
-        self, inspected_schema: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, inspected_schema: dict[str, Any]
+    ) -> dict[str, Any]:
         """Apply validated schema overrides without allowing identity changes."""
         merged_schema = deepcopy(inspected_schema)
         merged_fields = merged_schema.setdefault("fields", [])
@@ -364,7 +364,7 @@ class MCPConfig(BaseModel):
                 f"runtime.vector_field_name '{self.runtime.vector_field_name}' must reference a vector field"
             )
 
-    def to_index_schema(self, inspected_schema: Dict[str, Any]) -> IndexSchema:
+    def to_index_schema(self, inspected_schema: dict[str, Any]) -> IndexSchema:
         """Apply overrides to an inspected schema and validate the effective result."""
         merged_schema = self.merge_schema_overrides(inspected_schema)
         schema = IndexSchema.model_validate(merged_schema)
@@ -375,7 +375,7 @@ class MCPConfig(BaseModel):
         """Return the effective vector field from a validated schema."""
         return schema.fields[self.runtime.vector_field_name]
 
-    def get_vector_field_dims(self, schema: IndexSchema) -> Optional[int]:
+    def get_vector_field_dims(self, schema: IndexSchema) -> int | None:
         """Return the effective vector dimensions when the field exposes them."""
         attrs = self.get_vector_field(schema).attrs
         return getattr(attrs, "dims", None)

--- a/redisvl/mcp/errors.py
+++ b/redisvl/mcp/errors.py
@@ -1,6 +1,6 @@
 import asyncio
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any
 
 from pydantic import ValidationError
 from redis.exceptions import RedisError
@@ -27,7 +27,7 @@ class RedisVLMCPError(Exception):
         *,
         code: MCPErrorCode,
         retryable: bool,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(message)
         self.code = code

--- a/redisvl/mcp/filters.py
+++ b/redisvl/mcp/filters.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Iterable
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.query.filter import FilterExpression, Num, Tag, Text
@@ -6,8 +6,8 @@ from redisvl.schema import IndexSchema
 
 
 def parse_filter(
-    value: Optional[Union[str, Dict[str, Any]]], schema: IndexSchema
-) -> Optional[Union[str, FilterExpression]]:
+    value: str | dict[str, Any] | None, schema: IndexSchema
+) -> str | FilterExpression | None:
     """Parse an MCP filter value into a RedisVL filter representation."""
     if value is None:
         return None
@@ -22,7 +22,7 @@ def parse_filter(
     return _parse_expression(value, schema)
 
 
-def _parse_expression(value: Dict[str, Any], schema: IndexSchema) -> FilterExpression:
+def _parse_expression(value: dict[str, Any], schema: IndexSchema) -> FilterExpression:
     logical_keys = [key for key in ("and", "or", "not") if key in value]
     if logical_keys:
         if len(logical_keys) != 1 or len(value) != 1:
@@ -51,7 +51,7 @@ def _parse_expression(value: Dict[str, Any], schema: IndexSchema) -> FilterExpre
                 retryable=False,
             )
 
-        expressions: List[FilterExpression] = []
+        expressions: list[FilterExpression] = []
         for child in children:
             if not isinstance(child, dict):
                 raise RedisVLMCPError(
@@ -203,7 +203,7 @@ def _require_string(value: Any, field_name: str, op: str) -> str:
     return value
 
 
-def _require_string_list(value: Any, field_name: str, op: str) -> List[str]:
+def _require_string_list(value: Any, field_name: str, op: str) -> list[str]:
     if not isinstance(value, list) or not value:
         raise RedisVLMCPError(
             f"filter value for field '{field_name}' and operator '{op}' must be a non-empty array",
@@ -214,7 +214,7 @@ def _require_string_list(value: Any, field_name: str, op: str) -> List[str]:
     return strings
 
 
-def _require_number(value: Any, field_name: str, op: str) -> Union[int, float]:
+def _require_number(value: Any, field_name: str, op: str) -> int | float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RedisVLMCPError(
             f"filter value for field '{field_name}' and operator '{op}' must be numeric",
@@ -224,9 +224,7 @@ def _require_number(value: Any, field_name: str, op: str) -> Union[int, float]:
     return value
 
 
-def _require_number_list(
-    value: Any, field_name: str, op: str
-) -> List[Union[int, float]]:
+def _require_number_list(value: Any, field_name: str, op: str) -> list[int | float]:
     if not isinstance(value, list) or not value:
         raise RedisVLMCPError(
             f"filter value for field '{field_name}' and operator '{op}' must be a non-empty array",

--- a/redisvl/mcp/server.py
+++ b/redisvl/mcp/server.py
@@ -2,7 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from enum import Enum, auto
 from importlib import import_module
-from typing import Any, Awaitable, Optional, Type
+from typing import Any, Awaitable
 
 from redis import __version__ as redis_py_version
 
@@ -27,7 +27,7 @@ except ImportError:
             self.kwargs = kwargs
 
 
-def resolve_vectorizer_class(class_name: str) -> Type[Any]:
+def resolve_vectorizer_class(class_name: str) -> type[Any]:
     """Resolve a vectorizer class from the public RedisVL vectorizer module."""
     vectorize_module = import_module("redisvl.utils.vectorize")
     try:
@@ -52,11 +52,11 @@ class RedisVLMCPServer(FastMCP):
     def __init__(self, settings: MCPSettings):
         """Create a server shell with lazy config, index, and vectorizer state."""
         self.mcp_settings = settings
-        self.config: Optional[MCPConfig] = None
-        self._index: Optional[AsyncSearchIndex] = None
-        self._vectorizer: Optional[Any] = None
-        self._supports_native_hybrid_search: Optional[bool] = None
-        self._semaphore: Optional[asyncio.Semaphore] = None
+        self.config: MCPConfig | None = None
+        self._index: AsyncSearchIndex | None = None
+        self._vectorizer: Any | None = None
+        self._supports_native_hybrid_search: bool | None = None
+        self._semaphore: asyncio.Semaphore | None = None
         self._tools_registered = False
 
         # Lifecycle management
@@ -213,7 +213,7 @@ class RedisVLMCPServer(FastMCP):
         finally:
             await self.shutdown()
 
-    async def _teardown_runtime(self, client: Optional[Any] = None) -> None:
+    async def _teardown_runtime(self, client: Any | None = None) -> None:
         """Release runtime resources and clear terminal state."""
         vectorizer = self._vectorizer
         index = self._index

--- a/redisvl/mcp/settings.py
+++ b/redisvl/mcp/settings.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -14,17 +14,17 @@ class MCPSettings(BaseSettings):
 
     config: str = Field(..., min_length=1)
     read_only: bool = False
-    tool_search_description: Optional[str] = None
-    tool_upsert_description: Optional[str] = None
+    tool_search_description: str | None = None
+    tool_upsert_description: str | None = None
 
     @classmethod
     def from_env(
         cls,
         *,
-        config: Optional[str] = None,
-        read_only: Optional[bool] = None,
-        tool_search_description: Optional[str] = None,
-        tool_upsert_description: Optional[str] = None,
+        config: str | None = None,
+        read_only: bool | None = None,
+        tool_search_description: str | None = None,
+        tool_upsert_description: str | None = None,
     ) -> "MCPSettings":
         """Build settings from explicit overrides plus `REDISVL_MCP_*` env vars."""
         overrides: dict[str, object] = {}

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -1,6 +1,6 @@
 import asyncio
 import inspect
-from typing import Any, Optional, Union
+from typing import Any
 
 from redisvl.mcp.config import reserved_score_metadata_field_names
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError, map_exception
@@ -28,9 +28,9 @@ _FALLBACK_HYBRID_UNSUPPORTED_PARAMS = frozenset(
 def _validate_request(
     *,
     query: str,
-    limit: Optional[int],
+    limit: int | None,
     offset: int,
-    return_fields: Optional[list[str]],
+    return_fields: list[str] | None,
     server: Any,
     index: Any,
 ) -> tuple[int, list[str]]:
@@ -258,7 +258,7 @@ async def _build_query(
     query: str,
     limit: int,
     offset: int,
-    filter_value: Optional[Union[str, dict[str, Any]]],
+    filter_value: str | dict[str, Any] | None,
     return_fields: list[str],
 ) -> tuple[Any, str, str, str]:
     """Build the RedisVL query object from configured search mode and params.
@@ -356,10 +356,10 @@ async def search_records(
     server: Any,
     *,
     query: str,
-    limit: Optional[int] = None,
+    limit: int | None = None,
     offset: int = 0,
-    filter: Optional[Union[str, dict[str, Any]]] = None,
-    return_fields: Optional[list[str]] = None,
+    filter: str | dict[str, Any] | None = None,
+    return_fields: list[str] | None = None,
 ) -> dict[str, Any]:
     """Execute `search-records` against the configured Redis index binding."""
     try:
@@ -413,10 +413,10 @@ def register_search_tool(server: Any) -> None:
 
     async def search_records_tool(
         query: str,
-        limit: Optional[int] = None,
+        limit: int | None = None,
         offset: int = 0,
-        filter: Optional[Union[str, dict[str, Any]]] = None,
-        return_fields: Optional[list[str]] = None,
+        filter: str | dict[str, Any] | None = None,
+        return_fields: list[str] | None = None,
     ):
         """FastMCP wrapper for the `search-records` tool."""
         return await search_records(

--- a/redisvl/mcp/tools/upsert.py
+++ b/redisvl/mcp/tools/upsert.py
@@ -1,7 +1,7 @@
 import asyncio
 import inspect
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError, map_exception
 from redisvl.redis.utils import array_to_buffer
@@ -14,9 +14,9 @@ DEFAULT_UPSERT_DESCRIPTION = "Upsert records in the configured Redis index."
 def _validate_request(
     *,
     server: Any,
-    records: List[Dict[str, Any]],
-    id_field: Optional[str],
-    skip_embedding_if_present: Optional[bool],
+    records: list[dict[str, Any]],
+    id_field: str | None,
+    skip_embedding_if_present: bool | None,
 ) -> bool:
     """Validate the public upsert request contract and resolve defaults."""
     runtime = server.config.runtime
@@ -71,7 +71,7 @@ def _validate_request(
 
 
 def _record_needs_embedding(
-    record: Dict[str, Any],
+    record: dict[str, Any],
     *,
     vector_field_name: str,
     skip_embedding_if_present: bool,
@@ -85,12 +85,12 @@ def _record_needs_embedding(
 
 
 def _validate_embed_sources(
-    records: List[Dict[str, Any]],
+    records: list[dict[str, Any]],
     *,
     embed_text_field: str,
     vector_field_name: str,
     skip_embedding_if_present: bool,
-) -> List[str]:
+) -> list[str]:
     """Collect embed sources for records that require embedding."""
     contents = []
     for record in records:
@@ -114,7 +114,7 @@ def _validate_embed_sources(
     return contents
 
 
-async def _embed_one(vectorizer: Any, content: str) -> List[float]:
+async def _embed_one(vectorizer: Any, content: str) -> list[float]:
     """Embed one record, falling back from async to sync implementations."""
     aembed = getattr(vectorizer, "aembed", None)
     if callable(aembed):
@@ -131,7 +131,7 @@ async def _embed_one(vectorizer: Any, content: str) -> List[float]:
     return await asyncio.to_thread(embed, content)
 
 
-async def _embed_many(vectorizer: Any, contents: List[str]) -> List[List[float]]:
+async def _embed_many(vectorizer: Any, contents: list[str]) -> list[list[float]]:
     """Embed multiple records with batch-first fallbacks."""
     if not contents:
         return []
@@ -166,7 +166,7 @@ def _validation_schema_for_record(
     index: Any,
     *,
     vector_field_name: str,
-    record: Dict[str, Any],
+    record: dict[str, Any],
 ) -> Any:
     """Use a JSON-shaped schema when validating list vectors for HASH storage."""
     if index.schema.index.storage_type == StorageType.HASH and isinstance(
@@ -179,7 +179,7 @@ def _validation_schema_for_record(
 
 
 def _validate_record(
-    record: Dict[str, Any], *, index: Any, vector_field_name: str
+    record: dict[str, Any], *, index: Any, vector_field_name: str
 ) -> None:
     """Validate one record against the schema, allowing HASH list vectors."""
     validate_object(
@@ -193,11 +193,11 @@ def _validate_record(
 
 
 def _prepare_record_for_storage(
-    record: Dict[str, Any],
+    record: dict[str, Any],
     *,
     server: Any,
     index: Any,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Validate records before serializing HASH vectors for storage."""
     prepared = dict(record)
     vector_field_name = server.config.runtime.vector_field_name
@@ -217,10 +217,10 @@ def _prepare_record_for_storage(
 async def upsert_records(
     server: Any,
     *,
-    records: List[Dict[str, Any]],
-    id_field: Optional[str] = None,
-    skip_embedding_if_present: Optional[bool] = None,
-) -> Dict[str, Any]:
+    records: list[dict[str, Any]],
+    id_field: str | None = None,
+    skip_embedding_if_present: bool | None = None,
+) -> dict[str, Any]:
     """Execute `upsert-records` against the configured Redis index."""
     try:
         index = await server.get_index()
@@ -295,9 +295,9 @@ def register_upsert_tool(server: Any) -> None:
     )
 
     async def upsert_records_tool(
-        records: List[Dict[str, Any]],
-        id_field: Optional[str] = None,
-        skip_embedding_if_present: Optional[bool] = None,
+        records: list[dict[str, Any]],
+        id_field: str | None = None,
+        skip_embedding_if_present: bool | None = None,
     ):
         """FastMCP wrapper for the `upsert-records` tool."""
         return await upsert_records(

--- a/redisvl/query/aggregate.py
+++ b/redisvl/query/aggregate.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from redis.commands.search.aggregation import AggregateRequest, Desc
@@ -26,7 +26,7 @@ class Vector(BaseModel):
     max_distance: The maximum distance for vector range search (default: 2.0, range: [0.0, 2.0])
     """
 
-    vector: Union[List[float], bytes]
+    vector: list[float] | bytes
     field_name: str
     dtype: str = "float32"
     weight: float = 1.0
@@ -109,17 +109,17 @@ class AggregateHybridQuery(AggregationQuery):
         self,
         text: str,
         text_field_name: str,
-        vector: Union[bytes, List[float]],
+        vector: bytes | list[float],
         vector_field_name: str,
         text_scorer: str = "BM25STD",
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
+        filter_expression: str | FilterExpression | None = None,
         alpha: float = 0.7,
         dtype: str = "float32",
         num_results: int = 10,
-        return_fields: Optional[List[str]] = None,
-        stopwords: Optional[Union[str, Set[str]]] = "english",
+        return_fields: list[str] | None = None,
+        stopwords: str | set[str] | None = "english",
         dialect: int = 2,
-        text_weights: Optional[Dict[str, float]] = None,
+        text_weights: dict[str, float] | None = None,
     ):
         """
         Instantiates a AggregateHybridQuery object.
@@ -196,7 +196,7 @@ class AggregateHybridQuery(AggregationQuery):
             self.load(*return_fields)  # type: ignore[arg-type]
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         """Return the parameters for the aggregation.
 
         Returns:
@@ -207,12 +207,12 @@ class AggregateHybridQuery(AggregationQuery):
         else:
             vector = self._vector
 
-        params: Dict[str, Any] = {self.VECTOR_PARAM: vector}
+        params: dict[str, Any] = {self.VECTOR_PARAM: vector}
 
         return params
 
     @property
-    def stopwords(self) -> Set[str]:
+    def stopwords(self) -> set[str]:
         """Return the stopwords used in the query.
         Returns:
             Set[str]: The stopwords used in the query.
@@ -220,7 +220,7 @@ class AggregateHybridQuery(AggregationQuery):
         return self._ft_helper.stopwords
 
     @property
-    def text_weights(self) -> Dict[str, float]:
+    def text_weights(self) -> dict[str, float]:
         """Get the text weights.
 
         Returns:
@@ -228,7 +228,7 @@ class AggregateHybridQuery(AggregationQuery):
         """
         return self._ft_helper.text_weights
 
-    def set_text_weights(self, weights: Dict[str, float]):
+    def set_text_weights(self, weights: dict[str, float]):
         """Set or update the text weights for the query.
 
         Args:
@@ -305,13 +305,13 @@ class MultiVectorQuery(AggregationQuery):
         results = index.query(query)
     """
 
-    _vectors: List[Vector]
+    _vectors: list[Vector]
 
     def __init__(
         self,
-        vectors: Union[Vector, List[Vector]],
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
+        vectors: Vector | list[Vector],
+        return_fields: list[str] | None = None,
+        filter_expression: str | FilterExpression | None = None,
         num_results: int = 10,
         dialect: int = 2,
     ):
@@ -361,7 +361,7 @@ class MultiVectorQuery(AggregationQuery):
             self.load(*return_fields)  # type: ignore[arg-type]
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         """Return the parameters for the aggregation.
 
         Returns:

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -2,7 +2,7 @@ import datetime
 import re
 from enum import Enum
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable
 
 from redisvl.utils.token_escaper import TokenEscaper
 
@@ -39,7 +39,7 @@ class FilterOperator(Enum):
 
 class FilterField:
     escaper: TokenEscaper = TokenEscaper()
-    OPERATORS: Dict[FilterOperator, str] = {}
+    OPERATORS: dict[FilterOperator, str] = {}
 
     def __init__(self, field: str):
         self._field = field
@@ -54,7 +54,7 @@ class FilterField:
     def _set_value(
         self,
         val: Any,
-        val_type: Union[type, Tuple[type, ...]],
+        val_type: type | tuple[type, ...],
         operator: FilterOperator,
     ):
         # check that the operator is supported by this class
@@ -94,7 +94,7 @@ class FilterField:
 
 def check_operator_misuse(func: Callable) -> Callable:
     @wraps(func)
-    def wrapper(instance: Any, *args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+    def wrapper(instance: Any, *args: list[Any], **kwargs: dict[str, Any]) -> Any:
         # Extracting 'other' from positional arguments or keyword arguments
         other = kwargs.get("other") if "other" in kwargs else None
         if not other:
@@ -116,13 +116,13 @@ def check_operator_misuse(func: Callable) -> Callable:
 class Tag(FilterField):
     """A Tag filter can be applied to Tag fields"""
 
-    OPERATORS: Dict[FilterOperator, str] = {
+    OPERATORS: dict[FilterOperator, str] = {
         FilterOperator.EQ: "==",
         FilterOperator.NE: "!=",
         FilterOperator.IN: "==",
         FilterOperator.LIKE: "%",
     }
-    OPERATOR_MAP: Dict[FilterOperator, str] = {
+    OPERATOR_MAP: dict[FilterOperator, str] = {
         FilterOperator.EQ: "@%s:{%s}",
         FilterOperator.NE: "(-@%s:{%s})",
         FilterOperator.IN: "@%s:{%s}",
@@ -131,7 +131,7 @@ class Tag(FilterField):
     SUPPORTED_VAL_TYPES = (list, set, tuple, str, type(None))
 
     def _set_tag_value(
-        self, other: Union[List[str], Set[str], str], operator: FilterOperator
+        self, other: list[str] | set[str] | str, operator: FilterOperator
     ):
         if isinstance(other, (list, set, tuple)):
             try:
@@ -148,7 +148,7 @@ class Tag(FilterField):
         self._set_value(other, self.SUPPORTED_VAL_TYPES, operator)
 
     @check_operator_misuse
-    def __eq__(self, other: Union[List[str], str]) -> "FilterExpression":
+    def __eq__(self, other: list[str] | str) -> "FilterExpression":
         """Create a Tag equality filter expression.
 
         Args:
@@ -164,7 +164,7 @@ class Tag(FilterField):
         return FilterExpression(str(self))
 
     @check_operator_misuse
-    def __ne__(self, other: Union[List[str], str]) -> "FilterExpression":
+    def __ne__(self, other: list[str] | str) -> "FilterExpression":
         """Create a Tag inequality filter expression.
 
         Args:
@@ -179,7 +179,7 @@ class Tag(FilterField):
         self._set_tag_value(other, FilterOperator.NE)
         return FilterExpression(str(self))
 
-    def __mod__(self, other: Union[List[str], str]) -> "FilterExpression":
+    def __mod__(self, other: list[str] | str) -> "FilterExpression":
         """Create a Tag wildcard filter expression for pattern matching.
 
         This enables wildcard pattern matching on tag fields using the ``*``
@@ -262,7 +262,7 @@ class GeoRadius(GeoSpec):
         super().__init__(longitude, latitude, unit)
         self._radius = radius
 
-    def get_args(self) -> List[Union[float, int, str]]:
+    def get_args(self) -> list[float | int | str]:
         return [self._longitude, self._latitude, self._radius, self._unit]
 
 
@@ -270,11 +270,11 @@ class Geo(FilterField):
     """A Geo is a FilterField representing a geographic (lat/lon) field in a
     Redis index."""
 
-    OPERATORS: Dict[FilterOperator, str] = {
+    OPERATORS: dict[FilterOperator, str] = {
         FilterOperator.EQ: "==",
         FilterOperator.NE: "!=",
     }
-    OPERATOR_MAP: Dict[FilterOperator, str] = {
+    OPERATOR_MAP: dict[FilterOperator, str] = {
         FilterOperator.EQ: "@%s:[%s %s %i %s]",
         FilterOperator.NE: "(-@%s:[%s %s %i %s])",
     }
@@ -328,7 +328,7 @@ class Geo(FilterField):
 class Num(FilterField):
     """A Num is a FilterField representing a numeric field in a Redis index."""
 
-    OPERATORS: Dict[FilterOperator, str] = {
+    OPERATORS: dict[FilterOperator, str] = {
         FilterOperator.EQ: "==",
         FilterOperator.NE: "!=",
         FilterOperator.LT: "<",
@@ -337,7 +337,7 @@ class Num(FilterField):
         FilterOperator.GE: ">=",
         FilterOperator.BETWEEN: "between",
     }
-    OPERATOR_MAP: Dict[FilterOperator, str] = {
+    OPERATOR_MAP: dict[FilterOperator, str] = {
         FilterOperator.EQ: "@%s:[%s %s]",
         FilterOperator.NE: "(-@%s:[%s %s])",
         FilterOperator.GT: "@%s:[(%s +inf]",
@@ -349,7 +349,7 @@ class Num(FilterField):
 
     SUPPORTED_VAL_TYPES = (int, float, tuple, type(None))
 
-    def __eq__(self, other: Union[int, float]) -> "FilterExpression":
+    def __eq__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric equality filter expression.
 
         Args:
@@ -364,7 +364,7 @@ class Num(FilterField):
         self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.EQ)
         return FilterExpression(str(self))
 
-    def __ne__(self, other: Union[int, float]) -> "FilterExpression":
+    def __ne__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric inequality filter expression.
 
         Args:
@@ -380,7 +380,7 @@ class Num(FilterField):
         self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.NE)
         return FilterExpression(str(self))
 
-    def __gt__(self, other: Union[int, float]) -> "FilterExpression":
+    def __gt__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric greater than filter expression.
 
         Args:
@@ -396,7 +396,7 @@ class Num(FilterField):
         self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.GT)
         return FilterExpression(str(self))
 
-    def __lt__(self, other: Union[int, float]) -> "FilterExpression":
+    def __lt__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric less than filter expression.
 
         Args:
@@ -412,7 +412,7 @@ class Num(FilterField):
         self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.LT)
         return FilterExpression(str(self))
 
-    def __ge__(self, other: Union[int, float]) -> "FilterExpression":
+    def __ge__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric greater than or equal to filter expression.
 
         Args:
@@ -428,7 +428,7 @@ class Num(FilterField):
         self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.GE)
         return FilterExpression(str(self))
 
-    def __le__(self, other: Union[int, float]) -> "FilterExpression":
+    def __le__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric less than or equal to filter expression.
 
         Args:
@@ -502,12 +502,12 @@ class Num(FilterField):
 class Text(FilterField):
     """A Text is a FilterField representing a text field in a Redis index."""
 
-    OPERATORS: Dict[FilterOperator, str] = {
+    OPERATORS: dict[FilterOperator, str] = {
         FilterOperator.EQ: "==",
         FilterOperator.NE: "!=",
         FilterOperator.LIKE: "%",
     }
-    OPERATOR_MAP: Dict[FilterOperator, str] = {
+    OPERATOR_MAP: dict[FilterOperator, str] = {
         FilterOperator.EQ: '@%s:("%s")',
         FilterOperator.NE: '(-@%s:"%s")',
         FilterOperator.LIKE: "@%s:(%s)",
@@ -626,10 +626,10 @@ class FilterExpression:
 
     def __init__(
         self,
-        _filter: Optional[str] = None,
-        operator: Optional[FilterOperator] = None,
-        left: Optional["FilterExpression"] = None,
-        right: Optional["FilterExpression"] = None,
+        _filter: str | None = None,
+        operator: FilterOperator | None = None,
+        left: "FilterExpression | None" = None,
+        right: "FilterExpression | None" = None,
     ):
         self._filter = _filter
         self._operator = operator
@@ -760,7 +760,7 @@ class Timestamp(Num):
         raise TypeError(f"Unsupported type for timestamp conversion: {type(value)}")
 
     def __eq__(
-        self, other: Union[datetime.datetime, datetime.date, str, int, float]
+        self, other: datetime.datetime | datetime.date | str | int | float
     ) -> FilterExpression:
         """
         Filter for timestamps equal to the specified value.
@@ -790,7 +790,7 @@ class Timestamp(Num):
         return FilterExpression(str(self))
 
     def __ne__(
-        self, other: Union[datetime.datetime, datetime.date, str, int, float]
+        self, other: datetime.datetime | datetime.date | str | int | float
     ) -> FilterExpression:
         """
         Filter for timestamps not equal to the specified value.

--- a/redisvl/query/hybrid.py
+++ b/redisvl/query/hybrid.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Set, Union
+from typing import Any, Literal
 
 from redis.commands.search.query import Filter
 
@@ -47,27 +47,27 @@ class HybridQuery:
         self,
         text: str,
         text_field_name: str,
-        vector: Union[bytes, List[float]],
+        vector: bytes | list[float],
         vector_field_name: str,
         vector_param_name: str = "vector",
         text_scorer: str = "BM25STD",
-        yield_text_score_as: Optional[str] = None,
-        vector_search_method: Optional[Literal["KNN", "RANGE"]] = None,
+        yield_text_score_as: str | None = None,
+        vector_search_method: Literal["KNN", "RANGE"] | None = None,
         knn_ef_runtime: int = 10,
-        range_radius: Optional[float] = None,
+        range_radius: float | None = None,
         range_epsilon: float = 0.01,
-        yield_vsim_score_as: Optional[str] = None,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
-        combination_method: Optional[Literal["RRF", "LINEAR"]] = None,
+        yield_vsim_score_as: str | None = None,
+        filter_expression: str | FilterExpression | None = None,
+        combination_method: Literal["RRF", "LINEAR"] | None = None,
         rrf_window: int = 20,
         rrf_constant: int = 60,
         linear_alpha: float = 0.3,
-        yield_combined_score_as: Optional[str] = None,
+        yield_combined_score_as: str | None = None,
         dtype: str = "float32",
-        num_results: Optional[int] = 10,
-        return_fields: Optional[List[str]] = None,
-        stopwords: Optional[Union[str, Set[str]]] = "english",
-        text_weights: Optional[Dict[str, float]] = None,
+        num_results: int | None = 10,
+        return_fields: list[str] | None = None,
+        stopwords: str | set[str] | None = "english",
+        text_weights: dict[str, float] | None = None,
     ):
         """
         Instantiates a HybridQuery object.
@@ -173,7 +173,7 @@ class HybridQuery:
         )
 
         if combination_method:
-            self.combination_method: Optional[CombineResultsMethod] = (
+            self.combination_method: CombineResultsMethod | None = (
                 build_combination_method(
                     combination_method=combination_method,
                     rrf_window=rrf_window,
@@ -191,14 +191,14 @@ def build_base_query(
     vector_param_name: str,
     vector_field_name: str,
     text_scorer: str = "BM25STD",
-    yield_text_score_as: Optional[str] = None,
-    vector_search_method: Optional[Literal["KNN", "RANGE"]] = None,
-    num_results: Optional[int] = None,
-    knn_ef_runtime: Optional[int] = None,
-    range_radius: Optional[float] = None,
-    range_epsilon: Optional[float] = None,
-    yield_vsim_score_as: Optional[str] = None,
-    filter_expression: Optional[Union[str, FilterExpression]] = None,
+    yield_text_score_as: str | None = None,
+    vector_search_method: Literal["KNN", "RANGE"] | None = None,
+    num_results: int | None = None,
+    knn_ef_runtime: int | None = None,
+    range_radius: float | None = None,
+    range_epsilon: float | None = None,
+    yield_vsim_score_as: str | None = None,
+    filter_expression: str | FilterExpression | None = None,
 ):
     """Build a Redis HybridQuery for performing hybrid search.
 
@@ -251,8 +251,8 @@ def build_base_query(
     )
 
     # Serialize vector similarity search method and params, if specified
-    vsim_search_method: Optional[VectorSearchMethods] = None
-    vsim_search_method_params: Dict[str, Any] = {}
+    vsim_search_method: VectorSearchMethods | None = None
+    vsim_search_method_params: dict[str, Any] = {}
     if vector_search_method == "KNN":
         vsim_search_method = VectorSearchMethods.KNN
         if not num_results:
@@ -302,10 +302,10 @@ def build_base_query(
 
 def build_combination_method(
     combination_method: Literal["RRF", "LINEAR"],
-    rrf_window: Optional[int] = None,
-    rrf_constant: Optional[float] = None,
-    linear_alpha: Optional[float] = None,
-    yield_score_as: Optional[str] = None,
+    rrf_window: int | None = None,
+    rrf_constant: float | None = None,
+    linear_alpha: float | None = None,
+    yield_score_as: str | None = None,
 ):
     """Build a configuration for combining hybrid search scores.
 
@@ -335,7 +335,7 @@ def build_combination_method(
     except (ImportError, ModuleNotFoundError):
         raise ImportError(_IMPORT_ERROR_MESSAGE)
 
-    method_params: Dict[str, Any] = {}
+    method_params: dict[str, Any] = {}
     if combination_method == "RRF":
         method = CombinationMethods.RRF
         if rrf_window:

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any
 
 from redis.commands.search.query import Query as RedisQuery
 
@@ -19,7 +19,7 @@ nltk_stopwords = lazy_import("nltk.corpus.stopwords")
 # - str: single field name (ASC by default)
 # - Tuple[str, str]: (field_name, direction)
 # - List: list of field names or tuples
-SortSpec = Union[str, Tuple[str, str], List[Union[str, Tuple[str, str]]]]
+SortSpec = str | tuple[str, str] | list[str | tuple[str, str]]
 
 
 class BaseQuery(RedisQuery):
@@ -37,9 +37,9 @@ class BaseQuery(RedisQuery):
     string is accessed, it is rebuilt.
     """
 
-    _params: Dict[str, Any] = {}
-    _filter_expression: Union[str, FilterExpression] = FilterExpression("*")
-    _built_query_string: Optional[str] = None
+    _params: dict[str, Any] = {}
+    _filter_expression: str | FilterExpression = FilterExpression("*")
+    _built_query_string: str | None = None
 
     def __init__(self, query_string: str = "*"):
         """
@@ -58,7 +58,7 @@ class BaseQuery(RedisQuery):
         self._built_query_string = None
 
         # Initialize skip_decode_fields set
-        self._skip_decode_fields: Set[str] = set()
+        self._skip_decode_fields: set[str] = set()
 
     def __str__(self) -> str:
         """Return the string representation of the query."""
@@ -69,7 +69,7 @@ class BaseQuery(RedisQuery):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @staticmethod
-    def _parse_sort_spec(sort_spec: Optional[SortSpec]) -> List[Tuple[str, bool]]:
+    def _parse_sort_spec(sort_spec: SortSpec | None) -> list[tuple[str, bool]]:
         """Parse sort specification into list of (field, ascending) tuples.
 
         Args:
@@ -96,7 +96,7 @@ class BaseQuery(RedisQuery):
         if sort_spec is None or sort_spec == []:
             return []
 
-        result: List[Tuple[str, bool]] = []
+        result: list[tuple[str, bool]] = []
 
         # Single field as string
         if isinstance(sort_spec, str):
@@ -137,7 +137,7 @@ class BaseQuery(RedisQuery):
         return result
 
     def sort_by(
-        self, sort_spec: Optional[SortSpec] = None, asc: bool = True
+        self, sort_spec: SortSpec | None = None, asc: bool = True
     ) -> "BaseQuery":
         """Set the sort order for query results.
 
@@ -178,7 +178,7 @@ class BaseQuery(RedisQuery):
 
         # Handle backward compatibility: if sort_spec is a string and asc is specified
         # treat it as the old (field, asc) format
-        parsed: List[Tuple[str, bool]]
+        parsed: list[tuple[str, bool]]
         if isinstance(sort_spec, str) and asc is not True:
             # Old API: query.sort_by("field", asc=False)
             parsed = [(sort_spec, asc)]
@@ -206,9 +206,7 @@ class BaseQuery(RedisQuery):
 
         return self
 
-    def set_filter(
-        self, filter_expression: Optional[Union[str, FilterExpression]] = None
-    ):
+    def set_filter(self, filter_expression: str | FilterExpression | None = None):
         """Set the filter expression for the query.
 
         Args:
@@ -232,7 +230,7 @@ class BaseQuery(RedisQuery):
         self._built_query_string = None
 
     @property
-    def filter(self) -> Union[str, FilterExpression]:
+    def filter(self) -> str | FilterExpression:
         """The filter expression for the query."""
         return self._filter_expression
 
@@ -242,7 +240,7 @@ class BaseQuery(RedisQuery):
         return self
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         """Return the query parameters."""
         return self._params
 
@@ -254,13 +252,11 @@ class BaseQuery(RedisQuery):
         return self._built_query_string
 
     @_query_string.setter
-    def _query_string(self, value: Optional[str]):
+    def _query_string(self, value: str | None):
         """Setter for _query_string to maintain compatibility with parent class."""
         self._built_query_string = value
 
-    def return_fields(
-        self, *fields, skip_decode: Optional[Union[str, List[str]]] = None
-    ):
+    def return_fields(self, *fields, skip_decode: str | list[str] | None = None):
         """
         Set the fields to return with search results.
 
@@ -314,13 +310,13 @@ class BaseQuery(RedisQuery):
 class FilterQuery(BaseQuery):
     def __init__(
         self,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
-        return_fields: Optional[List[str]] = None,
+        filter_expression: str | FilterExpression | None = None,
+        return_fields: list[str] | None = None,
         num_results: int = 10,
         dialect: int = 2,
-        sort_by: Optional[SortSpec] = None,
+        sort_by: SortSpec | None = None,
         in_order: bool = False,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
     ):
         """A query for running a filtered search with a filter expression.
 
@@ -375,9 +371,9 @@ class FilterQuery(BaseQuery):
 class CountQuery(BaseQuery):
     def __init__(
         self,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
+        filter_expression: str | FilterExpression | None = None,
         dialect: int = 2,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
     ):
         """A query for a simple count operation provided some filter expression.
 
@@ -448,23 +444,23 @@ class HybridPolicy(str, Enum):
 class VectorQuery(BaseVectorQuery, BaseQuery):
     def __init__(
         self,
-        vector: Union[List[float], bytes],
+        vector: list[float] | bytes,
         vector_field_name: str,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
+        return_fields: list[str] | None = None,
+        filter_expression: str | FilterExpression | None = None,
         dtype: str = "float32",
         num_results: int = 10,
         return_score: bool = True,
         dialect: int = 2,
-        sort_by: Optional[SortSpec] = None,
+        sort_by: SortSpec | None = None,
         in_order: bool = False,
-        hybrid_policy: Optional[str] = None,
-        batch_size: Optional[int] = None,
-        ef_runtime: Optional[int] = None,
-        epsilon: Optional[float] = None,
-        search_window_size: Optional[int] = None,
-        use_search_history: Optional[str] = None,
-        search_buffer_capacity: Optional[int] = None,
+        hybrid_policy: str | None = None,
+        batch_size: int | None = None,
+        ef_runtime: int | None = None,
+        epsilon: float | None = None,
+        search_window_size: int | None = None,
+        use_search_history: str | None = None,
+        search_buffer_capacity: int | None = None,
         normalize_vector_distance: bool = False,
     ):
         """A query for running a vector search along with an optional filter
@@ -542,13 +538,13 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         self._vector_field_name = vector_field_name
         self._dtype = dtype
         self._num_results = num_results
-        self._hybrid_policy: Optional[HybridPolicy] = None
-        self._batch_size: Optional[int] = None
-        self._ef_runtime: Optional[int] = None
-        self._epsilon: Optional[float] = None
-        self._search_window_size: Optional[int] = None
-        self._use_search_history: Optional[str] = None
-        self._search_buffer_capacity: Optional[int] = None
+        self._hybrid_policy: HybridPolicy | None = None
+        self._batch_size: int | None = None
+        self._ef_runtime: int | None = None
+        self._epsilon: float | None = None
+        self._search_window_size: int | None = None
+        self._use_search_history: str | None = None
+        self._search_buffer_capacity: int | None = None
         self._normalize_vector_distance = normalize_vector_distance
         self.set_filter(filter_expression)
 
@@ -786,7 +782,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         self._built_query_string = None
 
     @property
-    def hybrid_policy(self) -> Optional[str]:
+    def hybrid_policy(self) -> str | None:
         """Return the hybrid policy for the query.
 
         Returns:
@@ -795,7 +791,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._hybrid_policy.value if self._hybrid_policy else None
 
     @property
-    def batch_size(self) -> Optional[int]:
+    def batch_size(self) -> int | None:
         """Return the batch size for the query.
 
         Returns:
@@ -804,7 +800,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._batch_size
 
     @property
-    def ef_runtime(self) -> Optional[int]:
+    def ef_runtime(self) -> int | None:
         """Return the EF_RUNTIME parameter for the query.
 
         Returns:
@@ -813,7 +809,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._ef_runtime
 
     @property
-    def epsilon(self) -> Optional[float]:
+    def epsilon(self) -> float | None:
         """Return the epsilon parameter for the query.
 
         Returns:
@@ -822,7 +818,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._epsilon
 
     @property
-    def search_window_size(self) -> Optional[int]:
+    def search_window_size(self) -> int | None:
         """Return the SEARCH_WINDOW_SIZE parameter for the query.
 
         Returns:
@@ -831,7 +827,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._search_window_size
 
     @property
-    def use_search_history(self) -> Optional[str]:
+    def use_search_history(self) -> str | None:
         """Return the USE_SEARCH_HISTORY parameter for the query.
 
         Returns:
@@ -840,7 +836,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._use_search_history
 
     @property
-    def search_buffer_capacity(self) -> Optional[int]:
+    def search_buffer_capacity(self) -> int | None:
         """Return the SEARCH_BUFFER_CAPACITY parameter for the query.
 
         Returns:
@@ -849,7 +845,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         return self._search_buffer_capacity
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         """Return the parameters for the query.
 
         Returns:
@@ -860,7 +856,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         else:
             vector = array_to_buffer(self._vector, dtype=self._dtype)
 
-        params: Dict[str, Any] = {self.VECTOR_PARAM: vector}
+        params: dict[str, Any] = {self.VECTOR_PARAM: vector}
 
         # Add EF_RUNTIME parameter if specified (HNSW)
         if self._ef_runtime is not None:
@@ -893,23 +889,23 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
 
     def __init__(
         self,
-        vector: Union[List[float], bytes],
+        vector: list[float] | bytes,
         vector_field_name: str,
-        return_fields: Optional[List[str]] = None,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
+        return_fields: list[str] | None = None,
+        filter_expression: str | FilterExpression | None = None,
         dtype: str = "float32",
         distance_threshold: float = 0.2,
-        epsilon: Optional[float] = None,
-        search_window_size: Optional[int] = None,
-        use_search_history: Optional[str] = None,
-        search_buffer_capacity: Optional[int] = None,
+        epsilon: float | None = None,
+        search_window_size: int | None = None,
+        use_search_history: str | None = None,
+        search_buffer_capacity: int | None = None,
         num_results: int = 10,
         return_score: bool = True,
         dialect: int = 2,
-        sort_by: Optional[SortSpec] = None,
+        sort_by: SortSpec | None = None,
         in_order: bool = False,
-        hybrid_policy: Optional[str] = None,
-        batch_size: Optional[int] = None,
+        hybrid_policy: str | None = None,
+        batch_size: int | None = None,
         normalize_vector_distance: bool = False,
     ):
         """A query for running a filtered vector search based on semantic
@@ -989,12 +985,12 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         self._dtype = dtype
         self._num_results = num_results
         self._distance_threshold: float = 0.2  # Initialize with default
-        self._epsilon: Optional[float] = None
-        self._search_window_size: Optional[int] = None
-        self._use_search_history: Optional[str] = None
-        self._search_buffer_capacity: Optional[int] = None
-        self._hybrid_policy: Optional[HybridPolicy] = None
-        self._batch_size: Optional[int] = None
+        self._epsilon: float | None = None
+        self._search_window_size: int | None = None
+        self._use_search_history: str | None = None
+        self._search_buffer_capacity: int | None = None
+        self._hybrid_policy: HybridPolicy | None = None
+        self._batch_size: int | None = None
         self._normalize_vector_distance = normalize_vector_distance
 
         # Initialize the base query
@@ -1236,7 +1232,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._distance_threshold
 
     @property
-    def epsilon(self) -> Optional[float]:
+    def epsilon(self) -> float | None:
         """Return the epsilon for the query.
 
         Returns:
@@ -1245,7 +1241,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._epsilon
 
     @property
-    def search_window_size(self) -> Optional[int]:
+    def search_window_size(self) -> int | None:
         """Return the SEARCH_WINDOW_SIZE parameter for the query.
 
         Returns:
@@ -1254,7 +1250,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._search_window_size
 
     @property
-    def use_search_history(self) -> Optional[str]:
+    def use_search_history(self) -> str | None:
         """Return the USE_SEARCH_HISTORY parameter for the query.
 
         Returns:
@@ -1263,7 +1259,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._use_search_history
 
     @property
-    def search_buffer_capacity(self) -> Optional[int]:
+    def search_buffer_capacity(self) -> int | None:
         """Return the SEARCH_BUFFER_CAPACITY parameter for the query.
 
         Returns:
@@ -1272,7 +1268,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._search_buffer_capacity
 
     @property
-    def hybrid_policy(self) -> Optional[str]:
+    def hybrid_policy(self) -> str | None:
         """Return the hybrid policy for the query.
 
         Returns:
@@ -1281,7 +1277,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._hybrid_policy.value if self._hybrid_policy else None
 
     @property
-    def batch_size(self) -> Optional[int]:
+    def batch_size(self) -> int | None:
         """Return the batch size for the query.
 
         Returns:
@@ -1290,7 +1286,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         return self._batch_size
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         """Return the parameters for the query.
 
         Returns:
@@ -1351,18 +1347,18 @@ class TextQuery(BaseQuery):
     def __init__(
         self,
         text: str,
-        text_field_name: Union[str, Dict[str, float]],
+        text_field_name: str | dict[str, float],
         text_scorer: str = "BM25STD",
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
-        return_fields: Optional[List[str]] = None,
+        filter_expression: str | FilterExpression | None = None,
+        return_fields: list[str] | None = None,
         num_results: int = 10,
         return_score: bool = True,
         dialect: int = 2,
-        sort_by: Optional[SortSpec] = None,
+        sort_by: SortSpec | None = None,
         in_order: bool = False,
-        params: Optional[Dict[str, Any]] = None,
-        stopwords: Optional[Union[str, Set[str]]] = "english",
-        text_weights: Optional[Dict[str, float]] = None,
+        params: dict[str, Any] | None = None,
+        stopwords: str | set[str] | None = "english",
+        text_weights: dict[str, float] | None = None,
     ):
         """A query for running a full text search, along with an optional filter expression.
 
@@ -1445,7 +1441,7 @@ class TextQuery(BaseQuery):
     def stopwords(self):
         return self._stopwords
 
-    def _set_stopwords(self, stopwords: Optional[Union[str, Set[str]]] = "english"):
+    def _set_stopwords(self, stopwords: str | set[str] | None = "english"):
         """Set the stopwords to use in the query.
         Args:
             stopwords (Optional[Union[str, Set[str]]]): The stopwords to use. If a string
@@ -1474,7 +1470,7 @@ class TextQuery(BaseQuery):
                 )
             except Exception as e:
                 raise ValueError(f"Error trying to load {stopwords} from nltk. {e}")
-        elif isinstance(stopwords, (Set, List, Tuple)) and all(  # type: ignore
+        elif isinstance(stopwords, (set, list, tuple)) and all(
             isinstance(word, str) for word in stopwords
         ):
             self._stopwords = set(stopwords)
@@ -1509,8 +1505,8 @@ class TextQuery(BaseQuery):
         return " | ".join(token_list)
 
     def _parse_field_weights(
-        self, field_spec: Union[str, Dict[str, float]]
-    ) -> Dict[str, float]:
+        self, field_spec: str | dict[str, float]
+    ) -> dict[str, float]:
         """Parse the field specification into a weights dictionary.
 
         Args:
@@ -1540,7 +1536,7 @@ class TextQuery(BaseQuery):
                 "text_field_name must be a string or dictionary of field:weight mappings"
             )
 
-    def set_field_weights(self, field_weights: Union[str, Dict[str, float]]):
+    def set_field_weights(self, field_weights: str | dict[str, float]):
         """Set or update the field weights for the query.
 
         Args:
@@ -1551,7 +1547,7 @@ class TextQuery(BaseQuery):
         self._built_query_string = None
 
     @property
-    def field_weights(self) -> Dict[str, float]:
+    def field_weights(self) -> dict[str, float]:
         """Get the field weights for the query.
 
         Returns:
@@ -1560,7 +1556,7 @@ class TextQuery(BaseQuery):
         return self._field_weights.copy()
 
     @property
-    def text_field_name(self) -> Union[str, Dict[str, float]]:
+    def text_field_name(self) -> str | dict[str, float]:
         """Get the text field name(s) - for backward compatibility.
 
         Returns:
@@ -1573,10 +1569,8 @@ class TextQuery(BaseQuery):
                 return field
         return self._field_weights.copy()
 
-    def _parse_text_weights(
-        self, weights: Optional[Dict[str, float]]
-    ) -> Dict[str, float]:
-        parsed_weights: Dict[str, float] = {}
+    def _parse_text_weights(self, weights: dict[str, float] | None) -> dict[str, float]:
+        parsed_weights: dict[str, float] = {}
         if not weights:
             return parsed_weights
         for word, weight in weights.items():
@@ -1595,7 +1589,7 @@ class TextQuery(BaseQuery):
             parsed_weights[word] = weight
         return parsed_weights
 
-    def set_text_weights(self, weights: Dict[str, float]):
+    def set_text_weights(self, weights: dict[str, float]):
         """Set or update the text weights for the query.
 
         Args:
@@ -1605,7 +1599,7 @@ class TextQuery(BaseQuery):
         self._built_query_string = None
 
     @property
-    def text_weights(self) -> Dict[str, float]:
+    def text_weights(self) -> dict[str, float]:
         """Get the text weights.
 
         Returns:

--- a/redisvl/query/sql.py
+++ b/redisvl/query/sql.py
@@ -1,7 +1,7 @@
 """SQL Query class for executing SQL-like queries against Redis."""
 
 import re
-from typing import Any, Dict, Optional
+from typing import Any
 
 from redisvl.redis.connection import RedisConnectionFactory
 
@@ -42,9 +42,9 @@ class SQLQuery:
     def __init__(
         self,
         sql: str,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         *,
-        sql_redis_options: Optional[Dict[str, Any]] = None,
+        sql_redis_options: dict[str, Any] | None = None,
     ):
         """Initialize a SQLQuery.
 
@@ -71,7 +71,7 @@ class SQLQuery:
         self.params = params or {}
         self.sql_redis_options = dict(sql_redis_options or {})
 
-    def _substitute_params(self, sql: str, params: Dict[str, Any]) -> str:
+    def _substitute_params(self, sql: str, params: dict[str, Any]) -> str:
         """Substitute parameter placeholders in SQL with actual values.
 
         Uses token-based approach: splits SQL on :param patterns, then rebuilds
@@ -122,7 +122,7 @@ class SQLQuery:
 
     def redis_query_string(
         self,
-        redis_client: Optional[Any] = None,
+        redis_client: Any | None = None,
         redis_url: str = "redis://localhost:6379",
     ) -> str:
         """Translate the SQL query to a Redis command string.

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -1,16 +1,5 @@
 import os
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Sequence, TypeVar, overload
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from warnings import warn
 
@@ -41,10 +30,10 @@ logger = get_logger(__name__)
 
 
 def _split_from_existing_kwargs(
-    kwargs: Dict[str, Any], *, nested_connection_keys: Sequence[str]
-) -> tuple[Dict[str, Any], Dict[str, Any]]:
-    init_kwargs: Dict[str, Any] = {}
-    connection_kwargs: Dict[str, Any] = {}
+    kwargs: dict[str, Any], *, nested_connection_keys: Sequence[str]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    init_kwargs: dict[str, Any] = {}
+    connection_kwargs: dict[str, Any] = {}
 
     for key in ("validate_on_load", "lib_name"):
         if key in kwargs:
@@ -65,7 +54,7 @@ def _split_from_existing_kwargs(
 
 def _strip_cluster_from_url_and_kwargs(
     url: str, **kwargs
-) -> Tuple[str, Dict[str, Any]]:
+) -> tuple[str, dict[str, Any]]:
     """Remove 'cluster' parameter from URL query string and kwargs.
 
     AsyncRedisCluster doesn't accept 'cluster' parameter, but it might be
@@ -138,7 +127,7 @@ def is_version_gte(version1: str, version2: str) -> bool:
     return True
 
 
-def unpack_redis_modules(module_list: List[Dict[str, Any]]) -> Dict[str, Any]:
+def unpack_redis_modules(module_list: list[dict[str, Any]]) -> dict[str, Any]:
     """Unpack a list of Redis modules pulled from the MODULES LIST command."""
     return {module["name"]: module["ver"] for module in module_list}
 
@@ -223,7 +212,7 @@ def make_lib_name(*args) -> str:
     return f"redis-py({custom_libs})"
 
 
-def convert_index_info_to_schema(index_info: Dict[str, Any]) -> Dict[str, Any]:
+def convert_index_info_to_schema(index_info: dict[str, Any]) -> dict[str, Any]:
     """Convert the output of FT.INFO into a schema-ready dictionary.
 
     Args:
@@ -484,7 +473,7 @@ class RedisConnectionFactory:
         "connect", "Please use `get_redis_connection` or `get_async_redis_connection`."
     )
     def connect(
-        cls, redis_url: Optional[str] = None, use_async: bool = False, **kwargs
+        cls, redis_url: str | None = None, use_async: bool = False, **kwargs
     ) -> RedisClient:
         """Create a connection to the Redis database based on a URL and some
         connection kwargs.
@@ -512,7 +501,7 @@ class RedisConnectionFactory:
 
     @staticmethod
     def get_redis_connection(
-        redis_url: Optional[str] = None,
+        redis_url: str | None = None,
         **kwargs,
     ) -> SyncRedisClient:
         """Creates and returns a synchronous Redis client.
@@ -552,7 +541,7 @@ class RedisConnectionFactory:
     @staticmethod
     @deprecated_argument("url", "redis_url")
     async def _get_aredis_connection(
-        redis_url: Optional[str] = None,
+        redis_url: str | None = None,
         **kwargs,
     ) -> AsyncRedisClient:
         """Creates and returns an asynchronous Redis client.
@@ -611,7 +600,7 @@ class RedisConnectionFactory:
     @staticmethod
     @deprecated_argument("url", "redis_url")
     def get_async_redis_connection(
-        redis_url: Optional[str] = None,
+        redis_url: str | None = None,
         **kwargs,
     ) -> AsyncRedisClient:
         """Creates and returns an asynchronous Redis client.
@@ -658,7 +647,7 @@ class RedisConnectionFactory:
 
     @staticmethod
     def get_redis_cluster_connection(
-        redis_url: Optional[str] = None,
+        redis_url: str | None = None,
         **kwargs,
     ) -> RedisCluster:
         """Creates and returns a synchronous Redis client for a Redis cluster."""
@@ -667,7 +656,7 @@ class RedisConnectionFactory:
 
     @staticmethod
     def get_async_redis_cluster_connection(
-        redis_url: Optional[str] = None,
+        redis_url: str | None = None,
         **kwargs,
     ) -> AsyncRedisCluster:
         """Creates and returns an asynchronous Redis client for a Redis cluster."""
@@ -690,7 +679,7 @@ class RedisConnectionFactory:
         assert isinstance(redis_client, Redis)  # Type narrowing for MyPy
 
         # pick the right connection class
-        connection_class: Type[AsyncAbstractConnection] = (
+        connection_class: type[AsyncAbstractConnection] = (
             AsyncSSLConnection
             if redis_client.connection_pool.connection_class == SSLConnection
             else AsyncConnection
@@ -704,17 +693,17 @@ class RedisConnectionFactory:
         )
 
     @staticmethod
-    def get_modules(client: SyncRedisClient) -> Dict[str, Any]:
+    def get_modules(client: SyncRedisClient) -> dict[str, Any]:
         return unpack_redis_modules(convert_bytes(client.module_list()))
 
     @staticmethod
-    async def get_modules_async(client: AsyncRedisClient) -> Dict[str, Any]:
+    async def get_modules_async(client: AsyncRedisClient) -> dict[str, Any]:
         return unpack_redis_modules(convert_bytes(await client.module_list()))
 
     @staticmethod
     def validate_sync_redis(
         redis_client: SyncRedisClient,
-        lib_name: Optional[str] = None,
+        lib_name: str | None = None,
     ) -> None:
         """Validates the sync Redis client.
 
@@ -741,7 +730,7 @@ class RedisConnectionFactory:
     @staticmethod
     async def validate_async_redis(
         redis_client: AsyncRedisClient,
-        lib_name: Optional[str] = None,
+        lib_name: str | None = None,
     ) -> None:
         """Validates the async Redis client.
 
@@ -777,8 +766,8 @@ class RedisConnectionFactory:
 
     @staticmethod
     def _redis_sentinel_client(
-        redis_url: str, redis_class: Union[type[Redis], type[AsyncRedis]], **kwargs: Any
-    ) -> Union[Redis, AsyncRedis]:
+        redis_url: str, redis_class: type[Redis] | type[AsyncRedis], **kwargs: Any
+    ) -> Redis | AsyncRedis:
         """Create a Redis client connected via Sentinel for high availability.
 
         Parses a Sentinel URL and creates a Redis client connected to the
@@ -805,7 +794,7 @@ class RedisConnectionFactory:
             RedisConnectionFactory._parse_sentinel_url(redis_url)
         )
 
-        sentinel_kwargs: Dict[str, Any] = {}
+        sentinel_kwargs: dict[str, Any] = {}
         if username:
             sentinel_kwargs["username"] = username
             kwargs["username"] = username
@@ -834,7 +823,7 @@ class RedisConnectionFactory:
     @staticmethod
     def _parse_sentinel_url(
         url: str,
-    ) -> Tuple[List[Tuple[str, int]], str, Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[list[tuple[str, int]], str, str | None, str | None, str | None]:
         """Parse a Redis Sentinel URL into its components.
 
         Args:

--- a/redisvl/redis/utils.py
+++ b/redisvl/redis/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import itertools
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from redis import RedisCluster
 from redis import __version__ as redis_version
@@ -45,7 +45,7 @@ np = lazy_import("numpy")
 from redisvl.schema.fields import VectorDataType
 
 
-def make_dict(values: List[Any]) -> Dict[Any, Any]:
+def make_dict(values: list[Any]) -> dict[Any, Any]:
     """Convert a list of objects into a dictionary"""
     i = 0
     di = {}
@@ -71,7 +71,7 @@ def convert_bytes(data: Any) -> Any:
     return data
 
 
-def array_to_buffer(array: List[float], dtype: str) -> bytes:
+def array_to_buffer(array: list[float], dtype: str) -> bytes:
     """Convert a list of floats into a numpy byte string."""
     try:
         VectorDataType(dtype.upper())
@@ -89,7 +89,7 @@ def array_to_buffer(array: List[float], dtype: str) -> bytes:
     return np.array(array, dtype=dtype.lower()).tobytes()
 
 
-def buffer_to_array(buffer: bytes, dtype: str) -> List[Any]:
+def buffer_to_array(buffer: bytes, dtype: str) -> list[Any]:
     """Convert bytes into into a list of numerics."""
     try:
         VectorDataType(dtype.upper())
@@ -108,7 +108,7 @@ def buffer_to_array(buffer: bytes, dtype: str) -> List[Any]:
     return np.frombuffer(buffer, dtype=dtype.lower()).tolist()  # type: ignore[return-value]
 
 
-def hashify(content: str, extras: Optional[Dict[str, Any]] = None) -> str:
+def hashify(content: str, extras: dict[str, Any] | None = None) -> str:
     """Create a secure hash of some arbitrary input text and optional dictionary."""
     if extras:
         extra_string = " ".join([str(k) + str(v) for k, v in sorted(extras.items())])
@@ -119,11 +119,11 @@ def hashify(content: str, extras: Optional[Dict[str, Any]] = None) -> str:
 def cluster_create_index(
     index_name: str,
     client: RedisCluster,
-    fields: List[Field],
+    fields: list[Field],
     no_term_offsets: bool = False,
     no_field_flags: bool = False,
-    stopwords: Optional[List[str]] = None,
-    definition: Optional[IndexDefinition] = None,
+    stopwords: list[str] | None = None,
+    definition: IndexDefinition | None = None,
     max_text_fields=False,
     temporary=None,
     no_highlight: bool = False,
@@ -194,11 +194,11 @@ def cluster_create_index(
 async def async_cluster_create_index(
     index_name: str,
     client: AsyncRedisCluster,
-    fields: List[Field],
+    fields: list[Field],
     no_term_offsets: bool = False,
     no_field_flags: bool = False,
-    stopwords: Optional[List[str]] = None,
-    definition: Optional[IndexDefinition] = None,
+    stopwords: list[str] | None = None,
+    definition: IndexDefinition | None = None,
     max_text_fields=False,
     temporary=None,
     no_highlight: bool = False,
@@ -269,9 +269,9 @@ async def async_cluster_create_index(
 # TODO: The return type is incorrect because 5.x doesn't have "ProfileInformation"
 def cluster_search(
     client: Search,
-    query: Union[str, Query],
-    query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
-) -> Union[Result, Pipeline, Any]:  # type: ignore[type-arg]
+    query: str | Query,
+    query_params: dict[str, str | int | float | bytes] | None = None,
+) -> Result | Pipeline | Any:  # type: ignore[type-arg]
     args, query = client._mk_query_args(query, query_params=query_params)
     st = time.monotonic()
 
@@ -293,9 +293,9 @@ def cluster_search(
 # TODO: The return type is incorrect because 5.x doesn't have "ProfileInformation"
 async def async_cluster_search(
     client: AsyncSearch,
-    query: Union[str, Query],
-    query_params: Optional[Dict[str, Union[str, int, float, bytes]]] = None,
-) -> Union[Result, Pipeline, Any]:  # type: ignore[type-arg]
+    query: str | Query,
+    query_params: dict[str, str | int | float | bytes] | None = None,
+) -> Result | Pipeline | Any:  # type: ignore[type-arg]
     args, query = client._mk_query_args(query, query_params=query_params)
     st = time.monotonic()
 
@@ -334,7 +334,7 @@ def _extract_hash_tag(key: str) -> str:
     return key[start : end + 1]
 
 
-def _keys_share_hash_tag(keys: List[str]) -> bool:
+def _keys_share_hash_tag(keys: list[str]) -> bool:
     """Check if all keys share the same hash tag for Redis Cluster compatibility.
 
     Args:

--- a/redisvl/schema/fields.py
+++ b/redisvl/schema/fields.py
@@ -35,7 +35,7 @@ References:
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from redis.commands.search.field import Field as RedisField
@@ -101,7 +101,7 @@ class CompressionType(str, Enum):
 
 
 def _normalize_field_modifiers(
-    field: RedisField, canonical_order: List[str], want_unf: bool = False
+    field: RedisField, canonical_order: list[str], want_unf: bool = False
 ) -> None:
     """Normalize field modifier ordering for Redis Search parser.
 
@@ -163,7 +163,7 @@ class TextFieldAttributes(BaseFieldAttributes):
     """Disable stemming on the text field during indexing"""
     withsuffixtrie: bool = Field(default=False)
     """Keep a suffix trie with all terms which match the suffix to optimize certain queries"""
-    phonetic_matcher: Optional[str] = None
+    phonetic_matcher: str | None = None
     """Used to perform phonetic matching during search"""
     index_empty: bool = Field(default=False)
     """Allow indexing and searching for empty strings"""
@@ -208,7 +208,7 @@ class BaseVectorFieldAttributes(BaseModel):
     """The float datatype for the vector embeddings"""
     distance_metric: VectorDistanceMetric = Field(default=VectorDistanceMetric.COSINE)
     """The distance metric used to measure query relevance"""
-    initial_cap: Optional[int] = None
+    initial_cap: int | None = None
     """Initial vector capacity in the index affecting memory allocation size of the index"""
     index_missing: bool = Field(default=False)
     """Allow indexing and searching for missing values (documents without the field)"""
@@ -220,7 +220,7 @@ class BaseVectorFieldAttributes(BaseModel):
         return v.upper()
 
     @property
-    def field_data(self) -> Dict[str, Any]:
+    def field_data(self) -> dict[str, Any]:
         """Select attributes required by the Redis API"""
         field_data = {
             "TYPE": self.datatype,
@@ -240,7 +240,7 @@ class FlatVectorFieldAttributes(BaseVectorFieldAttributes):
     algorithm: Literal[VectorIndexAlgorithm.FLAT] = VectorIndexAlgorithm.FLAT
     """The indexing algorithm (fixed as 'flat')"""
 
-    block_size: Optional[int] = None
+    block_size: int | None = None
     """Block size for processing (optional) - improves batch operation throughput"""
 
 
@@ -284,13 +284,13 @@ class SVSVectorFieldAttributes(BaseVectorFieldAttributes):
     """Range query boundary factor (default: 0.01)"""
 
     # Compression Parameters
-    compression: Optional[CompressionType] = None
+    compression: CompressionType | None = None
     """Vector compression: LVQ4, LVQ8, LeanVec4x8, LeanVec8x8"""
 
-    reduce: Optional[int] = None
+    reduce: int | None = None
     """Dimensionality reduction for LeanVec types (must be < dims)"""
 
-    training_threshold: Optional[int] = None
+    training_threshold: int | None = None
     """Min vectors before compression training (default: 10,240)"""
 
     @model_validator(mode="after")
@@ -361,12 +361,12 @@ class BaseField(BaseModel):
     """Field name"""
     type: str
     """Field type"""
-    path: Optional[str] = None
+    path: str | None = None
     """Field path (within JSON object)"""
-    attrs: Optional[Union[BaseFieldAttributes, BaseVectorFieldAttributes]] = None
+    attrs: BaseFieldAttributes | BaseVectorFieldAttributes | None = None
     """Specified field attributes"""
 
-    def _handle_names(self) -> Tuple[str, Optional[str]]:
+    def _handle_names(self) -> tuple[str, str | None]:
         """Helper to handle field naming with path support"""
         if self.path:
             return self.path, self.name
@@ -386,7 +386,7 @@ class TextField(BaseField):
     def as_redis_field(self) -> RedisField:
         name, as_name = self._handle_names()
         # Build arguments for RedisTextField
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "weight": self.attrs.weight,  # type: ignore
             "no_stem": self.attrs.no_stem,  # type: ignore
             "sortable": self.attrs.sortable,
@@ -436,7 +436,7 @@ class TagField(BaseField):
     def as_redis_field(self) -> RedisField:
         name, as_name = self._handle_names()
         # Build arguments for RedisTagField
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "separator": self.attrs.separator,  # type: ignore
             "case_sensitive": self.attrs.case_sensitive,  # type: ignore
             "sortable": self.attrs.sortable,
@@ -481,7 +481,7 @@ class NumericField(BaseField):
     def as_redis_field(self) -> RedisField:
         name, as_name = self._handle_names()
         # Build arguments for RedisNumericField
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "sortable": self.attrs.sortable,
         }
 
@@ -518,7 +518,7 @@ class GeoField(BaseField):
     def as_redis_field(self) -> RedisField:
         name, as_name = self._handle_names()
         # Build arguments for RedisGeoField
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "sortable": self.attrs.sortable,
         }
 
@@ -626,7 +626,7 @@ class FieldFactory:
     """Factory class to create fields from client data and kwargs."""
 
     @classmethod
-    def pick_vector_field_type(cls, attrs: Dict[str, Any]) -> Type[BaseField]:
+    def pick_vector_field_type(cls, attrs: dict[str, Any]) -> type[BaseField]:
         """Get the vector field type from the field data."""
         if "algorithm" not in attrs:
             raise ValueError("Must provide algorithm param for the vector field.")
@@ -645,8 +645,8 @@ class FieldFactory:
         cls,
         type: str,
         name: str,
-        attrs: Dict[str, Any] = {},
-        path: Optional[str] = None,
+        attrs: dict[str, Any] = {},
+        path: str | None = None,
     ) -> BaseField:
         """Create a field of a given type with provided attributes."""
 

--- a/redisvl/schema/schema.py
+++ b/redisvl/schema/schema.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
@@ -59,7 +59,7 @@ class IndexInfo(BaseModel):
 
     name: str
     """The unique name of the index."""
-    prefix: Union[str, List[str]] = "rvl"
+    prefix: str | list[str] = "rvl"
     """The prefix used for Redis keys associated with this index.
 
     A list of prefixes is supported for querying across multiple key namespaces,
@@ -69,7 +69,7 @@ class IndexInfo(BaseModel):
     """The separator character used in designing Redis keys."""
     storage_type: StorageType = StorageType.HASH
     """The storage type used in Redis (e.g., 'hash' or 'json')."""
-    stopwords: Optional[List[str]] = None
+    stopwords: list[str] | None = None
     """Index-level stopwords configuration. None (default) uses Redis default stopwords,
     empty list [] disables stopwords (STOPWORDS 0), or provide a custom list of stopwords."""
 
@@ -152,7 +152,7 @@ class IndexSchema(BaseModel):
 
     index: IndexInfo
     """Details of the basic index configurations."""
-    fields: Dict[str, BaseField] = Field(default_factory=dict)
+    fields: dict[str, BaseField] = Field(default_factory=dict)
     """Fields associated with the search index and their properties.
 
     Note: When creating from dict/YAML, provide fields as a list of field definitions.
@@ -182,7 +182,7 @@ class IndexSchema(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_and_create_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_and_create_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
         """
         Validate uniqueness of field names and create valid field instances.
         """
@@ -192,7 +192,7 @@ class IndexSchema(BaseModel):
             index = IndexInfo(**index)
 
         input_fields = values.get("fields", [])
-        prepared_fields: Dict[str, BaseField] = {}
+        prepared_fields: dict[str, BaseField] = {}
 
         # Handle both list and dict formats for fields
         if isinstance(input_fields, Mapping):
@@ -262,7 +262,7 @@ class IndexSchema(BaseModel):
             return cls.model_validate(yaml_data)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "IndexSchema":
+    def from_dict(cls, data: dict[str, Any]) -> "IndexSchema":
         """Create an IndexSchema from a dictionary.
 
         Args:
@@ -301,7 +301,7 @@ class IndexSchema(BaseModel):
         return cls.model_validate(schema_dict)
 
     @property
-    def field_names(self) -> List[str]:
+    def field_names(self) -> list[str]:
         """A list of field names associated with the index schema.
 
         Returns:
@@ -310,7 +310,7 @@ class IndexSchema(BaseModel):
         return list(self.fields.keys())
 
     @property
-    def redis_fields(self) -> List[RedisField]:
+    def redis_fields(self) -> list[RedisField]:
         """A list of core redis-py field definitions based on the
         current schema fields.
 
@@ -321,12 +321,12 @@ class IndexSchema(BaseModel):
         Returns:
             List[RedisField]: A list of redis-py field definitions.
         """
-        redis_fields: List[RedisField] = [
+        redis_fields: list[RedisField] = [
             field.as_redis_field() for _, field in self.fields.items()
         ]
         return redis_fields
 
-    def add_field(self, field_inputs: Dict[str, Any]):
+    def add_field(self, field_inputs: dict[str, Any]):
         """Adds a single field to the index schema based on the specified field
         type and attributes.
 
@@ -366,7 +366,7 @@ class IndexSchema(BaseModel):
         # Add field
         self.fields[field.name] = field
 
-    def add_fields(self, fields: List[Dict[str, Any]]):
+    def add_fields(self, fields: list[dict[str, Any]]):
         """Extends the schema with additional fields.
 
         This method allows dynamically adding new fields to the index schema. It
@@ -414,10 +414,10 @@ class IndexSchema(BaseModel):
 
     def generate_fields(
         self,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         strict: bool = False,
-        ignore_fields: List[str] = [],
-    ) -> List[Dict[str, Any]]:
+        ignore_fields: list[str] = [],
+    ) -> list[dict[str, Any]]:
         """Generates a list of extracted field specs from a sample data point.
 
         This method simplifies the process of creating a schema by inferring
@@ -441,7 +441,7 @@ class IndexSchema(BaseModel):
             - This method employs heuristics and may not always correctly infer
                 field types.
         """
-        fields: List[Dict[str, Any]] = []
+        fields: list[dict[str, Any]] = []
         for field_name, value in data.items():
             if field_name in ignore_fields:
                 continue
@@ -462,7 +462,7 @@ class IndexSchema(BaseModel):
                     )
         return fields
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize the index schema model to a dictionary, handling Enums
         and other special cases properly.
 

--- a/redisvl/schema/validation.py
+++ b/redisvl/schema/validation.py
@@ -6,7 +6,7 @@ using dynamically generated Pydantic models.
 """
 
 import json
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any
 
 from jsonpath_ng import parse as jsonpath_parse
 from pydantic import BaseModel, Field, field_validator
@@ -28,10 +28,10 @@ class SchemaModelGenerator:
     Pydantic models with appropriate field types and validators.
     """
 
-    _model_cache: Dict[str, Type[BaseModel]] = {}
+    _model_cache: dict[str, type[BaseModel]] = {}
 
     @classmethod
-    def get_model_for_schema(cls, schema: IndexSchema) -> Type[BaseModel]:
+    def get_model_for_schema(cls, schema: IndexSchema) -> type[BaseModel]:
         """
         Get or create a Pydantic model for a schema.
 
@@ -52,7 +52,7 @@ class SchemaModelGenerator:
     @classmethod
     def _map_field_to_pydantic_type(
         cls, field: BaseField, storage_type: StorageType
-    ) -> Type[Any]:
+    ) -> Any:
         """
         Map Redis field types to appropriate Pydantic types.
 
@@ -71,7 +71,7 @@ class SchemaModelGenerator:
         elif field.type == FieldTypes.TAG:
             return str
         elif field.type == FieldTypes.NUMERIC:
-            return Union[int, float]  # type: ignore
+            return int | float
         elif field.type == FieldTypes.GEO:
             return str
         elif field.type == FieldTypes.VECTOR:
@@ -82,8 +82,8 @@ class SchemaModelGenerator:
                     VectorDataType.INT8,
                     VectorDataType.UINT8,
                 ):
-                    return List[int]
-                return List[float]
+                    return list[int]
+                return list[float]
             else:
                 return bytes
 
@@ -91,7 +91,7 @@ class SchemaModelGenerator:
         raise ValueError(f"Unsupported field type: {field.type}")
 
     @classmethod
-    def _create_model(cls, schema: IndexSchema) -> Type[BaseModel]:
+    def _create_model(cls, schema: IndexSchema) -> type[BaseModel]:
         """
         Create a Pydantic model from schema definition using type() approach.
 
@@ -105,15 +105,15 @@ class SchemaModelGenerator:
         storage_type = schema.index.storage_type
 
         # Create annotations dictionary for the dynamic model
-        annotations: Dict[str, Any] = {}
-        class_dict: Dict[str, Any] = {}
+        annotations: dict[str, Any] = {}
+        class_dict: dict[str, Any] = {}
 
         # Build annotations and field metadata
         for field_name, field in schema.fields.items():
             field_type = cls._map_field_to_pydantic_type(field, storage_type)
 
             # Make all fields optional in the model
-            annotations[field_name] = Optional[field_type]
+            annotations[field_name] = field_type | None
 
             # Add default=None to make fields truly optional (can be missing from input)
             class_dict[field_name] = Field(default=None)
@@ -210,7 +210,7 @@ class SchemaModelGenerator:
         return type(model_name, (BaseModel,), class_dict)
 
 
-def extract_from_json_path(obj: Dict[str, Any], path: str) -> Any:
+def extract_from_json_path(obj: dict[str, Any], path: str) -> Any:
     """
     Extract a value from a nested JSON object using a JSONPath expression.
 
@@ -240,7 +240,7 @@ def extract_from_json_path(obj: Dict[str, Any], path: str) -> Any:
     return None
 
 
-def validate_object(schema: IndexSchema, obj: Dict[str, Any]) -> Dict[str, Any]:
+def validate_object(schema: IndexSchema, obj: dict[str, Any]) -> dict[str, Any]:
     """
     Validate an object against a schema.
 

--- a/redisvl/types.py
+++ b/redisvl/types.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from redis import Redis as SyncRedis
 from redis.asyncio import Redis as AsyncRedis
 from redis.asyncio.client import Pipeline as AsyncPipeline
@@ -9,12 +7,12 @@ from redis.client import Pipeline as SyncPipeline
 from redis.cluster import ClusterPipeline as SyncClusterPipeline
 from redis.cluster import RedisCluster as SyncRedisCluster
 
-SyncRedisClient = Union[SyncRedis, SyncRedisCluster]
-AsyncRedisClient = Union[AsyncRedis, AsyncRedisCluster]
-RedisClient = Union[SyncRedisClient, AsyncRedisClient]
+SyncRedisClient = SyncRedis | SyncRedisCluster
+AsyncRedisClient = AsyncRedis | AsyncRedisCluster
+RedisClient = SyncRedisClient | AsyncRedisClient
 
-SyncRedisPipeline = Union[SyncPipeline, SyncClusterPipeline]
-AsyncRedisPipeline = Union[AsyncPipeline, AsyncClusterPipeline]
+SyncRedisPipeline = SyncPipeline | SyncClusterPipeline
+AsyncRedisPipeline = AsyncPipeline | AsyncClusterPipeline
 
-RedisClientOrPipeline = Union[SyncRedisClient, SyncRedisPipeline]
-AsyncRedisClientOrPipeline = Union[AsyncRedisClient, AsyncRedisPipeline]
+RedisClientOrPipeline = SyncRedisClient | SyncRedisPipeline
+AsyncRedisClientOrPipeline = AsyncRedisClient | AsyncRedisPipeline

--- a/redisvl/utils/compression.py
+++ b/redisvl/utils/compression.py
@@ -1,6 +1,6 @@
 """SVS-VAMANA compression configuration utilities."""
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -19,14 +19,14 @@ class SVSConfig(BaseModel):
     """
 
     algorithm: Literal["svs-vamana"] = "svs-vamana"
-    datatype: Optional[str] = None
-    compression: Optional[str] = None
-    reduce: Optional[int] = Field(
+    datatype: str | None = None
+    compression: str | None = None
+    reduce: int | None = Field(
         default=None, description="Reduced dimensionality (only for LeanVec)"
     )
-    graph_max_degree: Optional[int] = None
-    construction_window_size: Optional[int] = None
-    search_window_size: Optional[int] = None
+    graph_max_degree: int | None = None
+    construction_window_size: int | None = None
+    search_window_size: int | None = None
 
 
 class CompressionAdvisor:
@@ -71,7 +71,7 @@ class CompressionAdvisor:
     def recommend(
         dims: int,
         priority: Literal["speed", "memory", "balanced"] = "balanced",
-        datatype: Optional[str] = None,
+        datatype: str | None = None,
     ) -> SVSConfig:
         """Recommend compression settings based on dimensions and priorities.
 
@@ -181,7 +181,7 @@ class CompressionAdvisor:
 
     @staticmethod
     def estimate_memory_savings(
-        compression: str, dims: int, reduce: Optional[int] = None
+        compression: str, dims: int, reduce: int | None = None
     ) -> float:
         """Estimate memory savings percentage from compression.
 

--- a/redisvl/utils/full_text_query_helper.py
+++ b/redisvl/utils/full_text_query_helper.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Optional, Set, Tuple, Union
-
 from redisvl.query.filter import FilterExpression
 from redisvl.utils.token_escaper import TokenEscaper
 from redisvl.utils.utils import lazy_import
@@ -8,8 +6,8 @@ nltk = lazy_import("nltk")
 nltk_stopwords = lazy_import("nltk.corpus.stopwords")
 
 
-def _parse_text_weights(weights: Optional[Dict[str, float]]) -> Dict[str, float]:
-    parsed_weights: Dict[str, float] = {}
+def _parse_text_weights(weights: dict[str, float] | None) -> dict[str, float]:
+    parsed_weights: dict[str, float] = {}
     if not weights:
         return parsed_weights
     for word, weight in weights.items():
@@ -31,14 +29,14 @@ class FullTextQueryHelper:
 
     def __init__(
         self,
-        stopwords: Optional[Union[str, Set[str]]] = "english",
-        text_weights: Optional[Dict[str, float]] = None,
+        stopwords: str | set[str] | None = "english",
+        text_weights: dict[str, float] | None = None,
     ):
         self._stopwords = self._get_stopwords(stopwords)
         self._text_weights = _parse_text_weights(text_weights)
 
     @property
-    def stopwords(self) -> Set[str]:
+    def stopwords(self) -> set[str]:
         """Return the stopwords used in the query.
         Returns:
             Set[str]: The stopwords used in the query.
@@ -46,7 +44,7 @@ class FullTextQueryHelper:
         return self._stopwords.copy() if self._stopwords else set()
 
     @property
-    def text_weights(self) -> Dict[str, float]:
+    def text_weights(self) -> dict[str, float]:
         """Get the text weights.
 
         Returns:
@@ -58,7 +56,7 @@ class FullTextQueryHelper:
         self,
         text: str,
         text_field_name: str,
-        filter_expression: Optional[Union[str, FilterExpression]] = None,
+        filter_expression: str | FilterExpression | None = None,
     ) -> str:
         """Build the full-text query string for text search with optional filtering."""
         if isinstance(filter_expression, FilterExpression):
@@ -71,9 +69,7 @@ class FullTextQueryHelper:
 
         return query + ")"
 
-    def _get_stopwords(
-        self, stopwords: Optional[Union[str, Set[str]]] = "english"
-    ) -> Set[str]:
+    def _get_stopwords(self, stopwords: str | set[str] | None = "english") -> set[str]:
         """Get the stopwords to use in the query.
 
         Args:
@@ -107,14 +103,14 @@ class FullTextQueryHelper:
                 )
             except Exception as e:
                 raise ValueError(f"Error trying to load {stopwords} from nltk. {e}")
-        elif isinstance(stopwords, (Set, List, Tuple)) and all(  # type: ignore
+        elif isinstance(stopwords, (set, list, tuple)) and all(
             isinstance(word, str) for word in stopwords
         ):
             return set(stopwords)
         else:
             raise TypeError("stopwords must be a set, list, or tuple of strings")
 
-    def set_text_weights(self, weights: Dict[str, float]):
+    def set_text_weights(self, weights: dict[str, float]):
         """Set or update the text weights for the query.
 
         Args:

--- a/redisvl/utils/redis_protocol.py
+++ b/redisvl/utils/redis_protocol.py
@@ -4,12 +4,10 @@ Wrapper for redis-py's get_protocol_version to handle edge cases.
 This fixes issue #365 where ClusterPipeline objects may not have nodes_manager attribute.
 """
 
-from typing import Optional
-
 from redis.commands.helpers import get_protocol_version as redis_get_protocol_version
 
 
-def get_protocol_version(client) -> Optional[str]:
+def get_protocol_version(client) -> str | None:
     """
     Safe wrapper for redis-py's get_protocol_version that handles edge cases.
 

--- a/redisvl/utils/rerank/base.py
+++ b/redisvl/utils/rerank/base.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from pydantic import BaseModel, field_validator
 
 
 class BaseReranker(BaseModel, ABC):
     model: str
-    rank_by: Optional[List[str]] = None
+    rank_by: list[str] | None = None
     limit: int
     return_score: bool
 
@@ -31,8 +31,8 @@ class BaseReranker(BaseModel, ABC):
 
     @abstractmethod
     def rank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Synchronously rerank the docs based on the provided query.
         """
@@ -40,8 +40,8 @@ class BaseReranker(BaseModel, ABC):
 
     @abstractmethod
     async def arank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Asynchronously rerank the docs based on the provided query.
         """

--- a/redisvl/utils/rerank/cohere.py
+++ b/redisvl/utils/rerank/cohere.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from pydantic import PrivateAttr
 
@@ -41,10 +41,10 @@ class CohereReranker(BaseReranker):
     def __init__(
         self,
         model: str = "rerank-english-v3.0",
-        rank_by: Optional[List[str]] = None,
+        rank_by: list[str] | None = None,
         limit: int = 5,
         return_score: bool = True,
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         **kwargs,
     ):
         """
@@ -74,7 +74,7 @@ class CohereReranker(BaseReranker):
         )
         self._initialize_clients(api_config, **kwargs)
 
-    def _initialize_clients(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_clients(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the Cohere clients using the provided API key or an
         environment variable.
@@ -100,9 +100,7 @@ class CohereReranker(BaseReranker):
         self._client = Client(api_key=api_key, client_name="redisvl", **kwargs)
         self._aclient = AsyncClient(api_key=api_key, client_name="redisvl", **kwargs)
 
-    def _preprocess(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ):
+    def _preprocess(self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs):
         """
         Prepare and validate reranking config based on provided input and
         optional overrides.
@@ -134,9 +132,9 @@ class CohereReranker(BaseReranker):
 
     @staticmethod
     def _postprocess(
-        docs: Union[List[Dict[str, Any]], List[str]],
-        rankings: List[Any],
-    ) -> Tuple[List[Any], List[float]]:
+        docs: list[dict[str, Any]] | list[str],
+        rankings: list[Any],
+    ) -> tuple[list[Any], list[float]]:
         """
         Post-process the initial list of documents to include ranking scores,
         if specified.
@@ -148,8 +146,8 @@ class CohereReranker(BaseReranker):
         return reranked_docs, scores
 
     def rank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Rerank documents based on the provided query using the Cohere rerank API.
 
@@ -173,8 +171,8 @@ class CohereReranker(BaseReranker):
         return reranked_docs
 
     async def arank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Rerank documents based on the provided query using the Cohere rerank API.
 

--- a/redisvl/utils/rerank/hf_cross_encoder.py
+++ b/redisvl/utils/rerank/hf_cross_encoder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
 
 from pydantic import PrivateAttr
 
@@ -71,8 +71,8 @@ class HFCrossEncoderReranker(BaseReranker):
         self._client = CrossEncoder(self.model, **kwargs)
 
     def rank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Rerank documents based on the provided query using the loaded cross-encoder model.
 
@@ -128,8 +128,8 @@ class HFCrossEncoderReranker(BaseReranker):
         return reranked_docs
 
     async def arank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Asynchronously rerank documents based on the provided query using the loaded cross-encoder model.
 

--- a/redisvl/utils/rerank/voyageai.py
+++ b/redisvl/utils/rerank/voyageai.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from pydantic import PrivateAttr
 
@@ -41,10 +41,10 @@ class VoyageAIReranker(BaseReranker):
     def __init__(
         self,
         model: str,
-        rank_by: Optional[List[str]] = None,
+        rank_by: list[str] | None = None,
         limit: int = 5,
         return_score: bool = True,
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         **kwargs,
     ):
         """
@@ -73,7 +73,7 @@ class VoyageAIReranker(BaseReranker):
         )
         self._initialize_clients(api_config, **kwargs)
 
-    def _initialize_clients(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_clients(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the VoyageAI clients using the provided API key or an
         environment variable.
@@ -99,9 +99,7 @@ class VoyageAIReranker(BaseReranker):
         self._client = Client(api_key=api_key, **kwargs)
         self._aclient = AsyncClient(api_key=api_key, **kwargs)
 
-    def _preprocess(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ):
+    def _preprocess(self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs):
         """
         Prepare and validate reranking config based on provided input and
         optional overrides.
@@ -135,9 +133,9 @@ class VoyageAIReranker(BaseReranker):
 
     @staticmethod
     def _postprocess(
-        docs: Union[List[Dict[str, Any]], List[str]],
-        rankings: List[Any],
-    ) -> Tuple[List[Any], List[float]]:
+        docs: list[dict[str, Any]] | list[str],
+        rankings: list[Any],
+    ) -> tuple[list[Any], list[float]]:
         """
         Post-process the initial list of documents to include ranking scores,
         if specified.
@@ -149,8 +147,8 @@ class VoyageAIReranker(BaseReranker):
         return reranked_docs, scores
 
     def rank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Rerank documents based on the provided query using the VoyageAI rerank API.
 
@@ -174,8 +172,8 @@ class VoyageAIReranker(BaseReranker):
         return reranked_docs
 
     async def arank(
-        self, query: str, docs: Union[List[Dict[str, Any]], List[str]], **kwargs
-    ) -> Union[Tuple[List[Dict[str, Any]], List[float]], List[Dict[str, Any]]]:
+        self, query: str, docs: list[dict[str, Any]] | list[str], **kwargs
+    ) -> tuple[list[dict[str, Any]], list[float]] | list[dict[str, Any]]:
         """
         Rerank documents based on the provided query using the VoyageAI rerank API.
 

--- a/redisvl/utils/token_escaper.py
+++ b/redisvl/utils/token_escaper.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, Pattern
+from typing import Pattern
 
 
 class TokenEscaper:
@@ -15,7 +15,7 @@ class TokenEscaper:
     # Same as above but excludes * and ? to allow wildcard patterns
     ESCAPED_CHARS_NO_WILDCARD = r"[,.<>{}\[\]\\\"\':;!@#$%^&()\-+=~\/ ]"
 
-    def __init__(self, escape_chars_re: Optional[Pattern] = None):
+    def __init__(self, escape_chars_re: Pattern | None = None):
         if escape_chars_re:
             self.escaped_chars_re = escape_chars_re
         else:

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
 from time import time
-from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, TypeVar
+from typing import Any, Callable, Coroutine, Sequence, TypeVar
 from warnings import warn
 
 from pydantic import BaseModel
@@ -28,7 +28,7 @@ def current_timestamp() -> float:
     return time()
 
 
-def model_to_dict(model: BaseModel) -> Dict[str, Any]:
+def model_to_dict(model: BaseModel) -> dict[str, Any]:
     """
     Custom serialization function that converts a Pydantic model to a dict,
     serializing Enum fields to their values, and handling nested models and lists.
@@ -75,7 +75,7 @@ def deserialize(data: str) -> Any:
     return json.loads(data)
 
 
-def deprecated_argument(argument: str, replacement: Optional[str] = None) -> Callable:
+def deprecated_argument(argument: str, replacement: str | None = None) -> Callable:
     """
     Decorator to warn if a deprecated argument is passed.
 
@@ -145,7 +145,7 @@ def assert_no_warnings():
         yield
 
 
-def deprecated_function(name: Optional[str] = None, replacement: Optional[str] = None):
+def deprecated_function(name: str | None = None, replacement: str | None = None):
     """
     Decorator to mark a function as deprecated.
 
@@ -172,7 +172,7 @@ def deprecated_function(name: Optional[str] = None, replacement: Optional[str] =
     return decorator
 
 
-def deprecated_class(name: Optional[str] = None, replacement: Optional[str] = None):
+def deprecated_class(name: str | None = None, replacement: str | None = None):
     """
     Decorator to mark a class as deprecated.
 

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -2,10 +2,9 @@ import io
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Annotated, Any, Callable
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from typing_extensions import Annotated
 
 from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.redis.utils import array_to_buffer
@@ -47,8 +46,8 @@ class BaseVectorizer(BaseModel):
 
     model: str
     dtype: str = "float32"
-    dims: Annotated[Optional[int], Field(strict=True, gt=0)] = None
-    cache: Optional[EmbeddingsCache] = Field(default=None)
+    dims: Annotated[int | None, Field(strict=True, gt=0)] = None
+    cache: EmbeddingsCache | None = Field(default=None)
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
@@ -73,11 +72,11 @@ class BaseVectorizer(BaseModel):
         self,
         content: Any = None,
         text: Any = None,
-        preprocess: Optional[Callable] = None,
+        preprocess: Callable | None = None,
         as_buffer: bool = False,
         skip_cache: bool = False,
         **kwargs,
-    ) -> Union[List[float], bytes]:
+    ) -> list[float] | bytes:
         """Generate a vector embedding for content.
 
         Args:
@@ -139,14 +138,14 @@ class BaseVectorizer(BaseModel):
     @deprecated_argument("texts", "contents")
     def embed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
-        preprocess: Optional[Callable] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
+        preprocess: Callable | None = None,
         batch_size: int = 10,
         as_buffer: bool = False,
         skip_cache: bool = False,
         **kwargs,
-    ) -> Union[List[List[float]], List[bytes]]:
+    ) -> list[list[float]] | list[bytes]:
         """Generate vector embeddings for multiple items efficiently.
 
         Args:
@@ -203,11 +202,11 @@ class BaseVectorizer(BaseModel):
         self,
         content: Any = None,
         text: Any = None,
-        preprocess: Optional[Callable] = None,
+        preprocess: Callable | None = None,
         as_buffer: bool = False,
         skip_cache: bool = False,
         **kwargs,
-    ) -> Union[List[float], bytes]:
+    ) -> list[float] | bytes:
         """Asynchronously generate a vector embedding for an item of content.
 
         Args:
@@ -272,14 +271,14 @@ class BaseVectorizer(BaseModel):
     @deprecated_argument("texts", "contents")
     async def aembed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
-        preprocess: Optional[Callable] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
+        preprocess: Callable | None = None,
         batch_size: int = 10,
         as_buffer: bool = False,
         skip_cache: bool = False,
         **kwargs,
-    ) -> Union[List[List[float]], List[bytes]]:
+    ) -> list[list[float]] | list[bytes]:
         """Asynchronously generate vector embeddings for multiple items efficiently.
 
         Args:
@@ -332,23 +331,23 @@ class BaseVectorizer(BaseModel):
         return [self._process_embedding(emb, as_buffer, self.dtype) for emb in results]
 
     @deprecated_argument("text", "content")
-    def _embed(self, text: Any = "", content: Any = "", **kwargs) -> List[float]:
+    def _embed(self, text: Any = "", content: Any = "", **kwargs) -> list[float]:
         """Generate a vector embedding for a single item."""
         raise NotImplementedError
 
     @deprecated_argument("texts", "contents")
     def _embed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of items."""
         raise NotImplementedError
 
     @deprecated_argument("text", "content")
-    async def _aembed(self, content: Any = "", text: Any = "", **kwargs) -> List[float]:
+    async def _aembed(self, content: Any = "", text: Any = "", **kwargs) -> list[float]:
         """Asynchronously generate a vector embedding for a single item."""
         logger.warning(
             "This vectorizer has no async embed method. Falling back to sync."
@@ -358,11 +357,11 @@ class BaseVectorizer(BaseModel):
     @deprecated_argument("texts", "contents")
     async def _aembed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Asynchronously generate vector embeddings for a batch of items."""
         logger.warning(
             "This vectorizer has no async embed_many method. Falling back to sync."
@@ -372,8 +371,8 @@ class BaseVectorizer(BaseModel):
         )
 
     def _get_from_cache_batch(
-        self, contents: List[Any], skip_cache: bool
-    ) -> tuple[List[Optional[List[float]]], List[str], List[int]]:
+        self, contents: list[Any], skip_cache: bool
+    ) -> tuple[list[list[float] | None], list[str], list[int]]:
         """Get vector embeddings from cache and track cache misses.
 
         Args:
@@ -418,8 +417,8 @@ class BaseVectorizer(BaseModel):
         return results, cache_misses, cache_miss_indices  # type: ignore
 
     async def _aget_from_cache_batch(
-        self, contents: List[Any], skip_cache: bool
-    ) -> tuple[List[Optional[List[float]]], List[str], List[int]]:
+        self, contents: list[Any], skip_cache: bool
+    ) -> tuple[list[list[float] | None], list[str], list[int]]:
         """Asynchronously get vector embeddings from cache and track cache misses.
 
         Args:
@@ -467,9 +466,9 @@ class BaseVectorizer(BaseModel):
 
     def _store_in_cache_batch(
         self,
-        contents: List[Any],
-        embeddings: List[List[float]],
-        metadata: Dict,
+        contents: list[Any],
+        embeddings: list[list[float]],
+        metadata: dict[str, Any],
         skip_cache: bool,
     ) -> None:
         """Store a batch of vector embeddings in the cache.
@@ -500,9 +499,9 @@ class BaseVectorizer(BaseModel):
 
     async def _astore_in_cache_batch(
         self,
-        contents: List[Any],
-        embeddings: List[List[float]],
-        metadata: Dict,
+        contents: list[Any],
+        embeddings: list[list[float]],
+        metadata: dict[str, Any],
         skip_cache: bool,
     ) -> None:
         """Asynchronously store a batch of vector embeddings in the cache.
@@ -533,7 +532,7 @@ class BaseVectorizer(BaseModel):
                 f"Error storing batch in embedding cache asynchronously: {str(e)}"
             )
 
-    def batchify(self, seq: list, size: int, preprocess: Optional[Callable] = None):
+    def batchify(self, seq: list, size: int, preprocess: Callable | None = None):
         """Split a sequence into batches of specified size.
 
         Args:
@@ -551,7 +550,7 @@ class BaseVectorizer(BaseModel):
                 yield seq[pos : pos + size]
 
     def _process_embedding(
-        self, embedding: Optional[List[float]], as_buffer: bool, dtype: str
+        self, embedding: list[float] | None, as_buffer: bool, dtype: str
     ):
         """Process the vector embedding format based on the as_buffer flag."""
         if embedding is not None:
@@ -559,7 +558,7 @@ class BaseVectorizer(BaseModel):
                 return array_to_buffer(embedding, dtype)
         return embedding
 
-    def _serialize_for_cache(self, content: Any) -> Union[bytes, str]:
+    def _serialize_for_cache(self, content: Any) -> bytes | str:
         """Convert content to a cacheable format."""
         if isinstance(content, str):
             return content

--- a/redisvl/utils/vectorize/bedrock.py
+++ b/redisvl/utils/vectorize/bedrock.py
@@ -3,7 +3,7 @@ import io
 import json
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -94,9 +94,9 @@ class BedrockVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "amazon.titan-embed-text-v2:0",
-        api_config: Optional[Dict[str, str]] = None,
+        api_config: dict[str, str] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ) -> None:
         """Initialize the AWS Bedrock Vectorizer.
@@ -121,18 +121,18 @@ class BedrockVectorizer(BaseVectorizer):
         # Initialize client and set up the model
         self._setup(api_config, **kwargs)
 
-    def embed_image(self, image_path: str, **kwargs) -> Union[List[float], bytes]:
+    def embed_image(self, image_path: str, **kwargs) -> list[float] | bytes:
         """Embed an image (from its path on disk) using a Bedrock multimodal model."""
         return self.embed(Path(image_path), **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the Bedrock client and determine the embedding dimensions."""
         # Initialize client
         self._initialize_client(api_config, **kwargs)
         # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_client(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_client(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the Bedrock client using the provided API keys or
         environment variables.
@@ -204,7 +204,7 @@ class BedrockVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    def _embed(self, content: Any, **kwargs) -> List[float]:
+    def _embed(self, content: Any, **kwargs) -> list[float]:
         """
         Generate a vector embedding for a single input using the AWS Bedrock API.
 
@@ -243,8 +243,8 @@ class BedrockVectorizer(BaseVectorizer):
         retry=retry_if_not_exception_type(TypeError),
     )
     def _embed_many(
-        self, contents: List[Any], batch_size: int = 10, **kwargs
-    ) -> List[List[float]]:
+        self, contents: list[Any], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
         """
         Generate vector embeddings for a batch of inputs using the AWS Bedrock API.
 
@@ -268,7 +268,7 @@ class BedrockVectorizer(BaseVectorizer):
             raise TypeError("`contents` must be a list")
 
         try:
-            embeddings: List[List[float]] = []
+            embeddings: list[list[float]] = []
 
             for batch in self.batchify(contents, batch_size):
                 # Process each text in the batch individually since Bedrock

--- a/redisvl/utils/vectorize/custom.py
+++ b/redisvl/utils/vectorize/custom.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic import ConfigDict
 
@@ -83,11 +83,11 @@ class CustomVectorizer(BaseVectorizer):
     def __init__(
         self,
         embed: Callable,
-        embed_many: Optional[Callable] = None,
-        aembed: Optional[Callable] = None,
-        aembed_many: Optional[Callable] = None,
+        embed_many: Callable | None = None,
+        aembed: Callable | None = None,
+        aembed_many: Callable | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
     ):
         """Initialize the Custom vectorizer.
 
@@ -152,7 +152,7 @@ class CustomVectorizer(BaseVectorizer):
             except Exception as e:
                 raise ValueError(f"Invalid embed_many function: {e}")
 
-    def _embed(self, content: Any, **kwargs) -> List[float]:
+    def _embed(self, content: Any, **kwargs) -> list[float]:
         """Generate a vector embedding for a single input using the provided user function.
 
         Args:
@@ -172,8 +172,8 @@ class CustomVectorizer(BaseVectorizer):
             raise ValueError(f"Embedding input failed: {e}")
 
     def _embed_many(
-        self, contents: List[Any], batch_size: int = 10, **kwargs
-    ) -> List[List[float]]:
+        self, contents: list[Any], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of inputs using the provided user function.
 
         Args:
@@ -201,7 +201,7 @@ class CustomVectorizer(BaseVectorizer):
         except Exception as e:
             raise ValueError(f"Embedding inputs failed: {e}")
 
-    async def _aembed(self, content: Any, **kwargs) -> List[float]:
+    async def _aembed(self, content: Any, **kwargs) -> list[float]:
         """Asynchronously generate a vector embedding for a single input.
 
         Args:
@@ -231,8 +231,8 @@ class CustomVectorizer(BaseVectorizer):
             raise ValueError(f"Embedding input failed: {e}")
 
     async def _aembed_many(
-        self, contents: List[Any], batch_size: int = 10, **kwargs
-    ) -> List[List[float]]:
+        self, contents: list[Any], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
         """Asynchronously generate vector embeddings for a batch of inputs.
 
         Args:

--- a/redisvl/utils/vectorize/text/azureopenai.py
+++ b/redisvl/utils/vectorize/text/azureopenai.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -80,9 +80,9 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "text-embedding-ada-002",
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the AzureOpenAI vectorizer.
@@ -109,14 +109,14 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         # Initialize clients and set up the model
         self._setup(api_config, **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the AzureOpenAI clients and determine the embedding dimensions."""
         # Initialize clients
         self._initialize_clients(api_config, **kwargs)
         # Set model dimensions after client initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_clients(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_clients(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the AzureOpenAI clients using the provided API key, API version,
         and Azure endpoint.
@@ -220,7 +220,7 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    def _embed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    def _embed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """
         Generate a vector embedding for a single text using the AzureOpenAI API.
 
@@ -256,11 +256,11 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
     )
     def _embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """
         Generate vector embeddings for a batch of texts using the AzureOpenAI API.
 
@@ -284,7 +284,7 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
             raise TypeError("Must pass in a list of str values to embed.")
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = self._client.embeddings.create(
                     input=batch, model=self.model, **kwargs
@@ -300,7 +300,7 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    async def _aembed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    async def _aembed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """
         Asynchronously generate a vector embedding for a single text using the AzureOpenAI API.
 
@@ -336,11 +336,11 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
     )
     async def _aembed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """
         Asynchronously generate vector embeddings for a batch of texts using the AzureOpenAI API.
 
@@ -364,7 +364,7 @@ class AzureOpenAITextVectorizer(BaseVectorizer):
             raise TypeError("Must pass in a list of str values to embed.")
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = await self._aclient.embeddings.create(
                     input=batch, model=self.model, **kwargs

--- a/redisvl/utils/vectorize/text/bedrock.py
+++ b/redisvl/utils/vectorize/text/bedrock.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from redisvl.utils.utils import deprecated_argument, deprecated_class
 from redisvl.utils.vectorize.bedrock import BedrockVectorizer
@@ -11,9 +11,7 @@ class BedrockTextVectorizer(BedrockVectorizer):
     """A backwards-compatible alias for BedrockVectorizer."""
 
     @deprecated_argument("text", "content")
-    def embed(
-        self, content: Any = "", text: Any = "", **kwargs
-    ) -> Union[List[float], bytes]:
+    def embed(self, content: Any = "", text: Any = "", **kwargs) -> list[float] | bytes:
         """Generate a vector embedding for a single input using the AWS Bedrock API.
 
         Deprecated: Use `BedrockVectorizer.embed` instead.
@@ -24,10 +22,10 @@ class BedrockTextVectorizer(BedrockVectorizer):
     @deprecated_argument("texts", "contents")
     def embed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of inputs using the AWS Bedrock API.
 
         Deprecated: Use `BedrockVectorizer.embed_many` instead.

--- a/redisvl/utils/vectorize/text/cohere.py
+++ b/redisvl/utils/vectorize/text/cohere.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -80,9 +80,9 @@ class CohereTextVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "embed-english-v3.0",
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the Cohere vectorizer.
@@ -109,14 +109,14 @@ class CohereTextVectorizer(BaseVectorizer):
         # Initialize client and set up the model
         self._setup(api_config, **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the Cohere client and determine the embedding dimensions."""
         # Initialize client
         self._initialize_client(api_config, **kwargs)
         # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_client(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_client(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the Cohere client using the provided API key or an
         environment variable.
@@ -172,7 +172,7 @@ class CohereTextVectorizer(BaseVectorizer):
             # fall back (TODO get more specific)
             raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
 
-    def _get_cohere_embedding_type(self, dtype: str) -> List[str]:
+    def _get_cohere_embedding_type(self, dtype: str) -> list[str]:
         """
         Map dtype to appropriate Cohere embedding_types value.
 
@@ -206,9 +206,7 @@ class CohereTextVectorizer(BaseVectorizer):
             )
 
     @deprecated_argument("text", "content")
-    def _embed(
-        self, content: str = "", text: str = "", **kwargs
-    ) -> List[Union[float, int]]:
+    def _embed(self, content: str = "", text: str = "", **kwargs) -> list[float | int]:
         """
         Generate a vector embedding for a single text using the Cohere API.
 
@@ -277,11 +275,11 @@ class CohereTextVectorizer(BaseVectorizer):
     )
     def _embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[Union[float, int]]]:
+    ) -> list[list[float | int]]:
         """
         Generate vector embeddings for a batch of texts using the Cohere API.
 
@@ -321,7 +319,7 @@ class CohereTextVectorizer(BaseVectorizer):
         # Map dtype to appropriate embedding_type
         embedding_types = self._get_cohere_embedding_type(self.dtype)
 
-        embeddings: List = []
+        embeddings: list[Any] = []
         for batch in self.batchify(contents, batch_size):
             try:
                 response = self._client.embed(

--- a/redisvl/utils/vectorize/text/custom.py
+++ b/redisvl/utils/vectorize/text/custom.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any
 
 from redisvl.utils.utils import deprecated_argument, deprecated_class
 from redisvl.utils.vectorize.custom import CustomVectorizer
@@ -11,7 +11,7 @@ class CustomTextVectorizer(CustomVectorizer):
     """A backwards-compatible alias for CustomVectorizer."""
 
     @deprecated_argument("text", "content")
-    def embed(self, content: Any = "", text: Any = "", **kwargs) -> List[float]:
+    def embed(self, content: Any = "", text: Any = "", **kwargs) -> list[float]:
         """Generate a vector embedding for a single input using the custom function.
 
         Deprecated: Use `CustomVectorizer.embed` instead.
@@ -22,10 +22,10 @@ class CustomTextVectorizer(CustomVectorizer):
     @deprecated_argument("texts", "contents")
     def embed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of inputs using the custom function.
 
         Deprecated: Use `CustomVectorizer.embed_many` instead.
@@ -34,7 +34,7 @@ class CustomTextVectorizer(CustomVectorizer):
         return super().embed_many(contents=contents, **kwargs)
 
     @deprecated_argument("text", "content")
-    async def aembed(self, content: Any = "", text: Any = "", **kwargs) -> List[float]:
+    async def aembed(self, content: Any = "", text: Any = "", **kwargs) -> list[float]:
         """Asynchronously generate a vector embedding for a single input using the custom function.
 
         Deprecated: Use `CustomVectorizer.aembed` instead.
@@ -45,10 +45,10 @@ class CustomTextVectorizer(CustomVectorizer):
     @deprecated_argument("texts", "contents")
     async def aembed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Asynchronously generate vector embeddings for a batch of inputs using the custom function.
 
         Deprecated: Use `CustomVectorizer.aembed_many` instead.

--- a/redisvl/utils/vectorize/text/huggingface.py
+++ b/redisvl/utils/vectorize/text/huggingface.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic.v1 import PrivateAttr
 
@@ -75,7 +75,7 @@ class HFTextVectorizer(BaseVectorizer):
         self,
         model: str = "sentence-transformers/all-mpnet-base-v2",
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the Hugging Face text vectorizer.
@@ -126,7 +126,7 @@ class HFTextVectorizer(BaseVectorizer):
         return len(embedding)
 
     @deprecated_argument("text", "content")
-    def _embed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    def _embed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """Generate a vector embedding for a single text using the Hugging Face model.
 
         Args:
@@ -148,11 +148,11 @@ class HFTextVectorizer(BaseVectorizer):
     @deprecated_argument("texts", "contents")
     def _embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of texts using the Hugging Face model.
 
         Args:
@@ -171,7 +171,7 @@ class HFTextVectorizer(BaseVectorizer):
             # disable annoying tqdm by default
             kwargs["show_progress_bar"] = False
 
-        embeddings: List = []
+        embeddings: list[Any] = []
         for batch in self.batchify(contents, batch_size, None):
             batch_embeddings = self._client.encode(batch, **kwargs)
             embeddings.extend([embedding.tolist() for embedding in batch_embeddings])

--- a/redisvl/utils/vectorize/text/mistral.py
+++ b/redisvl/utils/vectorize/text/mistral.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -71,9 +71,9 @@ class MistralAITextVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "mistral-embed",
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the MistralAI vectorizer.
@@ -98,14 +98,14 @@ class MistralAITextVectorizer(BaseVectorizer):
         # Initialize client and set up the model
         self._setup(api_config, **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the MistralAI client and determine the embedding dimensions."""
         # Initialize client
         self._initialize_client(api_config, **kwargs)
         # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_client(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_client(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the Mistral client using the provided API key or an
         environment variable.
@@ -169,7 +169,7 @@ class MistralAITextVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    def _embed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    def _embed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """
         Generate a vector embedding for a single text using the MistralAI API.
 
@@ -205,11 +205,11 @@ class MistralAITextVectorizer(BaseVectorizer):
     )
     def _embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """
         Generate vector embeddings for a batch of texts using the MistralAI API.
 
@@ -233,7 +233,7 @@ class MistralAITextVectorizer(BaseVectorizer):
             raise TypeError("Must pass in a list of str values to embed.")
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = self._client.embeddings.create(
                     model=self.model, inputs=batch, **kwargs
@@ -249,7 +249,7 @@ class MistralAITextVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    async def _aembed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    async def _aembed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """
         Asynchronously generate a vector embedding for a single text using the MistralAI API.
 
@@ -285,11 +285,11 @@ class MistralAITextVectorizer(BaseVectorizer):
     )
     async def _aembed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """
         Asynchronously generate vector embeddings for a batch of texts using the MistralAI API.
 
@@ -313,7 +313,7 @@ class MistralAITextVectorizer(BaseVectorizer):
             raise TypeError("Must pass in a list of str values to embed.")
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = await self._client.embeddings.create_async(
                     model=self.model, inputs=batch, **kwargs

--- a/redisvl/utils/vectorize/text/openai.py
+++ b/redisvl/utils/vectorize/text/openai.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -71,9 +71,9 @@ class OpenAITextVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "text-embedding-ada-002",
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the OpenAI vectorizer.
@@ -98,14 +98,14 @@ class OpenAITextVectorizer(BaseVectorizer):
         # Initialize clients and set up the model
         self._setup(api_config, **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the OpenAI clients and determine the embedding dimensions."""
         # Initialize clients
         self._initialize_clients(api_config, **kwargs)
         # Set model dimensions after client initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_clients(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_clients(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the OpenAI clients using the provided API key or an
         environment variable.
@@ -168,7 +168,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    def _embed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    def _embed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """Generate a vector embedding for a single text using the OpenAI API.
 
         Args:
@@ -203,11 +203,11 @@ class OpenAITextVectorizer(BaseVectorizer):
     )
     def _embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of texts using the OpenAI API.
 
         Args:
@@ -229,7 +229,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         if contents and not isinstance(contents[0], str):
             raise TypeError("Must pass in a list of str values to embed.")
 
-        embeddings: List = []
+        embeddings: list[Any] = []
         for batch in self.batchify(contents, batch_size):
             try:
                 response = self._client.embeddings.create(
@@ -246,7 +246,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type(TypeError),
     )
-    async def _aembed(self, content: str = "", text: str = "", **kwargs) -> List[float]:
+    async def _aembed(self, content: str = "", text: str = "", **kwargs) -> list[float]:
         """Asynchronously generate a vector embedding for a single text using the OpenAI API.
 
         Args:
@@ -281,11 +281,11 @@ class OpenAITextVectorizer(BaseVectorizer):
     )
     async def _aembed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         batch_size: int = 10,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Asynchronously generate vector embeddings for a batch of texts using the OpenAI API.
 
         Args:
@@ -307,7 +307,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         if contents and not isinstance(contents[0], str):
             raise TypeError("Must pass in a list of str values to embed.")
 
-        embeddings: List = []
+        embeddings: list[Any] = []
         for batch in self.batchify(contents, batch_size):
             try:
                 response = await self._aclient.embeddings.create(

--- a/redisvl/utils/vectorize/text/vertexai.py
+++ b/redisvl/utils/vectorize/text/vertexai.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any
 
 from redisvl.utils.utils import deprecated_argument, deprecated_class
 from redisvl.utils.vectorize.vertexai import VertexAIVectorizer
@@ -11,7 +11,7 @@ class VertexAITextVectorizer(VertexAIVectorizer):
     """A backwards-compatible alias for VertexAIVectorizer."""
 
     @deprecated_argument("text", "content")
-    def embed(self, content: str = "", text: Any = "", **kwargs) -> List[float]:
+    def embed(self, content: str = "", text: Any = "", **kwargs) -> list[float]:
         """Generate a vector embedding for a single input using the VertexAI API.
 
         Deprecated: Use `VertexAIVectorizer.embed` instead.
@@ -22,10 +22,10 @@ class VertexAITextVectorizer(VertexAIVectorizer):
     @deprecated_argument("texts", "contents")
     def embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[str] | None = None,
+        texts: list[Any] | None = None,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of inputs using the VertexAI API.
 
         Deprecated: Use `VertexAIVectorizer.embed_many` instead.

--- a/redisvl/utils/vectorize/text/voyageai.py
+++ b/redisvl/utils/vectorize/text/voyageai.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any
 
 from redisvl.utils.utils import deprecated_argument, deprecated_class
 from redisvl.utils.vectorize.voyageai import VoyageAIVectorizer
@@ -11,7 +11,7 @@ class VoyageAITextVectorizer(VoyageAIVectorizer):
     """A backwards-compatible alias for VoyageAIVectorizer."""
 
     @deprecated_argument("text", "content")
-    def embed(self, content: Any = "", text: Any = "", **kwargs) -> List[float]:
+    def embed(self, content: Any = "", text: Any = "", **kwargs) -> list[float]:
         """Generate a vector embedding for a single text using the VoyageAI API.
 
         Deprecated: Use `VoyageAIVectorizer.embed` instead.
@@ -22,10 +22,10 @@ class VoyageAITextVectorizer(VoyageAIVectorizer):
     @deprecated_argument("texts", "contents")
     def embed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Generate vector embeddings for a batch of texts using the VoyageAI API.
 
         Deprecated: Use `VoyageAIVectorizer.embed_many` instead.
@@ -34,7 +34,7 @@ class VoyageAITextVectorizer(VoyageAIVectorizer):
         return super().embed_many(contents=contents, **kwargs)
 
     @deprecated_argument("text", "content")
-    async def aembed(self, content: Any = "", text: Any = "", **kwargs) -> List[float]:
+    async def aembed(self, content: Any = "", text: Any = "", **kwargs) -> list[float]:
         """Asynchronously generate a vector embedding for a single text using the VoyageAI API.
 
         Deprecated: Use `VoyageAIVectorizer.aembed` instead.
@@ -45,10 +45,10 @@ class VoyageAITextVectorizer(VoyageAIVectorizer):
     @deprecated_argument("texts", "contents")
     async def aembed_many(
         self,
-        contents: Optional[List[Any]] = None,
-        texts: Optional[List[Any]] = None,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
         **kwargs,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """Asynchronously generate vector embeddings for a batch of texts using the VoyageAI API.
 
         Deprecated: Use `VoyageAIVectorizer.aembed_many` instead.

--- a/redisvl/utils/vectorize/vertexai.py
+++ b/redisvl/utils/vectorize/vertexai.py
@@ -1,6 +1,6 @@
 import os
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -86,9 +86,9 @@ class VertexAIVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "textembedding-gecko",
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the VertexAI vectorizer.
@@ -130,7 +130,7 @@ class VertexAIVectorizer(BaseVectorizer):
 
         return TextEmbeddingModel.from_pretrained(self.model)
 
-    def embed_image(self, image_path: str, **kwargs) -> Union[List[float], bytes]:
+    def embed_image(self, image_path: str, **kwargs) -> list[float] | bytes:
         """Embed an image (from its path on disk) using a VertexAI multimodal model."""
         if not self.is_multimodal:
             raise ValueError("Cannot embed image with a non-multimodal model.")
@@ -139,7 +139,7 @@ class VertexAIVectorizer(BaseVectorizer):
 
         return self.embed(Image.load_from_file(image_path), **kwargs)
 
-    def embed_video(self, video_path: str, **kwargs) -> Union[List[float], bytes]:
+    def embed_video(self, video_path: str, **kwargs) -> list[float] | bytes:
         """Embed a video (from its path on disk) using a VertexAI multimodal model."""
         if not self.is_multimodal:
             raise ValueError("Cannot embed video with a non-multimodal model.")
@@ -148,14 +148,14 @@ class VertexAIVectorizer(BaseVectorizer):
 
         return self.embed(Video.load_from_file(video_path), **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the VertexAI client and determine the embedding dimensions."""
         # Initialize client
         self._initialize_client(api_config, **kwargs)
         # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_client(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_client(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the VertexAI client using the provided config options or
         environment variables.
@@ -231,7 +231,7 @@ class VertexAIVectorizer(BaseVectorizer):
         stop=stop_after_attempt(6),
         retry=retry_if_not_exception_type((TypeError, ValueError)),
     )
-    def _embed(self, content: Any, **kwargs) -> List[float]:
+    def _embed(self, content: Any, **kwargs) -> list[float]:
         """
         Generate a vector embedding for a single input using the VertexAI API.
 
@@ -291,8 +291,8 @@ class VertexAIVectorizer(BaseVectorizer):
         retry=retry_if_not_exception_type((TypeError, ValueError)),
     )
     def _embed_many(
-        self, contents: List[str], batch_size: int = 10, **kwargs
-    ) -> List[List[float]]:
+        self, contents: list[str], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
         """
         Generate vector embeddings for a batch of texts using the VertexAI API.
 
@@ -317,7 +317,7 @@ class VertexAIVectorizer(BaseVectorizer):
             raise TypeError("Must pass in a list of str values to embed.")
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = self._client.get_embeddings(batch, **kwargs)
                 embeddings.extend([r.values for r in response])
@@ -325,7 +325,7 @@ class VertexAIVectorizer(BaseVectorizer):
         except Exception as e:
             raise ValueError(f"Embedding texts failed: {e}")
 
-    def _serialize_for_cache(self, content: Any) -> Union[bytes, str]:
+    def _serialize_for_cache(self, content: Any) -> bytes | str:
         """Convert content to a cacheable format."""
         from vertexai.vision_models import Image, Video
 

--- a/redisvl/utils/vectorize/voyageai.py
+++ b/redisvl/utils/vectorize/voyageai.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -94,9 +94,9 @@ class VoyageAIVectorizer(BaseVectorizer):
     def __init__(
         self,
         model: str = "voyage-3-large",
-        api_config: Optional[Dict] = None,
+        api_config: dict[str, Any] | None = None,
         dtype: str = "float32",
-        cache: Optional["EmbeddingsCache"] = None,
+        cache: "EmbeddingsCache | None" = None,
         **kwargs,
     ):
         """Initialize the VoyageAI vectorizer.
@@ -131,7 +131,7 @@ class VoyageAIVectorizer(BaseVectorizer):
         """Whether a multimodal model has been configured."""
         return "multimodal" in self.model
 
-    def embed_image(self, image_path: str, **kwargs) -> Union[List[float], bytes]:
+    def embed_image(self, image_path: str, **kwargs) -> list[float] | bytes:
         """Embed an image (from its path on disk) using VoyageAI's multimodal API. Requires pillow to be installed."""
         if not self.is_multimodal:
             raise ValueError("Cannot embed image with a non-multimodal model.")
@@ -145,7 +145,7 @@ class VoyageAIVectorizer(BaseVectorizer):
             )
         return self.embed(Image.open(image_path), **kwargs)
 
-    def embed_video(self, video_path: str, **kwargs) -> Union[List[float], bytes]:
+    def embed_video(self, video_path: str, **kwargs) -> list[float] | bytes:
         """Embed a video (from its path on disk) using VoyageAI's multimodal API.
 
         Requires voyageai>=0.3.6 to be installed, as well as ffmpeg to be installed on the system.
@@ -167,7 +167,7 @@ class VoyageAIVectorizer(BaseVectorizer):
         )
         return self.embed(video, **kwargs)
 
-    def _setup(self, api_config: Optional[Dict], **kwargs):
+    def _setup(self, api_config: dict[str, Any] | None, **kwargs):
         """Set up the VoyageAI client and determine the embedding dimensions."""
         # Initialize client
         self._initialize_client(api_config, **kwargs)
@@ -182,7 +182,7 @@ class VoyageAIVectorizer(BaseVectorizer):
         # Set model dimensions after initialization
         self.dims = self._set_model_dims()
 
-    def _initialize_client(self, api_config: Optional[Dict], **kwargs):
+    def _initialize_client(self, api_config: dict[str, Any] | None, **kwargs):
         """
         Setup the VoyageAI clients using the provided API key or an
         environment variable.
@@ -257,7 +257,7 @@ class VoyageAIVectorizer(BaseVectorizer):
             return 7  # Default for other models
 
     def _validate_input(
-        self, contents: List[Any], input_type: Optional[str], truncation: Optional[bool]
+        self, contents: list[Any], input_type: str | None, truncation: bool | None
     ):
         """
         Validate the inputs to the embedding methods.
@@ -284,7 +284,7 @@ class VoyageAIVectorizer(BaseVectorizer):
         if truncation is not None and not isinstance(truncation, bool):
             raise TypeError("Truncation (optional) parameter is a bool.")
 
-    def _embed(self, content: Any, **kwargs) -> List[float]:
+    def _embed(self, content: Any, **kwargs) -> list[float]:
         """
         Generate a vector embedding for a single item using the VoyageAI API.
 
@@ -310,8 +310,8 @@ class VoyageAIVectorizer(BaseVectorizer):
         retry=retry_if_not_exception_type(TypeError),
     )
     def _embed_many(
-        self, contents: List[Any], batch_size: Optional[int] = None, **kwargs
-    ) -> List[List[float]]:
+        self, contents: list[Any], batch_size: int | None = None, **kwargs
+    ) -> list[list[float]]:
         """
         Generate vector embeddings for a batch of items using the VoyageAI API.
 
@@ -341,7 +341,7 @@ class VoyageAIVectorizer(BaseVectorizer):
             batch_size = self._get_batch_size()
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = self._embed_fn(
                     (
@@ -359,7 +359,7 @@ class VoyageAIVectorizer(BaseVectorizer):
         except Exception as e:
             raise ValueError(f"Embedding texts failed: {e}")
 
-    async def _aembed(self, content: Any, **kwargs) -> List[float]:
+    async def _aembed(self, content: Any, **kwargs) -> list[float]:
         """
         Asynchronously generate a vector embedding for a single item using the VoyageAI API.
 
@@ -385,8 +385,8 @@ class VoyageAIVectorizer(BaseVectorizer):
         retry=retry_if_not_exception_type(TypeError),
     )
     async def _aembed_many(
-        self, contents: List[Any], batch_size: Optional[int] = None, **kwargs
-    ) -> List[List[float]]:
+        self, contents: list[Any], batch_size: int | None = None, **kwargs
+    ) -> list[list[float]]:
         """
         Asynchronously generate vector embeddings for a batch of items using the VoyageAI API.
 
@@ -416,7 +416,7 @@ class VoyageAIVectorizer(BaseVectorizer):
             batch_size = self._get_batch_size()
 
         try:
-            embeddings: List = []
+            embeddings: list[Any] = []
             for batch in self.batchify(contents, batch_size):
                 response = await self._aembed_fn(
                     (
@@ -434,7 +434,7 @@ class VoyageAIVectorizer(BaseVectorizer):
         except Exception as e:
             raise ValueError(f"Embedding texts failed: {e}")
 
-    def _serialize_for_cache(self, content: Any) -> Union[bytes, str]:
+    def _serialize_for_cache(self, content: Any) -> bytes | str:
         """Convert content to a cacheable format."""
         try:
             from voyageai.video_utils import Video

--- a/tests/integration/test_embedcache.py
+++ b/tests/integration/test_embedcache.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import time
-from typing import Any, Dict, List, Optional
 
 import pytest
 from redis.exceptions import ConnectionError

--- a/tests/integration/test_langcache_semantic_cache_integration.py
+++ b/tests/integration/test_langcache_semantic_cache_integration.py
@@ -14,7 +14,6 @@ Env vars (loaded from .env locally, injected via CI):
 """
 
 import os
-from typing import Dict
 
 import pytest
 from dotenv import load_dotenv
@@ -36,7 +35,7 @@ REQUIRED_NO_ATTRS_VARS = (
 )
 
 
-def _require_env_vars(var_names: tuple[str, ...]) -> Dict[str, str]:
+def _require_env_vars(var_names: tuple[str, ...]) -> dict[str, str]:
     missing = [name for name in var_names if not os.getenv(name)]
     if missing:
         pytest.skip(

--- a/tests/integration/test_mcp/test_server_startup.py
+++ b/tests/integration/test_mcp/test_server_startup.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from typing import Optional
+from typing import Any
 
 import pytest
 import yaml
@@ -33,7 +33,7 @@ async def existing_index(async_client, worker_id):
         *,
         index_name: str,
         storage_type: str = "hash",
-        vector_path: Optional[str] = None,
+        vector_path: str | None = None,
     ) -> AsyncSearchIndex:
         fields = [{"name": "content", "type": "text"}]
         vector_field = {
@@ -81,9 +81,9 @@ def mcp_config_path(tmp_path: Path, redis_url: str):
         *,
         redis_name: str,
         vector_dims: int = 3,
-        schema_overrides: Optional[dict] = None,
-        runtime_overrides: Optional[dict] = None,
-        search: Optional[dict] = None,
+        schema_overrides: dict[str, Any] | None = None,
+        runtime_overrides: dict[str, Any] | None = None,
+        search: dict[str, Any] | None = None,
     ) -> str:
         runtime = {
             "text_field_name": "content",

--- a/tests/integration/test_mcp/test_upsert_tool.py
+++ b/tests/integration/test_mcp/test_upsert_tool.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import pytest
 import yaml
@@ -17,32 +17,32 @@ class RecordingVectorizer:
         self.model = model
         self.dims = dims
         self.kwargs = kwargs
-        self.aembed_many_inputs: List[List[str]] = []
-        self.embed_many_inputs: List[List[str]] = []
-        self.aembed_inputs: List[str] = []
-        self.embed_inputs: List[str] = []
+        self.aembed_many_inputs: list[list[str]] = []
+        self.embed_many_inputs: list[list[str]] = []
+        self.aembed_inputs: list[str] = []
+        self.embed_inputs: list[str] = []
 
     @staticmethod
-    def _vector_for(text: str) -> List[float]:
+    def _vector_for(text: str) -> list[float]:
         base = float(len(text))
         return [base, base + 0.1, base + 0.2]
 
-    async def aembed(self, content: str = "", **kwargs: Any) -> List[float]:
+    async def aembed(self, content: str = "", **kwargs: Any) -> list[float]:
         del kwargs
         self.aembed_inputs.append(content)
         return self._vector_for(content)
 
-    def embed(self, content: str = "", **kwargs: Any) -> List[float]:
+    def embed(self, content: str = "", **kwargs: Any) -> list[float]:
         del kwargs
         self.embed_inputs.append(content)
         return self._vector_for(content)
 
     async def aembed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         **kwargs: Any,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         del kwargs
         items = contents or texts or []
         self.aembed_many_inputs.append(list(items))
@@ -50,10 +50,10 @@ class RecordingVectorizer:
 
     def embed_many(
         self,
-        contents: Optional[List[str]] = None,
-        texts: Optional[List[str]] = None,
+        contents: list[str] | None = None,
+        texts: list[str] | None = None,
         **kwargs: Any,
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         del kwargs
         items = contents or texts or []
         self.embed_many_inputs.append(list(items))
@@ -100,7 +100,7 @@ def mcp_config_path(tmp_path: Path, redis_url: str):
         *,
         redis_name: str,
         read_only: bool = False,
-        runtime_overrides: Optional[Dict[str, Any]] = None,
+        runtime_overrides: dict[str, Any] | None = None,
     ) -> str:
         runtime = {
             "text_field_name": "content",
@@ -145,12 +145,12 @@ async def started_server(monkeypatch, upsertable_index, mcp_config_path):
         lambda class_name: RecordingVectorizer,
     )
 
-    servers: List[RedisVLMCPServer] = []
+    servers: list[RedisVLMCPServer] = []
 
     async def factory(
         *,
         read_only: bool = False,
-        runtime_overrides: Optional[Dict[str, Any]] = None,
+        runtime_overrides: dict[str, Any] | None = None,
     ) -> RedisVLMCPServer:
         server = RedisVLMCPServer(
             MCPSettings(
@@ -299,7 +299,7 @@ async def test_read_only_mode_excludes_upsert_tool(
 
     monkeypatch.setattr(RedisVLMCPServer, "tool", fake_tool, raising=False)
 
-    called: List[bool] = []
+    called: list[bool] = []
 
     def fake_register_upsert_tool(server: Any) -> None:
         called.append(server.mcp_settings.read_only)

--- a/tests/unit/test_base_vectorizer.py
+++ b/tests/unit/test_base_vectorizer.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any
 
 from redisvl.utils.vectorize.base import BaseVectorizer
 
@@ -15,28 +15,28 @@ def test_base_vectorizer_defaults():
         model: str = "simple"
         dims: int = 10
 
-        def embed(self, content: Any = "", text: Any = "", **kwargs) -> List[float]:
+        def embed(self, content: Any = "", text: Any = "", **kwargs) -> list[float]:
             return [0.0] * self.dims
 
         async def aembed(
             self, content: Any = "", text: Any = "", **kwargs
-        ) -> List[float]:
+        ) -> list[float]:
             return [0.0] * self.dims
 
         async def aembed_many(
             self,
-            contents: Optional[List[Any]] = None,
-            texts: Optional[List[Any]] = None,
+            contents: list[Any] | None = None,
+            texts: list[Any] | None = None,
             **kwargs,
-        ) -> List[List[float]]:
+        ) -> list[list[float]]:
             return [[0.0] * self.dims] * len(contents)
 
         def embed_many(
             self,
-            contents: Optional[List[Any]] = None,
-            texts: Optional[List[Any]] = None,
+            contents: list[Any] | None = None,
+            texts: list[Any] | None = None,
             **kwargs,
-        ) -> List[List[float]]:
+        ) -> list[list[float]]:
             return [[0.0] * self.dims] * len(contents)
 
     vectorizer = SimpleVectorizer()

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -54,31 +54,6 @@ def test_cli_dispatches_mcp_command_lazily(monkeypatch):
     assert calls == [["rvl", "mcp", "--config", "/tmp/mcp.yaml"]]
 
 
-def test_mcp_command_rejects_unsupported_python(monkeypatch, capsys):
-    monkeypatch.delitem(sys.modules, "redisvl.mcp", raising=False)
-    monkeypatch.delitem(sys.modules, "redisvl.cli.mcp", raising=False)
-    monkeypatch.setattr(sys, "version_info", _make_version_info(3, 9, 18))
-    original_import = builtins.__import__
-
-    def missing_mcp_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "redisvl.mcp" or name.startswith("redisvl.mcp."):
-            raise ModuleNotFoundError(name)
-        return original_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", missing_mcp_import)
-
-    module = _import_cli_mcp()
-    monkeypatch.setattr(sys, "argv", ["rvl", "mcp", "--config", "/tmp/mcp.yaml"])
-
-    with pytest.raises(SystemExit) as exc_info:
-        module.MCP()
-
-    out = capsys.readouterr()
-
-    assert exc_info.value.code == 1
-    assert "3.10" in out.err or "3.10" in out.out
-
-
 def test_mcp_command_reports_missing_optional_dependencies(monkeypatch, capsys):
     monkeypatch.delitem(sys.modules, "redisvl.mcp", raising=False)
     monkeypatch.delitem(sys.modules, "redisvl.cli.mcp", raising=False)

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-from typing import Optional
 
 import pytest
 
@@ -93,7 +92,7 @@ def test_parser_leaves_connection_options_unset_by_default(parse_args):
     ],
 )
 def test_create_redis_url_resolves_connection_sources(
-    parse_args, monkeypatch, argv: list[str], env_url: Optional[str], expected: str
+    parse_args, monkeypatch, argv: list[str], env_url: str | None, expected: str
 ):
     """Resolve Redis URLs from CLI args, environment, and local defaults."""
     if env_url is None:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -38,7 +38,7 @@ class TestRedisErrorHandling:
         # Create a mock schema
         schema = Mock(spec=IndexSchema)
         schema.redis_fields = ["test_field"]
-        schema.fields = {}  # Dict[str, BaseField] for compatibility
+        schema.fields = {}  # dict[str, BaseField] for compatibility
         schema.index = Mock()
         schema.index.name = "test_index"
         schema.index.prefix = "test:"
@@ -69,7 +69,7 @@ class TestRedisErrorHandling:
         # Create a mock schema
         schema = Mock(spec=IndexSchema)
         schema.redis_fields = ["test_field"]
-        schema.fields = {}  # Dict[str, BaseField] for compatibility
+        schema.fields = {}  # dict[str, BaseField] for compatibility
         schema.index = Mock()
         schema.index.name = "test_index"
         schema.index.prefix = "test:"

--- a/tests/unit/test_hybrid_types.py
+++ b/tests/unit/test_hybrid_types.py
@@ -5,7 +5,7 @@ combines full-text search with vector similarity search using Redis's hybrid
 query capabilities (requires redis>=7.1.0).
 """
 
-from typing import List, Literal
+from typing import Literal
 
 import pytest
 
@@ -41,7 +41,7 @@ bytes_vector = array_to_buffer(sample_vector, "float32")
 sample_text = "the toon squad play basketball against a gang of aliens"
 
 
-def get_query_pieces(query: HybridQuery) -> List[str]:
+def get_query_pieces(query: HybridQuery) -> list[str]:
     """Get all the pieces of the complete hybrid query."""
     # NOTE: Modeled after logic in `redis.commands.search.commands.SearchCommands.hybrid_search`
     pieces = query.query.get_args()

--- a/tests/unit/test_index_schema_type_issue.py
+++ b/tests/unit/test_index_schema_type_issue.py
@@ -6,7 +6,7 @@ This test verifies that the IndexSchema fields type annotation
 matches what the validator actually expects.
 """
 
-from typing import Dict, List
+from typing import get_type_hints
 
 import pytest
 
@@ -52,7 +52,7 @@ class TestIndexSchemaTypeIssue:
             },
         }
 
-        # According to type annotation `fields: Dict[str, BaseField] = {}`
+        # According to type annotation `fields: dict[str, BaseField] = {}`
         # this should work, and now it does after fixing the validator
         schema = IndexSchema.from_dict(schema_dict)
         assert schema is not None
@@ -62,14 +62,11 @@ class TestIndexSchemaTypeIssue:
 
     def test_type_annotation_matches_runtime_behavior(self):
         """Test that the type annotation should match what the code actually accepts."""
-        # Get the type annotation
-        from typing import get_type_hints
-
         hints = get_type_hints(IndexSchema)
         fields_type = hints.get("fields")
 
-        # The annotation says Dict[str, BaseField]
-        assert fields_type == Dict[str, BaseField]
+        # The annotation says dict[str, BaseField]
+        assert fields_type == dict[str, BaseField]
 
         # But the validator expects List and converts to Dict
         # This is the inconsistency reported in issue #361
@@ -106,7 +103,7 @@ class TestIndexSchemaTypeIssue:
 
     def test_direct_instantiation_with_dict_fields(self):
         """Test direct instantiation with dict fields (should work after fix)."""
-        # After processing, fields are stored as Dict[str, BaseField]
+        # After processing, fields are stored as dict[str, BaseField]
         # So direct instantiation with proper dict should work
 
         # Create fields

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Optional
+from typing import Any
 
 import pytest
 
@@ -43,8 +43,8 @@ def _schema() -> IndexSchema:
 
 def _config_with_search(
     search_type: str,
-    params: Optional[dict] = None,
-    runtime_overrides: Optional[dict] = None,
+    params: dict[str, Any] | None = None,
+    runtime_overrides: dict[str, Any] | None = None,
 ) -> MCPConfig:
     runtime_config = {
         "text_field_name": "content",
@@ -91,8 +91,8 @@ class FakeServer:
         self,
         *,
         search_type: str = "vector",
-        search_params: Optional[dict] = None,
-        runtime_overrides: Optional[dict] = None,
+        search_params: dict[str, Any] | None = None,
+        runtime_overrides: dict[str, Any] | None = None,
     ):
         self.config = _config_with_search(
             search_type,

--- a/tests/unit/test_mcp/test_upsert_tool_unit.py
+++ b/tests/unit/test_mcp/test_upsert_tool_unit.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Any, List, Optional
+from typing import Any
 
 import pytest
 from redis.exceptions import RedisError
@@ -73,14 +73,14 @@ class FakeVectorizer:
         self.aembed_calls = []
         self.embed_calls = []
 
-    async def aembed_many(self, contents: List[str], **kwargs):
+    async def aembed_many(self, contents: list[str], **kwargs):
         self.aembed_many_calls.append((contents, kwargs))
         return [
             [float(index), float(index), float(index)]
             for index, _ in enumerate(contents, start=1)
         ]
 
-    def embed_many(self, contents: List[str], **kwargs):
+    def embed_many(self, contents: list[str], **kwargs):
         self.embed_many_calls.append((contents, kwargs))
         return [[9.0, 9.0, 9.0] for _ in contents]
 
@@ -94,7 +94,7 @@ class FakeVectorizer:
 
 
 class FallbackBatchVectorizer(FakeVectorizer):
-    async def aembed_many(self, contents: List[str], **kwargs):
+    async def aembed_many(self, contents: list[str], **kwargs):
         raise NotImplementedError
 
 
@@ -126,7 +126,7 @@ class FakeServer:
         storage_type: str = "hash",
         max_upsert_records: int = 5,
         skip_embedding_if_present: bool = True,
-        vectorizer: Optional[FakeVectorizer] = None,
+        vectorizer: FakeVectorizer | None = None,
     ):
         self.config = _config(
             storage_type,

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -9,7 +9,7 @@ This module tests the core validation functionality:
 """
 
 import re
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any
 
 import pytest
 
@@ -143,8 +143,8 @@ def validate_field(
     field_name: str,
     value: Any,
     should_pass: bool,
-    error_text: Optional[str] = None,
-) -> Tuple[bool, Optional[str]]:
+    error_text: str | None = None,
+) -> tuple[bool, str | None]:
     """
     Helper function to validate a field value against a schema.
 
@@ -232,14 +232,14 @@ class TestSchemaModelGenerator:
         [
             (FieldTypes.TEXT, StorageType.HASH, str),
             (FieldTypes.TAG, StorageType.HASH, str),
-            (FieldTypes.NUMERIC, StorageType.HASH, Union[int, float]),
+            (FieldTypes.NUMERIC, StorageType.HASH, int | float),
             (FieldTypes.GEO, StorageType.HASH, str),
             (FieldTypes.VECTOR, StorageType.HASH, bytes),
             (FieldTypes.TEXT, StorageType.JSON, str),
             (FieldTypes.TAG, StorageType.JSON, str),
-            (FieldTypes.NUMERIC, StorageType.JSON, Union[int, float]),
+            (FieldTypes.NUMERIC, StorageType.JSON, int | float),
             (FieldTypes.GEO, StorageType.JSON, str),
-            (FieldTypes.VECTOR, StorageType.JSON, List[float]),
+            (FieldTypes.VECTOR, StorageType.JSON, list[float]),
         ],
     )
     def test_type_mapping(self, field_type, storage_type, expected_type):

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,12 @@
 version = 1
 revision = 3
-requires-python = ">=3.9.2, <3.15"
+requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-    "python_full_version < '3.10'",
+    "python_full_version < '3.11'",
 ]
 
 [[package]]
@@ -27,7 +26,7 @@ name = "aiofile"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.10'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -161,23 +160,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/75/e19e93965ea675f1151753b409af97a14f1d888588a555e53af1e62b83eb/aiohttp-3.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8ac8854f7b0466c5d6a9ea49249b3f6176013859ac8f4bb2522ad8ed6b94ded2", size = 1760923, upload-time = "2025-10-17T14:02:37.364Z" },
     { url = "https://files.pythonhosted.org/packages/6c/a4/06ed38f1dabd98ea136fd116cba1d02c9b51af5a37d513b6850a9a567d86/aiohttp-3.13.1-cp314-cp314t-win32.whl", hash = "sha256:be697a5aeff42179ed13b332a411e674994bcd406c81642d014ace90bf4bb968", size = 463318, upload-time = "2025-10-17T14:02:39.924Z" },
     { url = "https://files.pythonhosted.org/packages/04/0f/27e4fdde899e1e90e35eeff56b54ed63826435ad6cdb06b09ed312d1b3fa/aiohttp-3.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f1d6aa90546a4e8f20c3500cb68ab14679cd91f927fa52970035fd3207dfb3da", size = 496721, upload-time = "2025-10-17T14:02:42.199Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/c8/76ef829954d9b08c0b785f43394e6cdce5c87673bf5cd6bc6dd04e1c3a04/aiohttp-3.13.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a5dc5c3b086adc232fd07e691dcc452e8e407bf7c810e6f7e18fd3941a24c5c0", size = 737600, upload-time = "2025-10-17T14:02:44.458Z" },
-    { url = "https://files.pythonhosted.org/packages/32/82/2e73cd55d35d6ecc4c5180d9388d8255c07010553badaa3634d2a77ab05a/aiohttp-3.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fb7c5f0b35f5a3a06bd5e1a7b46204c2dca734cd839da830db81f56ce60981fe", size = 493893, upload-time = "2025-10-17T14:02:47.003Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4f/b57cb7a1d16844ec58fa436fa8f8d80afd6de9281162f93a4087cd69a962/aiohttp-3.13.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cb1e557bd1a90f28dc88a6e31332753795cd471f8d18da749c35930e53d11880", size = 489224, upload-time = "2025-10-17T14:02:49.52Z" },
-    { url = "https://files.pythonhosted.org/packages/55/93/ab03a54fa57fbba05a40cae18b704965a5f2b5deec9ae11fb81b554cd393/aiohttp-3.13.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e95ea8fb27fbf667d322626a12db708be308b66cd9afd4a997230ded66ffcab4", size = 1661558, upload-time = "2025-10-17T14:02:51.897Z" },
-    { url = "https://files.pythonhosted.org/packages/27/de/c50d56b8a2baaf2178743758cb013aae343fec47a4f3e261459142df7b83/aiohttp-3.13.1-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f37da298a486e53f9b5e8ef522719b3787c4fe852639a1edcfcc9f981f2c20ba", size = 1625710, upload-time = "2025-10-17T14:02:54.39Z" },
-    { url = "https://files.pythonhosted.org/packages/11/07/1b4db771161afa796a86ffb4787fab7d81199a428d285742b553ba8d3c66/aiohttp-3.13.1-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:37cc1b9773d2a01c3f221c3ebecf0c82b1c93f55f3fde52929e40cf2ed777e6c", size = 1722626, upload-time = "2025-10-17T14:02:56.879Z" },
-    { url = "https://files.pythonhosted.org/packages/50/c6/b79780419bde91bac24ca91919f4a2bbd534cf52dc4a80b6a32bf9cfe60d/aiohttp-3.13.1-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:412bfc63a6de4907aae6041da256d183f875bf4dc01e05412b1d19cfc25ee08c", size = 1811491, upload-time = "2025-10-17T14:02:59.765Z" },
-    { url = "https://files.pythonhosted.org/packages/79/03/08dc71a29a32ef1b2e1d76c2d72559d0b729eb82933f824f149517f72d02/aiohttp-3.13.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d8ccd2946aadf7793643b57d98d5a82598295a37f98d218984039d5179823cd5", size = 1659551, upload-time = "2025-10-17T14:03:02.377Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/3d/0c43bef82e5ed691bf7b47bebe7323010bd5c9b685285829d4381e6514a3/aiohttp-3.13.1-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:51b3c44434a50bca1763792c6b98b9ba1d614339284780b43107ef37ec3aa1dc", size = 1552454, upload-time = "2025-10-17T14:03:04.894Z" },
-    { url = "https://files.pythonhosted.org/packages/09/e4/7f606092153e2f85868462efbe038da97f00459a787ba1dae84e43196041/aiohttp-3.13.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9bff813424c70ad38667edfad4fefe8ca1b09a53621ce7d0fd017e418438f58a", size = 1632849, upload-time = "2025-10-17T14:03:07.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e8/7b5dfa9c405022f6e08a97fe1e5f6aa3b8d368c0eaaca03888d4f91ede64/aiohttp-3.13.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed782a438ff4b66ce29503a1555be51a36e4b5048c3b524929378aa7450c26a9", size = 1638089, upload-time = "2025-10-17T14:03:09.798Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/d7/3bdb019f03c95238112eca8a02894b191ca1dd267544971433adc856912a/aiohttp-3.13.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:a1d6fd6e9e3578a7aeb0fa11e9a544dceccb840330277bf281325aa0fe37787e", size = 1692679, upload-time = "2025-10-17T14:03:12.274Z" },
-    { url = "https://files.pythonhosted.org/packages/29/26/a4910cad8e2699bf64f68bb01a585f164829c0b89036d4141f915c2a26ca/aiohttp-3.13.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c5e2660c6d6ab0d85c45bc8bd9f685983ebc63a5c7c0fd3ddeb647712722eca", size = 1539122, upload-time = "2025-10-17T14:03:15.106Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/ae/f4d1da25e352bee6a6973adee6f7fd551a5790b1ab2141a630d321c902c1/aiohttp-3.13.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:168279a11571a39d689fc7b9725ddcde0dc68f2336b06b69fcea0203f9fb25d8", size = 1708961, upload-time = "2025-10-17T14:03:17.756Z" },
-    { url = "https://files.pythonhosted.org/packages/92/40/b355f78d1c8a25568831847bddcb9e0999374b514bae566d53588e21a56f/aiohttp-3.13.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ff0357fa3dd28cf49ad8c515452a1d1d7ad611b513e0a4f6fa6ad6780abaddfd", size = 1647886, upload-time = "2025-10-17T14:03:20.231Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/41/c1a23276181d1f7a59e1569ae1f2ea4b03067753672791bb3587b7202899/aiohttp-3.13.1-cp39-cp39-win32.whl", hash = "sha256:a617769e8294ca58601a579697eae0b0e1b1ef770c5920d55692827d6b330ff9", size = 431590, upload-time = "2025-10-17T14:03:22.939Z" },
-    { url = "https://files.pythonhosted.org/packages/86/68/c83126f351ffa50b8b83b88c5e9bc219b6709a74139447d2e05786510873/aiohttp-3.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:f2543eebf890739fd93d06e2c16d97bdf1301d2cda5ffceb7a68441c7b590a92", size = 454627, upload-time = "2025-10-17T14:03:26.698Z" },
 ]
 
 [[package]]
@@ -288,7 +270,7 @@ name = "authlib"
 version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.10'" },
+    { name = "cryptography" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
 wheels = [
@@ -340,13 +322,11 @@ name = "black"
 version = "25.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "mypy-extensions" },
     { name = "packaging" },
     { name = "pathspec" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs" },
     { name = "pytokens" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -369,10 +349,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/18/799285282c8236a79f25d590f0222dbd6850e14b060dfaa3e720241fd772/black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f", size = 1581259, upload-time = "2025-09-19T00:32:49.685Z" },
     { url = "https://files.pythonhosted.org/packages/f1/ce/883ec4b6303acdeca93ee06b7622f1fa383c6b3765294824165d49b1a86b/black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831", size = 1655583, upload-time = "2025-09-19T00:30:44.505Z" },
     { url = "https://files.pythonhosted.org/packages/21/17/5c253aa80a0639ccc427a5c7144534b661505ae2b5a10b77ebe13fa25334/black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357", size = 1343428, upload-time = "2025-09-19T00:32:13.839Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/0f724eb152bc9fc03029a9c903ddd77a288285042222a381050d27e64ac1/black-25.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ef69351df3c84485a8beb6f7b8f9721e2009e20ef80a8d619e2d1788b7816d47", size = 1715243, upload-time = "2025-09-19T00:34:14.216Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/be/cb986ea2f0fabd0ee58668367724ba16c3a042842e9ebe009c139f8221c9/black-25.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e3c1f4cd5e93842774d9ee4ef6cd8d17790e65f44f7cdbaab5f2cf8ccf22a823", size = 1571246, upload-time = "2025-09-19T00:31:39.624Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ce/74cf4d66963fca33ab710e4c5817ceeff843c45649f61f41d88694c2e5db/black-25.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:154b06d618233fe468236ba1f0e40823d4eb08b26f5e9261526fde34916b9140", size = 1631265, upload-time = "2025-09-19T00:31:05.341Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/f3/9b11e001e84b4d1721f75e20b3c058854a748407e6fc1abe6da0aa22014f/black-25.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:e593466de7b998374ea2585a471ba90553283fb9beefcfa430d84a2651ed5933", size = 1326615, upload-time = "2025-09-19T00:31:25.347Z" },
     { url = "https://files.pythonhosted.org/packages/1b/46/863c90dcd3f9d41b109b7f19032ae0db021f0b2a81482ba0a1e28c84de86/black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae", size = 203363, upload-time = "2025-09-19T00:27:35.724Z" },
 ]
 
@@ -414,8 +390,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a4/92/dce4842b2e215d213d34b064fcdd13c6a782c43344e77336bcde586e9229/botocore-1.40.55.tar.gz", hash = "sha256:79b6472e2de92b3519d44fc1eec8c5feced7f99a0d10fdea6dc93133426057c1", size = 14446917, upload-time = "2025-10-17T19:34:47.44Z" }
 wheels = [
@@ -549,18 +524,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
-    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
-    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
 ]
 
 [[package]]
@@ -658,53 +621,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/a616d001b3f25647a9068e0b9199f697ce507ec898cacb06a0d5a1617c99/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc", size = 162340, upload-time = "2025-10-14T04:42:14.892Z" },
-    { url = "https://files.pythonhosted.org/packages/85/93/060b52deb249a5450460e0585c88a904a83aec474ab8e7aba787f45e79f2/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e", size = 159619, upload-time = "2025-10-14T04:42:16.676Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/21/0274deb1cc0632cd587a9a0ec6b4674d9108e461cb4cd40d457adaeb0564/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1", size = 153980, upload-time = "2025-10-14T04:42:17.917Z" },
-    { url = "https://files.pythonhosted.org/packages/28/2b/e3d7d982858dccc11b31906976323d790dded2017a0572f093ff982d692f/charset_normalizer-3.4.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3", size = 152174, upload-time = "2025-10-14T04:42:19.018Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ff/4a269f8e35f1e58b2df52c131a1fa019acb7ef3f8697b7d464b07e9b492d/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6", size = 151666, upload-time = "2025-10-14T04:42:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c9/ec39870f0b330d58486001dd8e532c6b9a905f5765f58a6f8204926b4a93/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88", size = 145550, upload-time = "2025-10-14T04:42:21.324Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8f/d186ab99e40e0ed9f82f033d6e49001701c81244d01905dd4a6924191a30/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1", size = 163721, upload-time = "2025-10-14T04:42:22.46Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b1/6047663b9744df26a7e479ac1e77af7134b1fcf9026243bb48ee2d18810f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf", size = 152127, upload-time = "2025-10-14T04:42:23.712Z" },
-    { url = "https://files.pythonhosted.org/packages/59/78/e5a6eac9179f24f704d1be67d08704c3c6ab9f00963963524be27c18ed87/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318", size = 161175, upload-time = "2025-10-14T04:42:24.87Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/43/0e626e42d54dd2f8dd6fc5e1c5ff00f05fbca17cb699bedead2cae69c62f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c", size = 155375, upload-time = "2025-10-14T04:42:27.246Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/91/d9615bf2e06f35e4997616ff31248c3657ed649c5ab9d35ea12fce54e380/charset_normalizer-3.4.4-cp39-cp39-win32.whl", hash = "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505", size = 99692, upload-time = "2025-10-14T04:42:28.425Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a9/6c040053909d9d1ef4fcab45fddec083aedc9052c10078339b47c8573ea8/charset_normalizer-3.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966", size = 107192, upload-time = "2025-10-14T04:42:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c6/4fa536b2c0cd3edfb7ccf8469fa0f363ea67b7213a842b90909ca33dd851/charset_normalizer-3.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50", size = 100220, upload-time = "2025-10-14T04:42:30.632Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
 name = "click"
 version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
@@ -732,8 +657,7 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "requests" },
     { name = "tokenizers" },
-    { name = "types-requests", version = "2.31.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "types-requests", version = "2.32.4.20250913", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "types-requests" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/91/a643240d558005edee11d67d29e29086d1ea4a595b9e8ba50c7a1f456d8f/cohere-5.19.0.tar.gz", hash = "sha256:95c038a4823913a6e0eabbfc1a208ed3e849144630f69010a6bb57ead2bbb55c", size = 168393, upload-time = "2025-10-16T00:39:08.4Z" }
@@ -761,129 +685,8 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.10.7"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/6c/3a3f7a46888e69d18abe3ccc6fe4cb16cccb1e6a2f99698931dafca489e6/coverage-7.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fc04cc7a3db33664e0c2d10eb8990ff6b3536f6842c9590ae8da4c614b9ed05a", size = 217987, upload-time = "2025-09-21T20:00:57.218Z" },
-    { url = "https://files.pythonhosted.org/packages/03/94/952d30f180b1a916c11a56f5c22d3535e943aa22430e9e3322447e520e1c/coverage-7.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e201e015644e207139f7e2351980feb7040e6f4b2c2978892f3e3789d1c125e5", size = 218388, upload-time = "2025-09-21T20:01:00.081Z" },
-    { url = "https://files.pythonhosted.org/packages/50/2b/9e0cf8ded1e114bcd8b2fd42792b57f1c4e9e4ea1824cde2af93a67305be/coverage-7.10.7-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:240af60539987ced2c399809bd34f7c78e8abe0736af91c3d7d0e795df633d17", size = 245148, upload-time = "2025-09-21T20:01:01.768Z" },
-    { url = "https://files.pythonhosted.org/packages/19/20/d0384ac06a6f908783d9b6aa6135e41b093971499ec488e47279f5b846e6/coverage-7.10.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8421e088bc051361b01c4b3a50fd39a4b9133079a2229978d9d30511fd05231b", size = 246958, upload-time = "2025-09-21T20:01:03.355Z" },
-    { url = "https://files.pythonhosted.org/packages/60/83/5c283cff3d41285f8eab897651585db908a909c572bdc014bcfaf8a8b6ae/coverage-7.10.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be8ed3039ae7f7ac5ce058c308484787c86e8437e72b30bf5e88b8ea10f3c87", size = 248819, upload-time = "2025-09-21T20:01:04.968Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/02eb98fdc5ff79f423e990d877693e5310ae1eab6cb20ae0b0b9ac45b23b/coverage-7.10.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e28299d9f2e889e6d51b1f043f58d5f997c373cc12e6403b90df95b8b047c13e", size = 245754, upload-time = "2025-09-21T20:01:06.321Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/bc/25c83bcf3ad141b32cd7dc45485ef3c01a776ca3aa8ef0a93e77e8b5bc43/coverage-7.10.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c4e16bd7761c5e454f4efd36f345286d6f7c5fa111623c355691e2755cae3b9e", size = 246860, upload-time = "2025-09-21T20:01:07.605Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/b7/95574702888b58c0928a6e982038c596f9c34d52c5e5107f1eef729399b5/coverage-7.10.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b1c81d0e5e160651879755c9c675b974276f135558cf4ba79fee7b8413a515df", size = 244877, upload-time = "2025-09-21T20:01:08.829Z" },
-    { url = "https://files.pythonhosted.org/packages/47/b6/40095c185f235e085df0e0b158f6bd68cc6e1d80ba6c7721dc81d97ec318/coverage-7.10.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:606cc265adc9aaedcc84f1f064f0e8736bc45814f15a357e30fca7ecc01504e0", size = 245108, upload-time = "2025-09-21T20:01:10.527Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/50/4aea0556da7a4b93ec9168420d170b55e2eb50ae21b25062513d020c6861/coverage-7.10.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:10b24412692df990dbc34f8fb1b6b13d236ace9dfdd68df5b28c2e39cafbba13", size = 245752, upload-time = "2025-09-21T20:01:11.857Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/28/ea1a84a60828177ae3b100cb6723838523369a44ec5742313ed7db3da160/coverage-7.10.7-cp310-cp310-win32.whl", hash = "sha256:b51dcd060f18c19290d9b8a9dd1e0181538df2ce0717f562fff6cf74d9fc0b5b", size = 220497, upload-time = "2025-09-21T20:01:13.459Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/1a/a81d46bbeb3c3fd97b9602ebaa411e076219a150489bcc2c025f151bd52d/coverage-7.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:3a622ac801b17198020f09af3eaf45666b344a0d69fc2a6ffe2ea83aeef1d807", size = 221392, upload-time = "2025-09-21T20:01:14.722Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/5d/c1a17867b0456f2e9ce2d8d4708a4c3a089947d0bec9c66cdf60c9e7739f/coverage-7.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a609f9c93113be646f44c2a0256d6ea375ad047005d7f57a5c15f614dc1b2f59", size = 218102, upload-time = "2025-09-21T20:01:16.089Z" },
-    { url = "https://files.pythonhosted.org/packages/54/f0/514dcf4b4e3698b9a9077f084429681bf3aad2b4a72578f89d7f643eb506/coverage-7.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:65646bb0359386e07639c367a22cf9b5bf6304e8630b565d0626e2bdf329227a", size = 218505, upload-time = "2025-09-21T20:01:17.788Z" },
-    { url = "https://files.pythonhosted.org/packages/20/f6/9626b81d17e2a4b25c63ac1b425ff307ecdeef03d67c9a147673ae40dc36/coverage-7.10.7-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5f33166f0dfcce728191f520bd2692914ec70fac2713f6bf3ce59c3deacb4699", size = 248898, upload-time = "2025-09-21T20:01:19.488Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ef/bd8e719c2f7417ba03239052e099b76ea1130ac0cbb183ee1fcaa58aaff3/coverage-7.10.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:35f5e3f9e455bb17831876048355dca0f758b6df22f49258cb5a91da23ef437d", size = 250831, upload-time = "2025-09-21T20:01:20.817Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b6/bf054de41ec948b151ae2b79a55c107f5760979538f5fb80c195f2517718/coverage-7.10.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da86b6d62a496e908ac2898243920c7992499c1712ff7c2b6d837cc69d9467e", size = 252937, upload-time = "2025-09-21T20:01:22.171Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e5/3860756aa6f9318227443c6ce4ed7bf9e70bb7f1447a0353f45ac5c7974b/coverage-7.10.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6b8b09c1fad947c84bbbc95eca841350fad9cbfa5a2d7ca88ac9f8d836c92e23", size = 249021, upload-time = "2025-09-21T20:01:23.907Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0f/bd08bd042854f7fd07b45808927ebcce99a7ed0f2f412d11629883517ac2/coverage-7.10.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4376538f36b533b46f8971d3a3e63464f2c7905c9800db97361c43a2b14792ab", size = 250626, upload-time = "2025-09-21T20:01:25.721Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a7/4777b14de4abcc2e80c6b1d430f5d51eb18ed1d75fca56cbce5f2db9b36e/coverage-7.10.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:121da30abb574f6ce6ae09840dae322bef734480ceafe410117627aa54f76d82", size = 248682, upload-time = "2025-09-21T20:01:27.105Z" },
-    { url = "https://files.pythonhosted.org/packages/34/72/17d082b00b53cd45679bad682fac058b87f011fd8b9fe31d77f5f8d3a4e4/coverage-7.10.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:88127d40df529336a9836870436fc2751c339fbaed3a836d42c93f3e4bd1d0a2", size = 248402, upload-time = "2025-09-21T20:01:28.629Z" },
-    { url = "https://files.pythonhosted.org/packages/81/7a/92367572eb5bdd6a84bfa278cc7e97db192f9f45b28c94a9ca1a921c3577/coverage-7.10.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ba58bbcd1b72f136080c0bccc2400d66cc6115f3f906c499013d065ac33a4b61", size = 249320, upload-time = "2025-09-21T20:01:30.004Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/88/a23cc185f6a805dfc4fdf14a94016835eeb85e22ac3a0e66d5e89acd6462/coverage-7.10.7-cp311-cp311-win32.whl", hash = "sha256:972b9e3a4094b053a4e46832b4bc829fc8a8d347160eb39d03f1690316a99c14", size = 220536, upload-time = "2025-09-21T20:01:32.184Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ef/0b510a399dfca17cec7bc2f05ad8bd78cf55f15c8bc9a73ab20c5c913c2e/coverage-7.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:a7b55a944a7f43892e28ad4bc0561dfd5f0d73e605d1aa5c3c976b52aea121d2", size = 221425, upload-time = "2025-09-21T20:01:33.557Z" },
-    { url = "https://files.pythonhosted.org/packages/51/7f/023657f301a276e4ba1850f82749bc136f5a7e8768060c2e5d9744a22951/coverage-7.10.7-cp311-cp311-win_arm64.whl", hash = "sha256:736f227fb490f03c6488f9b6d45855f8e0fd749c007f9303ad30efab0e73c05a", size = 220103, upload-time = "2025-09-21T20:01:34.929Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417", size = 218290, upload-time = "2025-09-21T20:01:36.455Z" },
-    { url = "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973", size = 218515, upload-time = "2025-09-21T20:01:37.982Z" },
-    { url = "https://files.pythonhosted.org/packages/66/80/4c49f7ae09cafdacc73fbc30949ffe77359635c168f4e9ff33c9ebb07838/coverage-7.10.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c", size = 250020, upload-time = "2025-09-21T20:01:39.617Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7", size = 252769, upload-time = "2025-09-21T20:01:41.341Z" },
-    { url = "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6", size = 253901, upload-time = "2025-09-21T20:01:43.042Z" },
-    { url = "https://files.pythonhosted.org/packages/53/dc/8d8119c9051d50f3119bb4a75f29f1e4a6ab9415cd1fa8bf22fcc3fb3b5f/coverage-7.10.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59", size = 250413, upload-time = "2025-09-21T20:01:44.469Z" },
-    { url = "https://files.pythonhosted.org/packages/98/b3/edaff9c5d79ee4d4b6d3fe046f2b1d799850425695b789d491a64225d493/coverage-7.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b", size = 251820, upload-time = "2025-09-21T20:01:45.915Z" },
-    { url = "https://files.pythonhosted.org/packages/11/25/9a0728564bb05863f7e513e5a594fe5ffef091b325437f5430e8cfb0d530/coverage-7.10.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a", size = 249941, upload-time = "2025-09-21T20:01:47.296Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/fd/ca2650443bfbef5b0e74373aac4df67b08180d2f184b482c41499668e258/coverage-7.10.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb", size = 249519, upload-time = "2025-09-21T20:01:48.73Z" },
-    { url = "https://files.pythonhosted.org/packages/24/79/f692f125fb4299b6f963b0745124998ebb8e73ecdfce4ceceb06a8c6bec5/coverage-7.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1", size = 251375, upload-time = "2025-09-21T20:01:50.529Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/75/61b9bbd6c7d24d896bfeec57acba78e0f8deac68e6baf2d4804f7aae1f88/coverage-7.10.7-cp312-cp312-win32.whl", hash = "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256", size = 220699, upload-time = "2025-09-21T20:01:51.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f3/3bf7905288b45b075918d372498f1cf845b5b579b723c8fd17168018d5f5/coverage-7.10.7-cp312-cp312-win_amd64.whl", hash = "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba", size = 221512, upload-time = "2025-09-21T20:01:53.481Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/44/3e32dbe933979d05cf2dac5e697c8599cfe038aaf51223ab901e208d5a62/coverage-7.10.7-cp312-cp312-win_arm64.whl", hash = "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf", size = 220147, upload-time = "2025-09-21T20:01:55.2Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/94/b765c1abcb613d103b64fcf10395f54d69b0ef8be6a0dd9c524384892cc7/coverage-7.10.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:981a651f543f2854abd3b5fcb3263aac581b18209be49863ba575de6edf4c14d", size = 218320, upload-time = "2025-09-21T20:01:56.629Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4f/732fff31c119bb73b35236dd333030f32c4bfe909f445b423e6c7594f9a2/coverage-7.10.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:73ab1601f84dc804f7812dc297e93cd99381162da39c47040a827d4e8dafe63b", size = 218575, upload-time = "2025-09-21T20:01:58.203Z" },
-    { url = "https://files.pythonhosted.org/packages/87/02/ae7e0af4b674be47566707777db1aa375474f02a1d64b9323e5813a6cdd5/coverage-7.10.7-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a8b6f03672aa6734e700bbcd65ff050fd19cddfec4b031cc8cf1c6967de5a68e", size = 249568, upload-time = "2025-09-21T20:01:59.748Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/77/8c6d22bf61921a59bce5471c2f1f7ac30cd4ac50aadde72b8c48d5727902/coverage-7.10.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:10b6ba00ab1132a0ce4428ff68cf50a25efd6840a42cdf4239c9b99aad83be8b", size = 252174, upload-time = "2025-09-21T20:02:01.192Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/20/b6ea4f69bbb52dac0aebd62157ba6a9dddbfe664f5af8122dac296c3ee15/coverage-7.10.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c79124f70465a150e89340de5963f936ee97097d2ef76c869708c4248c63ca49", size = 253447, upload-time = "2025-09-21T20:02:02.701Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/28/4831523ba483a7f90f7b259d2018fef02cb4d5b90bc7c1505d6e5a84883c/coverage-7.10.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:69212fbccdbd5b0e39eac4067e20a4a5256609e209547d86f740d68ad4f04911", size = 249779, upload-time = "2025-09-21T20:02:04.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/9f/4331142bc98c10ca6436d2d620c3e165f31e6c58d43479985afce6f3191c/coverage-7.10.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ea7c6c9d0d286d04ed3541747e6597cbe4971f22648b68248f7ddcd329207f0", size = 251604, upload-time = "2025-09-21T20:02:06.034Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/60/bda83b96602036b77ecf34e6393a3836365481b69f7ed7079ab85048202b/coverage-7.10.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b9be91986841a75042b3e3243d0b3cb0b2434252b977baaf0cd56e960fe1e46f", size = 249497, upload-time = "2025-09-21T20:02:07.619Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/af/152633ff35b2af63977edd835d8e6430f0caef27d171edf2fc76c270ef31/coverage-7.10.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b281d5eca50189325cfe1f365fafade89b14b4a78d9b40b05ddd1fc7d2a10a9c", size = 249350, upload-time = "2025-09-21T20:02:10.34Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/71/d92105d122bd21cebba877228990e1646d862e34a98bb3374d3fece5a794/coverage-7.10.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:99e4aa63097ab1118e75a848a28e40d68b08a5e19ce587891ab7fd04475e780f", size = 251111, upload-time = "2025-09-21T20:02:12.122Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9e/9fdb08f4bf476c912f0c3ca292e019aab6712c93c9344a1653986c3fd305/coverage-7.10.7-cp313-cp313-win32.whl", hash = "sha256:dc7c389dce432500273eaf48f410b37886be9208b2dd5710aaf7c57fd442c698", size = 220746, upload-time = "2025-09-21T20:02:13.919Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b1/a75fd25df44eab52d1931e89980d1ada46824c7a3210be0d3c88a44aaa99/coverage-7.10.7-cp313-cp313-win_amd64.whl", hash = "sha256:cac0fdca17b036af3881a9d2729a850b76553f3f716ccb0360ad4dbc06b3b843", size = 221541, upload-time = "2025-09-21T20:02:15.57Z" },
-    { url = "https://files.pythonhosted.org/packages/14/3a/d720d7c989562a6e9a14b2c9f5f2876bdb38e9367126d118495b89c99c37/coverage-7.10.7-cp313-cp313-win_arm64.whl", hash = "sha256:4b6f236edf6e2f9ae8fcd1332da4e791c1b6ba0dc16a2dc94590ceccb482e546", size = 220170, upload-time = "2025-09-21T20:02:17.395Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/22/e04514bf2a735d8b0add31d2b4ab636fc02370730787c576bb995390d2d5/coverage-7.10.7-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a0ec07fd264d0745ee396b666d47cef20875f4ff2375d7c4f58235886cc1ef0c", size = 219029, upload-time = "2025-09-21T20:02:18.936Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0b/91128e099035ece15da3445d9015e4b4153a6059403452d324cbb0a575fa/coverage-7.10.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd5e856ebb7bfb7672b0086846db5afb4567a7b9714b8a0ebafd211ec7ce6a15", size = 219259, upload-time = "2025-09-21T20:02:20.44Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/51/66420081e72801536a091a0c8f8c1f88a5c4bf7b9b1bdc6222c7afe6dc9b/coverage-7.10.7-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f57b2a3c8353d3e04acf75b3fed57ba41f5c0646bbf1d10c7c282291c97936b4", size = 260592, upload-time = "2025-09-21T20:02:22.313Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/22/9b8d458c2881b22df3db5bb3e7369e63d527d986decb6c11a591ba2364f7/coverage-7.10.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1ef2319dd15a0b009667301a3f84452a4dc6fddfd06b0c5c53ea472d3989fbf0", size = 262768, upload-time = "2025-09-21T20:02:24.287Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/08/16bee2c433e60913c610ea200b276e8eeef084b0d200bdcff69920bd5828/coverage-7.10.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83082a57783239717ceb0ad584de3c69cf581b2a95ed6bf81ea66034f00401c0", size = 264995, upload-time = "2025-09-21T20:02:26.133Z" },
-    { url = "https://files.pythonhosted.org/packages/20/9d/e53eb9771d154859b084b90201e5221bca7674ba449a17c101a5031d4054/coverage-7.10.7-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:50aa94fb1fb9a397eaa19c0d5ec15a5edd03a47bf1a3a6111a16b36e190cff65", size = 259546, upload-time = "2025-09-21T20:02:27.716Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/b0/69bc7050f8d4e56a89fb550a1577d5d0d1db2278106f6f626464067b3817/coverage-7.10.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2120043f147bebb41c85b97ac45dd173595ff14f2a584f2963891cbcc3091541", size = 262544, upload-time = "2025-09-21T20:02:29.216Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/4b/2514b060dbd1bc0aaf23b852c14bb5818f244c664cb16517feff6bb3a5ab/coverage-7.10.7-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2fafd773231dd0378fdba66d339f84904a8e57a262f583530f4f156ab83863e6", size = 260308, upload-time = "2025-09-21T20:02:31.226Z" },
-    { url = "https://files.pythonhosted.org/packages/54/78/7ba2175007c246d75e496f64c06e94122bdb914790a1285d627a918bd271/coverage-7.10.7-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:0b944ee8459f515f28b851728ad224fa2d068f1513ef6b7ff1efafeb2185f999", size = 258920, upload-time = "2025-09-21T20:02:32.823Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b3/fac9f7abbc841409b9a410309d73bfa6cfb2e51c3fada738cb607ce174f8/coverage-7.10.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4b583b97ab2e3efe1b3e75248a9b333bd3f8b0b1b8e5b45578e05e5850dfb2c2", size = 261434, upload-time = "2025-09-21T20:02:34.86Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/51/a03bec00d37faaa891b3ff7387192cef20f01604e5283a5fabc95346befa/coverage-7.10.7-cp313-cp313t-win32.whl", hash = "sha256:2a78cd46550081a7909b3329e2266204d584866e8d97b898cd7fb5ac8d888b1a", size = 221403, upload-time = "2025-09-21T20:02:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/53/22/3cf25d614e64bf6d8e59c7c669b20d6d940bb337bdee5900b9ca41c820bb/coverage-7.10.7-cp313-cp313t-win_amd64.whl", hash = "sha256:33a5e6396ab684cb43dc7befa386258acb2d7fae7f67330ebb85ba4ea27938eb", size = 222469, upload-time = "2025-09-21T20:02:39.011Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a1/00164f6d30d8a01c3c9c48418a7a5be394de5349b421b9ee019f380df2a0/coverage-7.10.7-cp313-cp313t-win_arm64.whl", hash = "sha256:86b0e7308289ddde73d863b7683f596d8d21c7d8664ce1dee061d0bcf3fbb4bb", size = 220731, upload-time = "2025-09-21T20:02:40.939Z" },
-    { url = "https://files.pythonhosted.org/packages/23/9c/5844ab4ca6a4dd97a1850e030a15ec7d292b5c5cb93082979225126e35dd/coverage-7.10.7-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b06f260b16ead11643a5a9f955bd4b5fd76c1a4c6796aeade8520095b75de520", size = 218302, upload-time = "2025-09-21T20:02:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/89/673f6514b0961d1f0e20ddc242e9342f6da21eaba3489901b565c0689f34/coverage-7.10.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:212f8f2e0612778f09c55dd4872cb1f64a1f2b074393d139278ce902064d5b32", size = 218578, upload-time = "2025-09-21T20:02:44.468Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e8/261cae479e85232828fb17ad536765c88dd818c8470aca690b0ac6feeaa3/coverage-7.10.7-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3445258bcded7d4aa630ab8296dea4d3f15a255588dd535f980c193ab6b95f3f", size = 249629, upload-time = "2025-09-21T20:02:46.503Z" },
-    { url = "https://files.pythonhosted.org/packages/82/62/14ed6546d0207e6eda876434e3e8475a3e9adbe32110ce896c9e0c06bb9a/coverage-7.10.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb45474711ba385c46a0bfe696c695a929ae69ac636cda8f532be9e8c93d720a", size = 252162, upload-time = "2025-09-21T20:02:48.689Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/49/07f00db9ac6478e4358165a08fb41b469a1b053212e8a00cb02f0d27a05f/coverage-7.10.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:813922f35bd800dca9994c5971883cbc0d291128a5de6b167c7aa697fcf59360", size = 253517, upload-time = "2025-09-21T20:02:50.31Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/59/c5201c62dbf165dfbc91460f6dbbaa85a8b82cfa6131ac45d6c1bfb52deb/coverage-7.10.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:93c1b03552081b2a4423091d6fb3787265b8f86af404cff98d1b5342713bdd69", size = 249632, upload-time = "2025-09-21T20:02:51.971Z" },
-    { url = "https://files.pythonhosted.org/packages/07/ae/5920097195291a51fb00b3a70b9bbd2edbfe3c84876a1762bd1ef1565ebc/coverage-7.10.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:cc87dd1b6eaf0b848eebb1c86469b9f72a1891cb42ac7adcfbce75eadb13dd14", size = 251520, upload-time = "2025-09-21T20:02:53.858Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/3c/a815dde77a2981f5743a60b63df31cb322c944843e57dbd579326625a413/coverage-7.10.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:39508ffda4f343c35f3236fe8d1a6634a51f4581226a1262769d7f970e73bffe", size = 249455, upload-time = "2025-09-21T20:02:55.807Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/99/f5cdd8421ea656abefb6c0ce92556709db2265c41e8f9fc6c8ae0f7824c9/coverage-7.10.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:925a1edf3d810537c5a3abe78ec5530160c5f9a26b1f4270b40e62cc79304a1e", size = 249287, upload-time = "2025-09-21T20:02:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/7a/e9a2da6a1fc5d007dd51fca083a663ab930a8c4d149c087732a5dbaa0029/coverage-7.10.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2c8b9a0636f94c43cd3576811e05b89aa9bc2d0a85137affc544ae5cb0e4bfbd", size = 250946, upload-time = "2025-09-21T20:02:59.431Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5b/0b5799aa30380a949005a353715095d6d1da81927d6dbed5def2200a4e25/coverage-7.10.7-cp314-cp314-win32.whl", hash = "sha256:b7b8288eb7cdd268b0304632da8cb0bb93fadcfec2fe5712f7b9cc8f4d487be2", size = 221009, upload-time = "2025-09-21T20:03:01.324Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b0/e802fbb6eb746de006490abc9bb554b708918b6774b722bb3a0e6aa1b7de/coverage-7.10.7-cp314-cp314-win_amd64.whl", hash = "sha256:1ca6db7c8807fb9e755d0379ccc39017ce0a84dcd26d14b5a03b78563776f681", size = 221804, upload-time = "2025-09-21T20:03:03.4Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e8/71d0c8e374e31f39e3389bb0bd19e527d46f00ea8571ec7ec8fd261d8b44/coverage-7.10.7-cp314-cp314-win_arm64.whl", hash = "sha256:097c1591f5af4496226d5783d036bf6fd6cd0cbc132e071b33861de756efb880", size = 220384, upload-time = "2025-09-21T20:03:05.111Z" },
-    { url = "https://files.pythonhosted.org/packages/62/09/9a5608d319fa3eba7a2019addeacb8c746fb50872b57a724c9f79f146969/coverage-7.10.7-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:a62c6ef0d50e6de320c270ff91d9dd0a05e7250cac2a800b7784bae474506e63", size = 219047, upload-time = "2025-09-21T20:03:06.795Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/6f/f58d46f33db9f2e3647b2d0764704548c184e6f5e014bef528b7f979ef84/coverage-7.10.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9fa6e4dd51fe15d8738708a973470f67a855ca50002294852e9571cdbd9433f2", size = 219266, upload-time = "2025-09-21T20:03:08.495Z" },
-    { url = "https://files.pythonhosted.org/packages/74/5c/183ffc817ba68e0b443b8c934c8795553eb0c14573813415bd59941ee165/coverage-7.10.7-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8fb190658865565c549b6b4706856d6a7b09302c797eb2cf8e7fe9dabb043f0d", size = 260767, upload-time = "2025-09-21T20:03:10.172Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/48/71a8abe9c1ad7e97548835e3cc1adbf361e743e9d60310c5f75c9e7bf847/coverage-7.10.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:affef7c76a9ef259187ef31599a9260330e0335a3011732c4b9effa01e1cd6e0", size = 262931, upload-time = "2025-09-21T20:03:11.861Z" },
-    { url = "https://files.pythonhosted.org/packages/84/fd/193a8fb132acfc0a901f72020e54be5e48021e1575bb327d8ee1097a28fd/coverage-7.10.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e16e07d85ca0cf8bafe5f5d23a0b850064e8e945d5677492b06bbe6f09cc699", size = 265186, upload-time = "2025-09-21T20:03:13.539Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/8f/74ecc30607dd95ad50e3034221113ccb1c6d4e8085cc761134782995daae/coverage-7.10.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03ffc58aacdf65d2a82bbeb1ffe4d01ead4017a21bfd0454983b88ca73af94b9", size = 259470, upload-time = "2025-09-21T20:03:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/55/79ff53a769f20d71b07023ea115c9167c0bb56f281320520cf64c5298a96/coverage-7.10.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1b4fd784344d4e52647fd7857b2af5b3fbe6c239b0b5fa63e94eb67320770e0f", size = 262626, upload-time = "2025-09-21T20:03:17.673Z" },
-    { url = "https://files.pythonhosted.org/packages/88/e2/dac66c140009b61ac3fc13af673a574b00c16efdf04f9b5c740703e953c0/coverage-7.10.7-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0ebbaddb2c19b71912c6f2518e791aa8b9f054985a0769bdb3a53ebbc765c6a1", size = 260386, upload-time = "2025-09-21T20:03:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/f1/f48f645e3f33bb9ca8a496bc4a9671b52f2f353146233ebd7c1df6160440/coverage-7.10.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a2d9a3b260cc1d1dbdb1c582e63ddcf5363426a1a68faa0f5da28d8ee3c722a0", size = 258852, upload-time = "2025-09-21T20:03:21.007Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/3b/8442618972c51a7affeead957995cfa8323c0c9bcf8fa5a027421f720ff4/coverage-7.10.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a3cc8638b2480865eaa3926d192e64ce6c51e3d29c849e09d5b4ad95efae5399", size = 261534, upload-time = "2025-09-21T20:03:23.12Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/dc/101f3fa3a45146db0cb03f5b4376e24c0aac818309da23e2de0c75295a91/coverage-7.10.7-cp314-cp314t-win32.whl", hash = "sha256:67f8c5cbcd3deb7a60b3345dffc89a961a484ed0af1f6f73de91705cc6e31235", size = 221784, upload-time = "2025-09-21T20:03:24.769Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a1/74c51803fc70a8a40d7346660379e144be772bab4ac7bb6e6b905152345c/coverage-7.10.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e1ed71194ef6dea7ed2d5cb5f7243d4bcd334bfb63e59878519be558078f848d", size = 222905, upload-time = "2025-09-21T20:03:26.93Z" },
-    { url = "https://files.pythonhosted.org/packages/12/65/f116a6d2127df30bcafbceef0302d8a64ba87488bf6f73a6d8eebf060873/coverage-7.10.7-cp314-cp314t-win_arm64.whl", hash = "sha256:7fe650342addd8524ca63d77b2362b02345e5f1a093266787d210c70a50b471a", size = 220922, upload-time = "2025-09-21T20:03:28.672Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3", size = 217978, upload-time = "2025-09-21T20:03:30.362Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c", size = 218370, upload-time = "2025-09-21T20:03:32.147Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6e/30d006c3b469e58449650642383dddf1c8fb63d44fdf92994bfd46570695/coverage-7.10.7-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396", size = 244802, upload-time = "2025-09-21T20:03:33.919Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40", size = 246625, upload-time = "2025-09-21T20:03:36.09Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594", size = 248399, upload-time = "2025-09-21T20:03:38.342Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/54/b140edee7257e815de7426d5d9846b58505dffc29795fff2dfb7f8a1c5a0/coverage-7.10.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a", size = 245142, upload-time = "2025-09-21T20:03:40.591Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/9e/6d6b8295940b118e8b7083b29226c71f6154f7ff41e9ca431f03de2eac0d/coverage-7.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b", size = 246284, upload-time = "2025-09-21T20:03:42.355Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e5/5e957ca747d43dbe4d9714358375c7546cb3cb533007b6813fc20fce37ad/coverage-7.10.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3", size = 244353, upload-time = "2025-09-21T20:03:44.218Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/45/540fc5cc92536a1b783b7ef99450bd55a4b3af234aae35a18a339973ce30/coverage-7.10.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0", size = 244430, upload-time = "2025-09-21T20:03:46.065Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0b/8287b2e5b38c8fe15d7e3398849bb58d382aedc0864ea0fa1820e8630491/coverage-7.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f", size = 245311, upload-time = "2025-09-21T20:03:48.19Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1d/29724999984740f0c86d03e6420b942439bf5bd7f54d4382cae386a9d1e9/coverage-7.10.7-cp39-cp39-win32.whl", hash = "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431", size = 220500, upload-time = "2025-09-21T20:03:50.024Z" },
-    { url = "https://files.pythonhosted.org/packages/43/11/4b1e6b129943f905ca54c339f343877b55b365ae2558806c1be4f7476ed5/coverage-7.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07", size = 221408, upload-time = "2025-09-21T20:03:51.803Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
-]
-
-[[package]]
-name = "coverage"
 version = "7.11.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/38/ee22495420457259d2f3390309505ea98f98a5eed40901cf62196abad006/coverage-7.11.0.tar.gz", hash = "sha256:167bd504ac1ca2af7ff3b81d245dfea0292c5032ebef9d66cc08a7d28c1b8050", size = 811905, upload-time = "2025-10-15T15:15:08.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/95/c49df0aceb5507a80b9fe5172d3d39bf23f05be40c23c8d77d556df96cec/coverage-7.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eb53f1e8adeeb2e78962bade0c08bfdc461853c7969706ed901821e009b35e31", size = 215800, upload-time = "2025-10-15T15:12:19.824Z" },
@@ -1049,12 +852,12 @@ name = "cyclopts"
 version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version >= '3.10'" },
-    { name = "docstring-parser", marker = "python_full_version >= '3.10'" },
-    { name = "rich", marker = "python_full_version >= '3.10'" },
-    { name = "rich-rst", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/c4/2ce2ca1451487dc7d59f09334c3fa1182c46cfcf0a2d5f19f9b26d53ac74/cyclopts-4.10.1.tar.gz", hash = "sha256:ad4e4bb90576412d32276b14a76f55d43353753d16217f2c3cd5bdceba7f15a0", size = 166623, upload-time = "2026-03-23T14:43:01.098Z" }
 wheels = [
@@ -1087,10 +890,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/73/2aa00c7f1f06e997ef57dc9b23d61a92120bec1437a012afb6d176585197/debugpy-1.8.17-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:b69b6bd9dba6a03632534cdf67c760625760a215ae289f7489a452af1031fe1f", size = 4268254, upload-time = "2025-09-17T16:34:04.486Z" },
     { url = "https://files.pythonhosted.org/packages/86/b5/ed3e65c63c68a6634e3ba04bd10255c8e46ec16ebed7d1c79e4816d8a760/debugpy-1.8.17-cp314-cp314-win32.whl", hash = "sha256:5c59b74aa5630f3a5194467100c3b3d1c77898f9ab27e3f7dc5d40fc2f122670", size = 5277203, upload-time = "2025-09-17T16:34:06.65Z" },
     { url = "https://files.pythonhosted.org/packages/b0/26/394276b71c7538445f29e792f589ab7379ae70fd26ff5577dfde71158e96/debugpy-1.8.17-cp314-cp314-win_amd64.whl", hash = "sha256:893cba7bb0f55161de4365584b025f7064e1f88913551bcd23be3260b231429c", size = 5318493, upload-time = "2025-09-17T16:34:08.483Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ee/0e9a08878f1b525f85c4e47723ea1f17b1bad69672c84fa910210604e3f8/debugpy-1.8.17-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:f2ac8055a0c4a09b30b931100996ba49ef334c6947e7ae365cdd870416d7513e", size = 2099309, upload-time = "2025-09-17T16:34:17.935Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/b5/0327b27efd8826ca92a256a3a250e80ccad6a834b4d12bd9cbd491f2da03/debugpy-1.8.17-cp39-cp39-manylinux_2_34_x86_64.whl", hash = "sha256:eaa85bce251feca8e4c87ce3b954aba84b8c645b90f0e6a515c00394a9f5c0e7", size = 3080100, upload-time = "2025-09-17T16:34:19.885Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/f0/2e210fa8884d2ab452fa31ffd1402e13010eaacfa67063d0565d97ac9e0e/debugpy-1.8.17-cp39-cp39-win32.whl", hash = "sha256:b13eea5587e44f27f6c48588b5ad56dcb74a4f3a5f89250443c94587f3eb2ea1", size = 5231016, upload-time = "2025-09-17T16:34:21.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/9b/6a45fb1553d09b618c9441bcbbf72b651246b83b5618b2f95c0e4cf1b8bd/debugpy-1.8.17-cp39-cp39-win_amd64.whl", hash = "sha256:bb1bbf92317e1f35afcf3ef0450219efb3afe00be79d8664b250ac0933b9015f", size = 5262778, upload-time = "2025-09-17T16:34:24.026Z" },
     { url = "https://files.pythonhosted.org/packages/b0/d0/89247ec250369fc76db477720a26b2fce7ba079ff1380e4ab4529d2fe233/debugpy-1.8.17-py2.py3-none-any.whl", hash = "sha256:60c7dca6571efe660ccb7a9508d73ca14b8796c4ed484c2002abba714226cfef", size = 5283210, upload-time = "2025-09-17T16:34:25.835Z" },
 ]
 
@@ -1155,8 +954,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
@@ -1186,8 +984,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython", marker = "python_full_version >= '3.10'" },
-    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "dnspython" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -1278,12 +1076,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/1c/6dfd082a205be4510543221b734b1191299e6a1810c452b6bc76dfa6968e/fastavro-1.12.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6a3462934b20a74f9ece1daa49c2e4e749bd9a35fa2657b53bf62898fba80f5", size = 3433972, upload-time = "2025-10-10T15:42:14.485Z" },
     { url = "https://files.pythonhosted.org/packages/24/90/9de694625a1a4b727b1ad0958d220cab25a9b6cf7f16a5c7faa9ea7b2261/fastavro-1.12.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1f81011d54dd47b12437b51dd93a70a9aa17b61307abf26542fc3c13efbc6c51", size = 3368752, upload-time = "2025-10-10T15:42:16.618Z" },
     { url = "https://files.pythonhosted.org/packages/fa/93/b44f67589e4d439913dab6720f7e3507b0fa8b8e56d06f6fc875ced26afb/fastavro-1.12.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43ded16b3f4a9f1a42f5970c2aa618acb23ea59c4fcaa06680bdf470b255e5a8", size = 3386636, upload-time = "2025-10-10T15:42:18.974Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b8/67f5682cd59cb59ec6eecb5479b132caaf69709d1e1ceda4f92d8c69d7f1/fastavro-1.12.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:02281432dcb11c78b3280da996eff61ee0eff39c5de06c6e0fbf19275093e6d4", size = 1002311, upload-time = "2025-10-10T15:42:20.415Z" },
-    { url = "https://files.pythonhosted.org/packages/93/38/2f15a7ad24e4b6e0239016c068f142358732bf8ead0315ee926b88634bec/fastavro-1.12.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4128978b930aaf930332db4b3acc290783183f3be06a241ae4a482f3ed8ce892", size = 3195871, upload-time = "2025-10-10T15:42:22.675Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/e5/6fc0250b3006b1b42c1ab9f0511ccd44e1aeb15a63a77fc780ee97f58797/fastavro-1.12.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:546ffffda6610fca672f0ed41149808e106d8272bb246aa7539fa8bb6f117f17", size = 3204127, upload-time = "2025-10-10T15:42:24.855Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/43/1f3909eb096eb1066e416f0875abe783b73fabe823ad616f6956b3e80e84/fastavro-1.12.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a7d840ccd9aacada3ddc80fbcc4ea079b658107fe62e9d289a0de9d54e95d366", size = 3135604, upload-time = "2025-10-10T15:42:28.899Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/61/ec083a3a5d7c2b97d0e2c9e137a6e667583afe884af0e49318f7ee7eaa5a/fastavro-1.12.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3100ad643e7fa658469a2a2db229981c1a000ff16b8037c0b58ce3ec4d2107e8", size = 3210932, upload-time = "2025-10-10T15:42:30.891Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ba/b814fb09b32c8f3059451c33bb11d55eb23188e6a499f5dde628d13bc076/fastavro-1.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:a38607444281619eda3a9c1be9f5397634012d1b237142eee1540e810b30ac8b", size = 510328, upload-time = "2025-10-10T15:42:32.415Z" },
 ]
 
 [[package]]
@@ -1300,27 +1092,27 @@ name = "fastmcp"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib", marker = "python_full_version >= '3.10'" },
-    { name = "cyclopts", marker = "python_full_version >= '3.10'" },
-    { name = "exceptiongroup", marker = "python_full_version >= '3.10'" },
-    { name = "httpx", marker = "python_full_version >= '3.10'" },
-    { name = "jsonref", marker = "python_full_version >= '3.10'" },
-    { name = "jsonschema-path", marker = "python_full_version >= '3.10'" },
-    { name = "mcp", marker = "python_full_version >= '3.10'" },
-    { name = "openapi-pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"], marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", extra = ["email"], marker = "python_full_version >= '3.10'" },
-    { name = "pyperclip", marker = "python_full_version >= '3.10'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "rich", marker = "python_full_version >= '3.10'" },
-    { name = "uncalled-for", marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.10'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.10'" },
-    { name = "websockets", marker = "python_full_version >= '3.10'" },
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
 wheels = [
@@ -1341,27 +1133,8 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
-]
-
-[[package]]
-name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
@@ -1485,22 +1258,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/59/ae5cdac87a00962122ea37bb346d41b66aec05f9ce328fa2b9e216f8967b/frozenlist-1.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d8b7138e5cd0647e4523d6685b0eac5d4be9a184ae9634492f25c6eb38c12a47", size = 86967, upload-time = "2025-10-06T05:37:55.607Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/10/17059b2db5a032fd9323c41c39e9d1f5f9d0c8f04d1e4e3e788573086e61/frozenlist-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a6483e309ca809f1efd154b4d37dc6d9f61037d6c6a81c2dc7a15cb22c8c5dca", size = 49984, upload-time = "2025-10-06T05:37:57.049Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/de/ad9d82ca8e5fa8f0c636e64606553c79e2b859ad253030b62a21fe9986f5/frozenlist-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1b9290cf81e95e93fdf90548ce9d3c1211cf574b8e3f4b3b7cb0537cf2227068", size = 50240, upload-time = "2025-10-06T05:37:58.145Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/45/3dfb7767c2a67d123650122b62ce13c731b6c745bc14424eea67678b508c/frozenlist-1.8.0-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:59a6a5876ca59d1b63af8cd5e7ffffb024c3dc1e9cf9301b21a2e76286505c95", size = 219472, upload-time = "2025-10-06T05:37:59.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/bf/5bf23d913a741b960d5c1dac7c1985d8a2a1d015772b2d18ea168b08e7ff/frozenlist-1.8.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6dc4126390929823e2d2d9dc79ab4046ed74680360fc5f38b585c12c66cdf459", size = 221531, upload-time = "2025-10-06T05:38:00.521Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/03/27ec393f3b55860859f4b74cdc8c2a4af3dbf3533305e8eacf48a4fd9a54/frozenlist-1.8.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:332db6b2563333c5671fecacd085141b5800cb866be16d5e3eb15a2086476675", size = 219211, upload-time = "2025-10-06T05:38:01.842Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ad/0fd00c404fa73fe9b169429e9a972d5ed807973c40ab6b3cf9365a33d360/frozenlist-1.8.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9ff15928d62a0b80bb875655c39bf517938c7d589554cbd2669be42d97c2cb61", size = 231775, upload-time = "2025-10-06T05:38:03.384Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/c3/86962566154cb4d2995358bc8331bfc4ea19d07db1a96f64935a1607f2b6/frozenlist-1.8.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7bf6cdf8e07c8151fba6fe85735441240ec7f619f935a5205953d58009aef8c6", size = 236631, upload-time = "2025-10-06T05:38:04.609Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/9e/6ffad161dbd83782d2c66dc4d378a9103b31770cb1e67febf43aea42d202/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:48e6d3f4ec5c7273dfe83ff27c91083c6c9065af655dc2684d2c200c94308bb5", size = 218632, upload-time = "2025-10-06T05:38:05.917Z" },
-    { url = "https://files.pythonhosted.org/packages/58/b2/4677eee46e0a97f9b30735e6ad0bf6aba3e497986066eb68807ac85cf60f/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:1a7607e17ad33361677adcd1443edf6f5da0ce5e5377b798fba20fae194825f3", size = 235967, upload-time = "2025-10-06T05:38:07.614Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f3/86e75f8639c5a93745ca7addbbc9de6af56aebb930d233512b17e46f6493/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:5a3a935c3a4e89c733303a2d5a7c257ea44af3a56c8202df486b7f5de40f37e1", size = 228799, upload-time = "2025-10-06T05:38:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/30/00/39aad3a7f0d98f5eb1d99a3c311215674ed87061aecee7851974b335c050/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:940d4a017dbfed9daf46a3b086e1d2167e7012ee297fef9e1c545c4d022f5178", size = 230566, upload-time = "2025-10-06T05:38:10.52Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/4d/aa144cac44568d137846ddc4d5210fb5d9719eb1d7ec6fa2728a54b5b94a/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b9be22a69a014bc47e78072d0ecae716f5eb56c15238acca0f43d6eb8e4a5bda", size = 217715, upload-time = "2025-10-06T05:38:11.832Z" },
-    { url = "https://files.pythonhosted.org/packages/64/4c/8f665921667509d25a0dd72540513bc86b356c95541686f6442a3283019f/frozenlist-1.8.0-cp39-cp39-win32.whl", hash = "sha256:1aa77cb5697069af47472e39612976ed05343ff2e84a3dcf15437b232cbfd087", size = 39933, upload-time = "2025-10-06T05:38:13.061Z" },
-    { url = "https://files.pythonhosted.org/packages/79/bd/bcc926f87027fad5e59926ff12d136e1082a115025d33c032d1cd69ab377/frozenlist-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:7398c222d1d405e796970320036b1b563892b65809d9e5261487bb2c7f7b5c6a", size = 44121, upload-time = "2025-10-06T05:38:14.572Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/07/9c2e4eb7584af4b705237b971b89a4155a8e57599c4483a131a39256a9a0/frozenlist-1.8.0-cp39-cp39-win_arm64.whl", hash = "sha256:b4f3b365f31c6cd4af24545ca0a244a53688cad8834e32f56831c4923b50a103", size = 40312, upload-time = "2025-10-06T05:38:15.699Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
 
@@ -1555,8 +1312,7 @@ resolution-markers = [
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-    "python_full_version < '3.10'",
+    "python_full_version < '3.11'",
 ]
 dependencies = [
     { name = "google-auth", marker = "python_full_version < '3.14'" },
@@ -1607,8 +1363,7 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
     { name = "pydantic" },
-    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "shapely", version = "2.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "shapely" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/86/d1bad9a342122f0f5913cd8b7758ab340aac3f579cffb800d294da605a7c/google_cloud_aiplatform-1.121.0.tar.gz", hash = "sha256:65710396238fa461dbea9b2af9ed23f95458d70d9684e75519c7c9c1601ff308", size = 9705200, upload-time = "2025-10-15T20:27:59.262Z" }
@@ -1714,12 +1469,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/32/a22a281806e3ef21b72db16f948cad22ec68e4bdd384139291e00ff82fe2/google_crc32c-1.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:0f99eaa09a9a7e642a61e06742856eec8b19fc0037832e03f941fe7cf0c8e4db", size = 33475, upload-time = "2025-03-26T14:29:11.771Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c5/002975aff514e57fc084ba155697a049b3f9b52225ec3bc0f542871dd524/google_crc32c-1.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32d1da0d74ec5634a05f53ef7df18fc646666a25efaaca9fc7dcfd4caf1d98c3", size = 33243, upload-time = "2025-03-26T14:41:35.975Z" },
     { url = "https://files.pythonhosted.org/packages/61/cb/c585282a03a0cea70fcaa1bf55d5d702d0f2351094d663ec3be1c6c67c52/google_crc32c-1.7.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10554d4abc5238823112c2ad7e4560f96c7bf3820b202660373d769d9e6e4c9", size = 32870, upload-time = "2025-03-26T14:41:37.08Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/89/940d170a9f24e6e711666a7c5596561358243023b4060869d9adae97a762/google_crc32c-1.7.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:9fc196f0b8d8bd2789352c6a522db03f89e83a0ed6b64315923c396d7a932315", size = 30462, upload-time = "2025-03-26T14:29:25.969Z" },
-    { url = "https://files.pythonhosted.org/packages/42/0c/22bebe2517368e914a63e5378aab74e2b6357eb739d94b6bc0e830979a37/google_crc32c-1.7.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:bb5e35dcd8552f76eed9461a23de1030920a3c953c1982f324be8f97946e7127", size = 30304, upload-time = "2025-03-26T14:49:16.642Z" },
-    { url = "https://files.pythonhosted.org/packages/36/32/2daf4c46f875aaa3a057ecc8569406979cb29fb1e2389e4f2570d8ed6a5c/google_crc32c-1.7.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f2226b6a8da04f1d9e61d3e357f2460b9551c5e6950071437e122c958a18ae14", size = 37734, upload-time = "2025-03-26T14:41:37.88Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b5/b3e220b68d5d265c4aacd2878301fdb2df72715c45ba49acc19f310d4555/google_crc32c-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f2b3522222746fff0e04a9bd0a23ea003ba3cccc8cf21385c564deb1f223242", size = 32869, upload-time = "2025-03-26T14:41:38.965Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/90/2931c3c8d2de1e7cde89945d3ceb2c4258a1f23f0c22c3c1c921c3c026a6/google_crc32c-1.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bda0fcb632d390e3ea8b6b07bf6b4f4a66c9d02dcd6fbf7ba00a197c143f582", size = 37875, upload-time = "2025-03-26T14:41:41.732Z" },
-    { url = "https://files.pythonhosted.org/packages/30/9e/0aaed8a209ea6fa4b50f66fed2d977f05c6c799e10bb509f5523a5a5c90c/google_crc32c-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:713121af19f1a617054c41f952294764e0c5443d5a5d9034b2cd60f5dd7e0349", size = 33471, upload-time = "2025-03-26T14:29:12.578Z" },
     { url = "https://files.pythonhosted.org/packages/0b/43/31e57ce04530794917dfe25243860ec141de9fadf4aa9783dffe7dac7c39/google_crc32c-1.7.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8e9afc74168b0b2232fb32dd202c93e46b7d5e4bf03e66ba5dc273bb3559589", size = 28242, upload-time = "2025-03-26T14:41:42.858Z" },
     { url = "https://files.pythonhosted.org/packages/eb/f3/8b84cd4e0ad111e63e30eb89453f8dd308e3ad36f42305cf8c202461cdf0/google_crc32c-1.7.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa8136cc14dd27f34a3221c0f16fd42d8a40e4778273e61a3c19aedaa44daf6b", size = 28049, upload-time = "2025-03-26T14:41:44.651Z" },
     { url = "https://files.pythonhosted.org/packages/16/1b/1693372bf423ada422f80fd88260dbfd140754adb15cbc4d7e9a68b1cb8e/google_crc32c-1.7.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85fef7fae11494e747c9fd1359a527e5970fc9603c90764843caabd3a16a0a48", size = 28241, upload-time = "2025-03-26T14:41:45.898Z" },
@@ -1783,6 +1532,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1793,6 +1543,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1803,6 +1554,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1813,6 +1565,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1823,22 +1576,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
     { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/c0/93885c4106d2626bf51fdec377d6aef740dfa5c4877461889a7cf8e565cc/greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c", size = 269859, upload-time = "2025-08-07T13:16:16.003Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f5/33f05dc3ba10a02dedb1485870cf81c109227d3d3aa280f0e48486cac248/greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d", size = 627610, upload-time = "2025-08-07T13:43:01.345Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a7/9476decef51a0844195f99ed5dc611d212e9b3515512ecdf7321543a7225/greenlet-3.2.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:18d9260df2b5fbf41ae5139e1be4e796d99655f023a636cd0e11e6406cca7d58", size = 639417, upload-time = "2025-08-07T13:45:32.094Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/d3/844e714a9bbd39034144dca8b658dcd01839b72bb0ec7d8014e33e3705f0/greenlet-3.2.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16458c245a38991aa19676900d48bd1a6f2ce3e16595051a4db9d012154e8433", size = 634020, upload-time = "2025-08-07T13:18:36.841Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/4c/f3de2a8de0e840ecb0253ad0dc7e2bb3747348e798ec7e397d783a3cb380/greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df", size = 582817, upload-time = "2025-08-07T13:18:35.48Z" },
-    { url = "https://files.pythonhosted.org/packages/89/80/7332915adc766035c8980b161c2e5d50b2f941f453af232c164cff5e0aeb/greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594", size = 1111985, upload-time = "2025-08-07T13:42:42.425Z" },
-    { url = "https://files.pythonhosted.org/packages/66/71/1928e2c80197353bcb9b50aa19c4d8e26ee6d7a900c564907665cf4b9a41/greenlet-3.2.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:81701fd84f26330f0d5f4944d4e92e61afe6319dcd9775e39396e39d7c3e5f98", size = 1136137, upload-time = "2025-08-07T13:18:26.168Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/bf/7bd33643e48ed45dcc0e22572f650767832bd4e1287f97434943cc402148/greenlet-3.2.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:28a3c6b7cd72a96f61b0e4b2a36f681025b60ae4779cc73c1535eb5f29560b10", size = 1542941, upload-time = "2025-11-04T12:42:27.427Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/74/4bc433f91d0d09a1c22954a371f9df928cb85e72640870158853a83415e5/greenlet-3.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:52206cd642670b0b320a1fd1cbfd95bca0e043179c1d8a045f2c6109dfe973be", size = 1609685, upload-time = "2025-11-04T12:42:29.242Z" },
-    { url = "https://files.pythonhosted.org/packages/89/48/a5dc74dde38aeb2b15d418cec76ed50e1dd3d620ccda84d8199703248968/greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b", size = 281400, upload-time = "2025-08-07T14:02:20.263Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/44/342c4591db50db1076b8bda86ed0ad59240e3e1da17806a4cf10a6d0e447/greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb", size = 298533, upload-time = "2025-08-07T13:56:34.168Z" },
 ]
 
 [[package]]
@@ -1914,16 +1657,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/8e/3204b94ac30b0f675ab1c06540ab5578660dc8b690db71854d3116f20d00/grpcio-1.75.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aad1c774f4ebf0696a7f148a56d39a3432550612597331792528895258966dc0", size = 7464478, upload-time = "2025-09-26T09:03:03.096Z" },
     { url = "https://files.pythonhosted.org/packages/b7/97/2d90652b213863b2cf466d9c1260ca7e7b67a16780431b3eb1d0420e3d5b/grpcio-1.75.1-cp314-cp314-win32.whl", hash = "sha256:62ce42d9994446b307649cb2a23335fa8e927f7ab2cbf5fcb844d6acb4d85f9c", size = 4012672, upload-time = "2025-09-26T09:03:05.477Z" },
     { url = "https://files.pythonhosted.org/packages/f9/df/e2e6e9fc1c985cd1a59e6996a05647c720fe8a03b92f5ec2d60d366c531e/grpcio-1.75.1-cp314-cp314-win_amd64.whl", hash = "sha256:f86e92275710bea3000cb79feca1762dc0ad3b27830dd1a74e82ab321d4ee464", size = 4772475, upload-time = "2025-09-26T09:03:07.661Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e2/33efd823a879dc7b60c10192df1900ee5c200f8e782663a41a3b2aecd143/grpcio-1.75.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:c09fba33327c3ac11b5c33dbdd8218eef8990d78f83b1656d628831812a8c0fb", size = 5706679, upload-time = "2025-09-26T09:03:10.218Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/13/17e39ee4897f1cd12dd463e863b830e64643b13e9a4af5062b4a6f0790be/grpcio-1.75.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:7e21400b037be29545704889e72e586c238e346dcb2d08d8a7288d16c883a9ec", size = 11490271, upload-time = "2025-09-26T09:03:12.778Z" },
-    { url = "https://files.pythonhosted.org/packages/77/90/b80e75f8cce758425b2772742eed4e9db765a965d902ba4b7f239b2513de/grpcio-1.75.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c12121e509b9f8b0914d10054d24120237d19e870b1cd82acbb8a9b9ddd198a3", size = 6291926, upload-time = "2025-09-26T09:03:16.282Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5f/e6033d8f99063350e20873a46225468b73045b9ef2c8cba73d66a87c3fd5/grpcio-1.75.1-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:73577a93e692b3474b1bfe84285d098de36705dbd838bb4d6a056d326e4dc880", size = 6950040, upload-time = "2025-09-26T09:03:18.874Z" },
-    { url = "https://files.pythonhosted.org/packages/01/12/34076c079b45af5aed40f037fffe388d7fbe90dd539ed01e4744c926d227/grpcio-1.75.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e19e7dfa0d7ca7dea22be464339e18ac608fd75d88c56770c646cdabe54bc724", size = 6465780, upload-time = "2025-09-26T09:03:21.219Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c5/ee6fd69a9f6e7288d04da010ad7480a0566d2aac81097ff4dafbc5ffa9b6/grpcio-1.75.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e1c28f51c1cf67eccdfc1065e8e866c9ed622f09773ca60947089c117f848a1", size = 7098308, upload-time = "2025-09-26T09:03:23.875Z" },
-    { url = "https://files.pythonhosted.org/packages/78/32/f2be13f13035361768923159fe20470a7d22db2c7c692b952e21284f56e5/grpcio-1.75.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:030a6164bc2ca726052778c0cf8e3249617a34e368354f9e6107c27ad4af8c28", size = 8042268, upload-time = "2025-09-26T09:03:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/2d/1bb0572f0a2eaab100b4635c6c2cd0d37e3cda5554037e3f90b1bc428d56/grpcio-1.75.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:67697efef5a98d46d5db7b1720fa4043536f8b8e5072a5d61cfca762f287e939", size = 7491470, upload-time = "2025-09-26T09:03:28.906Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e0/1e962dcb64019bbd87eedcfacdedb83af0f66da01f2f6e03d69b0aa1b7f0/grpcio-1.75.1-cp39-cp39-win32.whl", hash = "sha256:52015cf73eb5d76f6404e0ce0505a69b51fd1f35810b3a01233b34b10baafb41", size = 3951697, upload-time = "2025-09-26T09:03:31.535Z" },
-    { url = "https://files.pythonhosted.org/packages/87/bc/47fb3aaa77e7d657999937ec1026beba9e37f3199599fe510f762d31da97/grpcio-1.75.1-cp39-cp39-win_amd64.whl", hash = "sha256:9fe51e4a1f896ea84ac750900eae34d9e9b896b5b1e4a30b02dc31ad29f36383", size = 4645764, upload-time = "2025-09-26T09:03:34.071Z" },
 ]
 
 [[package]]
@@ -2006,8 +1739,7 @@ name = "huggingface-hub"
 version = "0.35.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
@@ -2062,27 +1794,8 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -2099,57 +1812,23 @@ wheels = [
 
 [[package]]
 name = "ipykernel"
-version = "6.31.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "appnope", marker = "python_full_version < '3.10' and sys_platform == 'darwin'" },
-    { name = "comm", marker = "python_full_version < '3.10'" },
-    { name = "debugpy", marker = "python_full_version < '3.10'" },
-    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jupyter-client", marker = "python_full_version < '3.10'" },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
-    { name = "nest-asyncio", marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "psutil", marker = "python_full_version < '3.10'" },
-    { name = "pyzmq", marker = "python_full_version < '3.10'" },
-    { name = "tornado", marker = "python_full_version < '3.10'" },
-    { name = "traitlets", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/1d/d5ba6edbfe6fae4c3105bca3a9c889563cc752c7f2de45e333164c7f4846/ipykernel-6.31.0.tar.gz", hash = "sha256:2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6", size = 167493, upload-time = "2025-10-20T11:42:39.948Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl", hash = "sha256:abe5386f6ced727a70e0eb0cf1da801fa7c5fa6ff82147747d5a0406cd8c94af", size = 117003, upload-time = "2025-10-20T11:42:37.502Z" },
-]
-
-[[package]]
-name = "ipykernel"
 version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "appnope", marker = "python_full_version >= '3.10' and sys_platform == 'darwin'" },
-    { name = "comm", marker = "python_full_version >= '3.10'" },
-    { name = "debugpy", marker = "python_full_version >= '3.10'" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jupyter-client", marker = "python_full_version >= '3.10'" },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.10'" },
-    { name = "nest-asyncio", marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "psutil", marker = "python_full_version >= '3.10'" },
-    { name = "pyzmq", marker = "python_full_version >= '3.10'" },
-    { name = "tornado", marker = "python_full_version >= '3.10'" },
-    { name = "traitlets", marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4c/9f0024c8457286c6bfd5405a15d650ec5ea36f420ef9bbc58b301f66cfc5/ipykernel-7.0.1.tar.gz", hash = "sha256:2d3fd7cdef22071c2abbad78f142b743228c5d59cd470d034871ae0ac359533c", size = 171460, upload-time = "2025-10-14T16:17:07.325Z" }
 wheels = [
@@ -2158,48 +1837,23 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.18.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.10'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "jedi", marker = "python_full_version < '3.10'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
-    { name = "pexpect", marker = "python_full_version < '3.10' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "stack-data", marker = "python_full_version < '3.10'" },
-    { name = "traitlets", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330, upload-time = "2023-11-27T09:58:34.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/6b/d9fdcdef2eb6a23f391251fde8781c38d42acd82abe84d054cb74f7863b0/ipython-8.18.1-py3-none-any.whl", hash = "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397", size = 808161, upload-time = "2023-11-27T09:58:30.538Z" },
-]
-
-[[package]]
-name = "ipython"
 version = "8.37.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.10.*'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "jedi", marker = "python_full_version == '3.10.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.10.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.10.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.10.*'" },
-    { name = "pygments", marker = "python_full_version == '3.10.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.10.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -2260,7 +1914,7 @@ name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "python_full_version >= '3.10'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
@@ -2272,7 +1926,7 @@ name = "jaraco-context"
 version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
@@ -2284,7 +1938,7 @@ name = "jaraco-functools"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "python_full_version >= '3.10'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
 wheels = [
@@ -2411,18 +2065,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/db/c4438e8febfb303486d13c6b72f5eb71cf851e300a0c1f0b4140018dd31f/jiter-0.11.1-cp314-cp314t-win32.whl", hash = "sha256:b2ce0d6156a1d3ad41da3eec63b17e03e296b78b0e0da660876fccfada86d2f7", size = 204043, upload-time = "2025-10-17T11:30:40.308Z" },
     { url = "https://files.pythonhosted.org/packages/36/59/81badb169212f30f47f817dfaabf965bc9b8204fed906fab58104ee541f9/jiter-0.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f4db07d127b54c4a2d43b4cf05ff0193e4f73e0dd90c74037e16df0b29f666e1", size = 204046, upload-time = "2025-10-17T11:30:41.692Z" },
     { url = "https://files.pythonhosted.org/packages/dd/01/43f7b4eb61db3e565574c4c5714685d042fb652f9eef7e5a3de6aafa943a/jiter-0.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:28e4fdf2d7ebfc935523e50d1efa3970043cfaa161674fe66f9642409d001dfe", size = 188069, upload-time = "2025-10-17T11:30:43.23Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/0c/c9f2e6bf00e873741ca9a7b44eb386d4a211b5f8fdebf3c711e1b4f5a9a2/jiter-0.11.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:baa99c8db49467527658bb479857344daf0a14dff909b7f6714579ac439d1253", size = 311957, upload-time = "2025-10-17T11:30:44.539Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/be/106752513486e351166edee3e7316c0f14d5278cf973d4ee265c65d8916e/jiter-0.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:860fe55fa3b01ad0edf2adde1098247ff5c303d0121f9ce028c03d4f88c69502", size = 305180, upload-time = "2025-10-17T11:30:45.942Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/26/0ca909a5e1af629e4395edd9e2d8e05bffe2a245694827ef78f6f5cf6c79/jiter-0.11.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:173dd349d99b6feaf5a25a6fbcaf3489a6f947708d808240587a23df711c67db", size = 351025, upload-time = "2025-10-17T11:30:47.443Z" },
-    { url = "https://files.pythonhosted.org/packages/02/12/90de4d022f41ba7ee691c2d753e4dcea303ae42c94cae31eb6106f3b05bc/jiter-0.11.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:14ac1dca837514cc946a6ac2c4995d9695303ecc754af70a3163d057d1a444ab", size = 365626, upload-time = "2025-10-17T11:30:49.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/a7/e6cf83a41e20fdda9e6e3a355387f32571910e832a86e0cde852ec97f725/jiter-0.11.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69af47de5f93a231d5b85f7372d3284a5be8edb4cc758f006ec5a1406965ac5e", size = 487278, upload-time = "2025-10-17T11:30:50.848Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/00/25390dfd5aa664d4e0cfad76bd4f1f812e875256781339ec72bbef9c4b8e/jiter-0.11.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:685f8b3abd3bbd3e06e4dfe2429ff87fd5d7a782701151af99b1fcbd80e31b2b", size = 377638, upload-time = "2025-10-17T11:30:52.305Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/2c/0921a1a5358dfb8de16e9094fff26631c38a2a4aadb822f6db8f90e2713f/jiter-0.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d04afa2d4e5526e54ae8a58feea953b1844bf6e3526bc589f9de68e86d0ea01", size = 361719, upload-time = "2025-10-17T11:30:54.324Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/4a/b4400c5fb809ea65be5d89aee35fcc8b82bb8e3cee1a5e8aff495fa535ae/jiter-0.11.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e92b927259035b50d8e11a8fdfe0ebd014d883e4552d37881643fa289a4bcf1", size = 387173, upload-time = "2025-10-17T11:30:56.077Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/bc/03f21d262265734e2733d5edd7f2f7b7ccb1640e8fa9f9d53b8b13355143/jiter-0.11.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e7bd8be4fad8d4c5558b7801770cd2da6c072919c6f247cc5336edb143f25304", size = 519388, upload-time = "2025-10-17T11:30:57.472Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c8/3b49c635cef4ea557abb79984be28cb42a487f9a8a38cfc182bf480da8bc/jiter-0.11.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:121381a77a3c85987f3eba0d30ceaca9116f7463bedeec2fa79b2e7286b89b60", size = 509866, upload-time = "2025-10-17T11:30:58.955Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/bc/357a30d83dfffaf2e1bdfb0e366e5e8b7e91b4db4aa6c119c1f98ec987ba/jiter-0.11.1-cp39-cp39-win32.whl", hash = "sha256:160225407f6dfabdf9be1b44e22f06bc293a78a28ffa4347054698bd712dad06", size = 205505, upload-time = "2025-10-17T11:31:00.885Z" },
-    { url = "https://files.pythonhosted.org/packages/49/cd/e37b51fdd66d76ee3047f50df91e3e8cf3a5574a27c0c484dc5f4fdfb7c4/jiter-0.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:028e0d59bcdfa1079f8df886cdaefc6f515c27a5288dec956999260c7e4a7cfd", size = 207552, upload-time = "2025-10-17T11:31:02.245Z" },
     { url = "https://files.pythonhosted.org/packages/9d/51/bd41562dd284e2a18b6dc0a99d195fd4a3560d52ab192c42e56fe0316643/jiter-0.11.1-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:e642b5270e61dd02265866398707f90e365b5db2eb65a4f30c789d826682e1f6", size = 306871, upload-time = "2025-10-17T11:31:03.616Z" },
     { url = "https://files.pythonhosted.org/packages/ba/cb/64e7f21dd357e8cd6b3c919c26fac7fc198385bbd1d85bb3b5355600d787/jiter-0.11.1-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:464ba6d000585e4e2fd1e891f31f1231f497273414f5019e27c00a4b8f7a24ad", size = 301454, upload-time = "2025-10-17T11:31:05.338Z" },
     { url = "https://files.pythonhosted.org/packages/55/b0/54bdc00da4ef39801b1419a01035bd8857983de984fd3776b0be6b94add7/jiter-0.11.1-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:055568693ab35e0bf3a171b03bb40b2dcb10352359e0ab9b5ed0da2bf1eb6f6f", size = 336801, upload-time = "2025-10-17T11:31:06.893Z" },
@@ -2500,8 +2142,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
-    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "referencing" },
     { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
@@ -2514,9 +2155,9 @@ name = "jsonschema-path"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pathable", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
 wheels = [
@@ -2528,8 +2169,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -2542,8 +2182,7 @@ version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "importlib-metadata" },
     { name = "nbclient" },
     { name = "nbformat" },
@@ -2561,9 +2200,7 @@ name = "jupyter-client"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core" },
     { name = "python-dateutil" },
     { name = "pyzmq" },
     { name = "tornado" },
@@ -2576,35 +2213,11 @@ wheels = [
 
 [[package]]
 name = "jupyter-core"
-version = "5.8.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pywin32", marker = "python_full_version < '3.10' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
-    { name = "traitlets", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/1b/72906d554acfeb588332eaaa6f61577705e9ec752ddb486f302dafa292d9/jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941", size = 88923, upload-time = "2025-05-27T07:38:16.655Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl", hash = "sha256:c28d268fc90fb53f1338ded2eb410704c5449a358406e8a948b75706e24863d0", size = 28880, upload-time = "2025-05-27T07:38:15.137Z" },
-]
-
-[[package]]
-name = "jupyter-core"
 version = "5.9.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "traitlets", marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
@@ -2625,13 +2238,13 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
-    { name = "jaraco-classes", marker = "python_full_version >= '3.10'" },
-    { name = "jaraco-context", marker = "python_full_version >= '3.10'" },
-    { name = "jaraco-functools", marker = "python_full_version >= '3.10'" },
-    { name = "jeepney", marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
@@ -2654,44 +2267,16 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.79"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "jsonpatch", marker = "python_full_version < '3.10'" },
-    { name = "langsmith", marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pydantic", marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "tenacity", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/99/f926495f467e0f43289f12e951655d267d1eddc1136c3cf4dd907794a9a7/langchain_core-0.3.79.tar.gz", hash = "sha256:024ba54a346dd9b13fb8b2342e0c83d0111e7f26fa01f545ada23ad772b55a60", size = 580895, upload-time = "2025-10-09T21:59:08.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/71/46b0efaf3fc6ad2c2bd600aef500f1cb2b7038a4042f58905805630dd29d/langchain_core-0.3.79-py3-none-any.whl", hash = "sha256:92045bfda3e741f8018e1356f83be203ec601561c6a7becfefe85be5ddc58fdb", size = 449779, upload-time = "2025-10-09T21:59:06.493Z" },
-]
-
-[[package]]
-name = "langchain-core"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "jsonpatch", marker = "python_full_version >= '3.10'" },
-    { name = "langsmith", marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "tenacity", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "jsonpatch" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/d0/9db6d375ecf8bd498fcc87016e43c3d930ddbfbacf9a1e99018ada4e824f/langchain_core-1.0.0.tar.gz", hash = "sha256:8e81c94a22fa3a362a0f101bbd1271bf3725e50cf1e31c84e8f4a1c731279785", size = 764484, upload-time = "2025-10-17T13:48:24.408Z" }
 wheels = [
@@ -2700,32 +2285,10 @@ wheels = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "0.3.11"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "langchain-core", version = "0.3.79", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
-]
-
-[[package]]
-name = "langchain-text-splitters"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "langchain-core", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "langchain-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/2e/c833dcc379c1c086453708ef5eef7d4d1f808559ca4458bd6569d5d83ad7/langchain_text_splitters-1.0.0.tar.gz", hash = "sha256:d8580a20ad7ed10b432feb273e5758b2cc0902d094919629cec0e1ad691a6744", size = 264257, upload-time = "2025-10-17T14:33:41.743Z" }
 wheels = [
@@ -2845,17 +2408,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-    { url = "https://files.pythonhosted.org/packages/56/23/0d8c13a44bde9154821586520840643467aee574d8ce79a17da539ee7fed/markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26", size = 11623, upload-time = "2025-09-27T18:37:29.296Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/23/07a2cb9a8045d5f3f0890a8c3bc0859d7a47bfd9a560b563899bec7b72ed/markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc", size = 12049, upload-time = "2025-09-27T18:37:30.234Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e4/6be85eb81503f8e11b61c0b6369b6e077dcf0a74adbd9ebf6b349937b4e9/markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c", size = 21923, upload-time = "2025-09-27T18:37:31.177Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/bc/4dc914ead3fe6ddaef035341fee0fc956949bbd27335b611829292b89ee2/markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42", size = 20543, upload-time = "2025-09-27T18:37:32.168Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/5fe81fbcfba4aef4093d5f856e5c774ec2057946052d18d168219b7bd9f9/markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b", size = 20585, upload-time = "2025-09-27T18:37:33.166Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f6/e0e5a3d3ae9c4020f696cd055f940ef86b64fe88de26f3a0308b9d3d048c/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758", size = 21387, upload-time = "2025-09-27T18:37:34.185Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/25/651753ef4dea08ea790f4fbb65146a9a44a014986996ca40102e237aa49a/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2", size = 20133, upload-time = "2025-09-27T18:37:35.138Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/0a/c3cf2b4fef5f0426e8a6d7fce3cb966a17817c568ce59d76b92a233fdbec/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d", size = 20588, upload-time = "2025-09-27T18:37:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
 ]
 
 [[package]]
@@ -2884,20 +2436,20 @@ name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.10'" },
-    { name = "httpx", marker = "python_full_version >= '3.10'" },
-    { name = "httpx-sse", marker = "python_full_version >= '3.10'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic-settings", version = "2.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.10'" },
-    { name = "python-multipart", marker = "python_full_version >= '3.10'" },
-    { name = "pywin32", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "sse-starlette", marker = "python_full_version >= '3.10'" },
-    { name = "starlette", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
@@ -2906,32 +2458,10 @@ wheels = [
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316, upload-time = "2024-09-09T20:27:48.397Z" },
-]
-
-[[package]]
-name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
 wheels = [
@@ -2982,8 +2512,7 @@ name = "ml-dtypes"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/a7/aad060393123cfb383956dca68402aff3db1e1caffd5764887ed5153f41b/ml_dtypes-0.5.3.tar.gz", hash = "sha256:95ce33057ba4d05df50b1f3cfefab22e351868a843b3b15a46c65836283670c9", size = 692316, upload-time = "2025-07-29T18:39:19.454Z" }
@@ -3018,10 +2547,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/21/783dfb51f40d2660afeb9bccf3612b99f6a803d980d2a09132b0f9d216ab/ml_dtypes-0.5.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:e12e29764a0e66a7a31e9b8bf1de5cc0423ea72979f45909acd4292de834ccd3", size = 689324, upload-time = "2025-07-29T18:39:07.567Z" },
     { url = "https://files.pythonhosted.org/packages/09/f7/a82d249c711abf411ac027b7163f285487f5e615c3e0716c61033ce996ab/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19f6c3a4f635c2fc9e2aa7d91416bd7a3d649b48350c51f7f715a09370a90d93", size = 5275917, upload-time = "2025-07-29T18:39:09.339Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3c/541c4b30815ab90ebfbb51df15d0b4254f2f9f1e2b4907ab229300d5e6f2/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab039ffb40f3dc0aeeeba84fd6c3452781b5e15bef72e2d10bcb33e4bbffc39", size = 5285284, upload-time = "2025-07-29T18:39:11.532Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2d/c61af51173083bbf2a3b0f1a1a01d50ef1830436880027433d1b75271083/ml_dtypes-0.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5ee72568d46b9533ad54f78b1e1f3067c0534c5065120ea8ecc6f210d22748b3", size = 663552, upload-time = "2025-07-29T18:39:13.102Z" },
-    { url = "https://files.pythonhosted.org/packages/61/0e/a628f2aefd719745e8a13492375a55cedea77c0cfc917b1ce11bde435c68/ml_dtypes-0.5.3-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01de48de4537dc3c46e684b969a40ec36594e7eeb7c69e9a093e7239f030a28a", size = 4952704, upload-time = "2025-07-29T18:39:14.829Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/2e/5ba92f1f99d1f5f62bffec614a5b8161e55c3961257c902fa26dbe909baa/ml_dtypes-0.5.3-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b1a6e231b0770f2894910f1dce6d2f31d65884dbf7668f9b08d73623cdca909", size = 4923538, upload-time = "2025-07-29T18:39:16.581Z" },
-    { url = "https://files.pythonhosted.org/packages/70/3b/f801c69027866ea6e387224551185fedef62ad8e2e71181ec0d9dda905f7/ml_dtypes-0.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:a4f39b9bf6555fab9bfb536cf5fdd1c1c727e8d22312078702e9ff005354b37f", size = 206567, upload-time = "2025-07-29T18:39:18.047Z" },
 ]
 
 [[package]]
@@ -3177,24 +2702,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/ca/c05f144128ea232ae2178b008d5011d4e2cea86e4ee8c85c2631b1b94802/multidict-6.7.0-cp314-cp314t-win32.whl", hash = "sha256:b2d7f80c4e1fd010b07cb26820aae86b7e73b681ee4889684fb8d2d4537aab13", size = 48023, upload-time = "2025-10-06T14:51:51.883Z" },
     { url = "https://files.pythonhosted.org/packages/ba/8f/0a60e501584145588be1af5cc829265701ba3c35a64aec8e07cbb71d39bb/multidict-6.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:09929cab6fcb68122776d575e03c6cc64ee0b8fca48d17e135474b042ce515cd", size = 53507, upload-time = "2025-10-06T14:51:53.672Z" },
     { url = "https://files.pythonhosted.org/packages/7f/ae/3148b988a9c6239903e786eac19c889fab607c31d6efa7fb2147e5680f23/multidict-6.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:cc41db090ed742f32bd2d2c721861725e6109681eddf835d0a82bd3a5c382827", size = 44804, upload-time = "2025-10-06T14:51:55.415Z" },
-    { url = "https://files.pythonhosted.org/packages/90/d7/4cf84257902265c4250769ac49f4eaab81c182ee9aff8bf59d2714dbb174/multidict-6.7.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:363eb68a0a59bd2303216d2346e6c441ba10d36d1f9969fcb6f1ba700de7bb5c", size = 77073, upload-time = "2025-10-06T14:51:57.386Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/51/194e999630a656e76c2965a1590d12faa5cd528170f2abaa04423e09fe8d/multidict-6.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d874eb056410ca05fed180b6642e680373688efafc7f077b2a2f61811e873a40", size = 44928, upload-time = "2025-10-06T14:51:58.791Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/6b/2a195373c33068c9158e0941d0b46cfcc9c1d894ca2eb137d1128081dff0/multidict-6.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8b55d5497b51afdfde55925e04a022f1de14d4f4f25cdfd4f5d9b0aa96166851", size = 44581, upload-time = "2025-10-06T14:52:00.174Z" },
-    { url = "https://files.pythonhosted.org/packages/69/7b/7f4f2e644b6978bf011a5fd9a5ebb7c21de3f38523b1f7897d36a1ac1311/multidict-6.7.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f8e5c0031b90ca9ce555e2e8fd5c3b02a25f14989cbc310701823832c99eb687", size = 239901, upload-time = "2025-10-06T14:52:02.416Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/b5/952c72786710a031aa204a9adf7db66d7f97a2c6573889d58b9e60fe6702/multidict-6.7.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cf41880c991716f3c7cec48e2f19ae4045fc9db5fc9cff27347ada24d710bb5", size = 240534, upload-time = "2025-10-06T14:52:04.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ef/109fe1f2471e4c458c74242c7e4a833f2d9fc8a6813cd7ee345b0bad18f9/multidict-6.7.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cfc12a8630a29d601f48d47787bd7eb730e475e83edb5d6c5084317463373eb", size = 219545, upload-time = "2025-10-06T14:52:06.208Z" },
-    { url = "https://files.pythonhosted.org/packages/42/bd/327d91288114967f9fe90dc53de70aa3fec1b9073e46aa32c4828f771a87/multidict-6.7.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3996b50c3237c4aec17459217c1e7bbdead9a22a0fcd3c365564fbd16439dde6", size = 251187, upload-time = "2025-10-06T14:52:08.049Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/13/a8b078ebbaceb7819fd28cd004413c33b98f1b70d542a62e6a00b74fb09f/multidict-6.7.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7f5170993a0dd3ab871c74f45c0a21a4e2c37a2f2b01b5f722a2ad9c6650469e", size = 249379, upload-time = "2025-10-06T14:52:09.831Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/6d/ab12e1246be4d65d1f55de1e6f6aaa9b8120eddcfdd1d290439c7833d5ce/multidict-6.7.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ec81878ddf0e98817def1e77d4f50dae5ef5b0e4fe796fae3bd674304172416e", size = 239241, upload-time = "2025-10-06T14:52:11.561Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d7/079a93625208c173b8fa756396814397c0fd9fee61ef87b75a748820b86e/multidict-6.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9281bf5b34f59afbc6b1e477a372e9526b66ca446f4bf62592839c195a718b32", size = 237418, upload-time = "2025-10-06T14:52:13.671Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/29/03777c2212274aa9440918d604dc9d6af0e6b4558c611c32c3dcf1a13870/multidict-6.7.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:68af405971779d8b37198726f2b6fe3955db846fee42db7a4286fc542203934c", size = 232987, upload-time = "2025-10-06T14:52:15.708Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/00/11188b68d85a84e8050ee34724d6ded19ad03975caebe0c8dcb2829b37bf/multidict-6.7.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3ba3ef510467abb0667421a286dc906e30eb08569365f5cdb131d7aff7c2dd84", size = 240985, upload-time = "2025-10-06T14:52:17.317Z" },
-    { url = "https://files.pythonhosted.org/packages/df/0c/12eef6aeda21859c6cdf7d75bd5516d83be3efe3d8cc45fd1a3037f5b9dc/multidict-6.7.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:b61189b29081a20c7e4e0b49b44d5d44bb0dc92be3c6d06a11cc043f81bf9329", size = 246855, upload-time = "2025-10-06T14:52:19.096Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f6/076120fd8bb3975f09228e288e08bff6b9f1bfd5166397c7ba284f622ab2/multidict-6.7.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:fb287618b9c7aa3bf8d825f02d9201b2f13078a5ed3b293c8f4d953917d84d5e", size = 241804, upload-time = "2025-10-06T14:52:21.166Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/51/41bb950c81437b88a93e6ddfca1d8763569ae861e638442838c4375f7497/multidict-6.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:521f33e377ff64b96c4c556b81c55d0cfffb96a11c194fd0c3f1e56f3d8dd5a4", size = 235321, upload-time = "2025-10-06T14:52:23.208Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cf/5bbd31f055199d56c1f6b04bbadad3ccb24e6d5d4db75db774fc6d6674b8/multidict-6.7.0-cp39-cp39-win32.whl", hash = "sha256:ce8fdc2dca699f8dbf055a61d73eaa10482569ad20ee3c36ef9641f69afa8c91", size = 41435, upload-time = "2025-10-06T14:52:24.735Z" },
-    { url = "https://files.pythonhosted.org/packages/af/01/547ffe9c2faec91c26965c152f3fea6cff068b6037401f61d310cc861ff4/multidict-6.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:7e73299c99939f089dd9b2120a04a516b95cdf8c1cd2b18c53ebf0de80b1f18f", size = 46193, upload-time = "2025-10-06T14:52:26.101Z" },
-    { url = "https://files.pythonhosted.org/packages/27/77/cfa5461d1d2651d6fc24216c92b4a21d4e385a41c46e0d9f3b070675167b/multidict-6.7.0-cp39-cp39-win_arm64.whl", hash = "sha256:6bdce131e14b04fd34a809b6380dbfd826065c3e2fe8a50dbae659fa0c390546", size = 43118, upload-time = "2025-10-06T14:52:27.876Z" },
     { url = "https://files.pythonhosted.org/packages/b7/da/7d22601b625e241d4f23ef1ebff8acfc60da633c9e7e7922e24d10f592b3/multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3", size = 12317, upload-time = "2025-10-06T14:52:29.272Z" },
 ]
 
@@ -3240,12 +2747,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
     { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
     { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/a6/490ff491d8ecddf8ab91762d4f67635040202f76a44171420bcbe38ceee5/mypy-1.18.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:25a9c8fb67b00599f839cf472713f54249a62efd53a54b565eb61956a7e3296b", size = 12807230, upload-time = "2025-09-19T00:09:49.471Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/2e/60076fc829645d167ece9e80db9e8375648d210dab44cc98beb5b322a826/mypy-1.18.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2b9c7e284ee20e7598d6f42e13ca40b4928e6957ed6813d1ab6348aa3f47133", size = 11895666, upload-time = "2025-09-19T00:10:53.678Z" },
-    { url = "https://files.pythonhosted.org/packages/97/4a/1e2880a2a5dda4dc8d9ecd1a7e7606bc0b0e14813637eeda40c38624e037/mypy-1.18.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6985ed057513e344e43a26cc1cd815c7a94602fb6a3130a34798625bc2f07b6", size = 12499608, upload-time = "2025-09-19T00:09:36.204Z" },
-    { url = "https://files.pythonhosted.org/packages/00/81/a117f1b73a3015b076b20246b1f341c34a578ebd9662848c6b80ad5c4138/mypy-1.18.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f27105f1525ec024b5c630c0b9f36d5c1cc4d447d61fe51ff4bd60633f47ac", size = 13244551, upload-time = "2025-09-19T00:10:17.531Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/61/b9f48e1714ce87c7bf0358eb93f60663740ebb08f9ea886ffc670cea7933/mypy-1.18.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:030c52d0ea8144e721e49b1f68391e39553d7451f0c3f8a7565b59e19fcb608b", size = 13491552, upload-time = "2025-09-19T00:10:13.753Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/66/b2c0af3b684fa80d1b27501a8bdd3d2daa467ea3992a8aa612f5ca17c2db/mypy-1.18.2-cp39-cp39-win_amd64.whl", hash = "sha256:aa5e07ac1a60a253445797e42b8b2963c9675563a94f11291ab40718b016a7a0", size = 9765635, upload-time = "2025-09-19T00:10:30.993Z" },
     { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
 ]
 
@@ -3264,14 +2765,11 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
-    { name = "ipykernel", version = "6.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "ipykernel", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "ipykernel" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter-cache" },
-    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "myst-parser" },
     { name = "nbclient" },
     { name = "nbformat" },
     { name = "pyyaml" },
@@ -3285,42 +2783,15 @@ wheels = [
 
 [[package]]
 name = "myst-parser"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", marker = "python_full_version < '3.10'" },
-    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "sphinx", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392, upload-time = "2024-04-28T20:22:42.116Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/21aa8394f16add8f7427f0a1326ccd2b3a2a8a3245c9252bc5ac034c6155/myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1", size = 83163, upload-time = "2024-04-28T20:22:39.985Z" },
-]
-
-[[package]]
-name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.10'" },
-    { name = "jinja2", marker = "python_full_version >= '3.10'" },
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
-    { name = "mdit-py-plugins", version = "0.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "sphinx", marker = "python_full_version >= '3.10'" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -3333,8 +2804,7 @@ version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-client" },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core" },
     { name = "nbformat" },
     { name = "traitlets" },
 ]
@@ -3351,10 +2821,8 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "bleach", extra = ["css"] },
     { name = "defusedxml" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core" },
     { name = "jupyterlab-pygments" },
     { name = "markupsafe" },
     { name = "mistune" },
@@ -3377,8 +2845,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastjsonschema" },
     { name = "jsonschema" },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core" },
     { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
@@ -3408,10 +2875,8 @@ name = "nbval"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "coverage", version = "7.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "ipykernel", version = "6.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "ipykernel", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "coverage" },
+    { name = "ipykernel" },
     { name = "jupyter-client" },
     { name = "nbformat" },
     { name = "pytest" },
@@ -3432,22 +2897,10 @@ wheels = [
 
 [[package]]
 name = "networkx"
-version = "3.2.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/80/a84676339aaae2f1cfdf9f418701dd634aef9cc76f708ef55c36ff39c3ca/networkx-3.2.1.tar.gz", hash = "sha256:9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6", size = 2073928, upload-time = "2023-10-28T08:41:39.364Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/f0/8fbc882ca80cf077f1b246c0e3c3465f7f415439bdea6b899f6b19f61f70/networkx-3.2.1-py3-none-any.whl", hash = "sha256:f18c69adc97877c42332c170849c96cefa91881c99a7cb3e95b7c659ebdc1ec2", size = 1647772, upload-time = "2023-10-28T08:41:36.945Z" },
-]
-
-[[package]]
-name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -3474,8 +2927,7 @@ name = "nltk"
 version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
@@ -3496,65 +2948,10 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78", size = 18902015, upload-time = "2024-08-26T20:19:40.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/91/3495b3237510f79f5d81f2508f9f13fea78ebfdf07538fc7444badda173d/numpy-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51129a29dbe56f9ca83438b706e2e69a39892b5eda6cedcb6b0c9fdc9b0d3ece", size = 21165245, upload-time = "2024-08-26T20:04:14.625Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/26178c7d437a87082d11019292dce6d3fe6f0e9026b7b2309cbf3e489b1d/numpy-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f15975dfec0cf2239224d80e32c3170b1d168335eaedee69da84fbe9f1f9cd04", size = 13738540, upload-time = "2024-08-26T20:04:36.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/31/cc46e13bf07644efc7a4bf68df2df5fb2a1a88d0cd0da9ddc84dc0033e51/numpy-2.0.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8c5713284ce4e282544c68d1c3b2c7161d38c256d2eefc93c1d683cf47683e66", size = 5300623, upload-time = "2024-08-26T20:04:46.491Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/16/7bfcebf27bb4f9d7ec67332ffebee4d1bf085c84246552d52dbb548600e7/numpy-2.0.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:becfae3ddd30736fe1889a37f1f580e245ba79a5855bff5f2a29cb3ccc22dd7b", size = 6901774, upload-time = "2024-08-26T20:04:58.173Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a3/561c531c0e8bf082c5bef509d00d56f82e0ea7e1e3e3a7fc8fa78742a6e5/numpy-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2da5960c3cf0df7eafefd806d4e612c5e19358de82cb3c343631188991566ccd", size = 13907081, upload-time = "2024-08-26T20:05:19.098Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/66/f7177ab331876200ac7563a580140643d1179c8b4b6a6b0fc9838de2a9b8/numpy-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:496f71341824ed9f3d2fd36cf3ac57ae2e0165c143b55c3a035ee219413f3318", size = 19523451, upload-time = "2024-08-26T20:05:47.479Z" },
-    { url = "https://files.pythonhosted.org/packages/25/7f/0b209498009ad6453e4efc2c65bcdf0ae08a182b2b7877d7ab38a92dc542/numpy-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a61ec659f68ae254e4d237816e33171497e978140353c0c2038d46e63282d0c8", size = 19927572, upload-time = "2024-08-26T20:06:17.137Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/df/2619393b1e1b565cd2d4c4403bdd979621e2c4dea1f8532754b2598ed63b/numpy-2.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d731a1c6116ba289c1e9ee714b08a8ff882944d4ad631fd411106a30f083c326", size = 14400722, upload-time = "2024-08-26T20:06:39.16Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ad/77e921b9f256d5da36424ffb711ae79ca3f451ff8489eeca544d0701d74a/numpy-2.0.2-cp310-cp310-win32.whl", hash = "sha256:984d96121c9f9616cd33fbd0618b7f08e0cfc9600a7ee1d6fd9b239186d19d97", size = 6472170, upload-time = "2024-08-26T20:06:50.361Z" },
-    { url = "https://files.pythonhosted.org/packages/10/05/3442317535028bc29cf0c0dd4c191a4481e8376e9f0db6bcf29703cadae6/numpy-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:c7b0be4ef08607dd04da4092faee0b86607f111d5ae68036f16cc787e250a131", size = 15905558, upload-time = "2024-08-26T20:07:13.881Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cf/034500fb83041aa0286e0fb16e7c76e5c8b67c0711bb6e9e9737a717d5fe/numpy-2.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:49ca4decb342d66018b01932139c0961a8f9ddc7589611158cb3c27cbcf76448", size = 21169137, upload-time = "2024-08-26T20:07:45.345Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d9/32de45561811a4b87fbdee23b5797394e3d1504b4a7cf40c10199848893e/numpy-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11a76c372d1d37437857280aa142086476136a8c0f373b2e648ab2c8f18fb195", size = 13703552, upload-time = "2024-08-26T20:08:06.666Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ca/2f384720020c7b244d22508cb7ab23d95f179fcfff33c31a6eeba8d6c512/numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:807ec44583fd708a21d4a11d94aedf2f4f3c3719035c76a2bbe1fe8e217bdc57", size = 5298957, upload-time = "2024-08-26T20:08:15.83Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/78/a3e4f9fb6aa4e6fdca0c5428e8ba039408514388cf62d89651aade838269/numpy-2.0.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8cafab480740e22f8d833acefed5cc87ce276f4ece12fdaa2e8903db2f82897a", size = 6905573, upload-time = "2024-08-26T20:08:27.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/72/cfc3a1beb2caf4efc9d0b38a15fe34025230da27e1c08cc2eb9bfb1c7231/numpy-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a15f476a45e6e5a3a79d8a14e62161d27ad897381fecfa4a09ed5322f2085669", size = 13914330, upload-time = "2024-08-26T20:08:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/a8/c17acf65a931ce551fee11b72e8de63bf7e8a6f0e21add4c937c83563538/numpy-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13e689d772146140a252c3a28501da66dfecd77490b498b168b501835041f951", size = 19534895, upload-time = "2024-08-26T20:09:16.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/86/8767f3d54f6ae0165749f84648da9dcc8cd78ab65d415494962c86fac80f/numpy-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9ea91dfb7c3d1c56a0e55657c0afb38cf1eeae4544c208dc465c3c9f3a7c09f9", size = 19937253, upload-time = "2024-08-26T20:09:46.263Z" },
-    { url = "https://files.pythonhosted.org/packages/df/87/f76450e6e1c14e5bb1eae6836478b1028e096fd02e85c1c37674606ab752/numpy-2.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c1c9307701fec8f3f7a1e6711f9089c06e6284b3afbbcd259f7791282d660a15", size = 14414074, upload-time = "2024-08-26T20:10:08.483Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ca/0f0f328e1e59f73754f06e1adfb909de43726d4f24c6a3f8805f34f2b0fa/numpy-2.0.2-cp311-cp311-win32.whl", hash = "sha256:a392a68bd329eafac5817e5aefeb39038c48b671afd242710b451e76090e81f4", size = 6470640, upload-time = "2024-08-26T20:10:19.732Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/57/3a3f14d3a759dcf9bf6e9eda905794726b758819df4663f217d658a58695/numpy-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:286cd40ce2b7d652a6f22efdfc6d1edf879440e53e76a75955bc0c826c7e64dc", size = 15910230, upload-time = "2024-08-26T20:10:43.413Z" },
-    { url = "https://files.pythonhosted.org/packages/45/40/2e117be60ec50d98fa08c2f8c48e09b3edea93cfcabd5a9ff6925d54b1c2/numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b", size = 20895803, upload-time = "2024-08-26T20:11:13.916Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/1b8b8dee833f53cef3e0a3f69b2374467789e0bb7399689582314df02651/numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e", size = 13471835, upload-time = "2024-08-26T20:11:34.779Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/19/e2793bde475f1edaea6945be141aef6c8b4c669b90c90a300a8954d08f0a/numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c", size = 5038499, upload-time = "2024-08-26T20:11:43.902Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ff/ddf6dac2ff0dd50a7327bcdba45cb0264d0e96bb44d33324853f781a8f3c/numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c", size = 6633497, upload-time = "2024-08-26T20:11:55.09Z" },
-    { url = "https://files.pythonhosted.org/packages/72/21/67f36eac8e2d2cd652a2e69595a54128297cdcb1ff3931cfc87838874bd4/numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692", size = 13621158, upload-time = "2024-08-26T20:12:14.95Z" },
-    { url = "https://files.pythonhosted.org/packages/39/68/e9f1126d757653496dbc096cb429014347a36b228f5a991dae2c6b6cfd40/numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a", size = 19236173, upload-time = "2024-08-26T20:12:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/e9/1f5333281e4ebf483ba1c888b1d61ba7e78d7e910fdd8e6499667041cc35/numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c", size = 19634174, upload-time = "2024-08-26T20:13:13.634Z" },
-    { url = "https://files.pythonhosted.org/packages/71/af/a469674070c8d8408384e3012e064299f7a2de540738a8e414dcfd639996/numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded", size = 14099701, upload-time = "2024-08-26T20:13:34.851Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3d/08ea9f239d0e0e939b6ca52ad403c84a2bce1bde301a8eb4888c1c1543f1/numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5", size = 6174313, upload-time = "2024-08-26T20:13:45.653Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/b5/4ac39baebf1fdb2e72585c8352c56d063b6126be9fc95bd2bb5ef5770c20/numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a", size = 15606179, upload-time = "2024-08-26T20:14:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c1/41c8f6df3162b0c6ffd4437d729115704bd43363de0090c7f913cfbc2d89/numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c", size = 21169942, upload-time = "2024-08-26T20:14:40.108Z" },
-    { url = "https://files.pythonhosted.org/packages/39/bc/fd298f308dcd232b56a4031fd6ddf11c43f9917fbc937e53762f7b5a3bb1/numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd", size = 13711512, upload-time = "2024-08-26T20:15:00.985Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ff/06d1aa3eeb1c614eda245c1ba4fb88c483bee6520d361641331872ac4b82/numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b", size = 5306976, upload-time = "2024-08-26T20:15:10.876Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/98/121996dcfb10a6087a05e54453e28e58694a7db62c5a5a29cee14c6e047b/numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729", size = 6906494, upload-time = "2024-08-26T20:15:22.055Z" },
-    { url = "https://files.pythonhosted.org/packages/15/31/9dffc70da6b9bbf7968f6551967fc21156207366272c2a40b4ed6008dc9b/numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1", size = 13912596, upload-time = "2024-08-26T20:15:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/14/78635daab4b07c0930c919d451b8bf8c164774e6a3413aed04a6d95758ce/numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd", size = 19526099, upload-time = "2024-08-26T20:16:11.048Z" },
-    { url = "https://files.pythonhosted.org/packages/26/4c/0eeca4614003077f68bfe7aac8b7496f04221865b3a5e7cb230c9d055afd/numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d", size = 19932823, upload-time = "2024-08-26T20:16:40.171Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/46/ea25b98b13dccaebddf1a803f8c748680d972e00507cd9bc6dcdb5aa2ac1/numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d", size = 14404424, upload-time = "2024-08-26T20:17:02.604Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/a6/177dd88d95ecf07e722d21008b1b40e681a929eb9e329684d449c36586b2/numpy-2.0.2-cp39-cp39-win32.whl", hash = "sha256:905d16e0c60200656500c95b6b8dca5d109e23cb24abc701d41c02d74c6b3afa", size = 6476809, upload-time = "2024-08-26T20:17:13.553Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2b/7fc9f4e7ae5b507c1a3a21f0f15ed03e794c1242ea8a242ac158beb56034/numpy-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73", size = 15911314, upload-time = "2024-08-26T20:17:36.72Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3b/df5a870ac6a3be3a86856ce195ef42eec7ae50d2a202be1f5a4b3b340e14/numpy-2.0.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f0a0c6f12e07fa94133c8a67404322845220c06a9e80e85999afe727f7438b8", size = 21025288, upload-time = "2024-08-26T20:18:07.732Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/97/51af92f18d6f6f2d9ad8b482a99fb74e142d71372da5d834b3a2747a446e/numpy-2.0.2-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:312950fdd060354350ed123c0e25a71327d3711584beaef30cdaa93320c392d4", size = 6762793, upload-time = "2024-08-26T20:18:19.125Z" },
-    { url = "https://files.pythonhosted.org/packages/12/46/de1fbd0c1b5ccaa7f9a005b66761533e2f6a3e560096682683a223631fe9/numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26df23238872200f63518dd2aa984cfca675d82469535dc7162dc2ee52d9dd5c", size = 19334885, upload-time = "2024-08-26T20:18:47.237Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/dc/d330a6faefd92b446ec0f0dfea4c3207bb1fef3c4771d19cf4543efd2c78/numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385", size = 15828784, upload-time = "2024-08-26T20:19:11.19Z" },
-]
-
-[[package]]
-name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -3805,26 +3202,8 @@ wheels = [
 
 [[package]]
 name = "nvidia-nccl-cu12"
-version = "2.27.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
 version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
 ]
@@ -3877,7 +3256,7 @@ name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
@@ -3889,8 +3268,8 @@ name = "opentelemetry-api"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
 wheels = [
@@ -3972,19 +3351,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/09/17d9d2b60592890ff7382e591aa1d9afb202a266b180c3d4049b1ec70e4a/orjson-3.11.3-cp314-cp314-win32.whl", hash = "sha256:0c6d7328c200c349e3a4c6d8c83e0a5ad029bdc2d417f234152bf34842d0fc8d", size = 136266, upload-time = "2025-08-26T17:46:13.853Z" },
     { url = "https://files.pythonhosted.org/packages/15/58/358f6846410a6b4958b74734727e582ed971e13d335d6c7ce3e47730493e/orjson-3.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:317bbe2c069bbc757b1a2e4105b64aacd3bc78279b66a6b9e51e846e4809f804", size = 131351, upload-time = "2025-08-26T17:46:15.27Z" },
     { url = "https://files.pythonhosted.org/packages/28/01/d6b274a0635be0468d4dbd9cafe80c47105937a0d42434e805e67cd2ed8b/orjson-3.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:e8f6a7a27d7b7bec81bd5924163e9af03d49bbb63013f107b48eb5d16db711bc", size = 125985, upload-time = "2025-08-26T17:46:16.67Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a6/18d88ccf8e5d8f711310eba9b4f6562f4aa9d594258efdc4dcf8c1550090/orjson-3.11.3-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:56afaf1e9b02302ba636151cfc49929c1bb66b98794291afd0e5f20fecaf757c", size = 238221, upload-time = "2025-08-26T17:46:18.113Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/18/e210365a17bf984c89db40c8be65da164b4ce6a866a2a0ae1d6407c2630b/orjson-3.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913f629adef31d2d350d41c051ce7e33cf0fd06a5d1cb28d49b1899b23b903aa", size = 123209, upload-time = "2025-08-26T17:46:19.688Z" },
-    { url = "https://files.pythonhosted.org/packages/26/43/6b3f8ec15fa910726ed94bd2e618f86313ad1cae7c3c8c6b9b8a3a161814/orjson-3.11.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0a23b41f8f98b4e61150a03f83e4f0d566880fe53519d445a962929a4d21045", size = 127881, upload-time = "2025-08-26T17:46:21.502Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/ed/f41d2406355ce67efdd4ab504732b27bea37b7dbdab3eb86314fe764f1b9/orjson-3.11.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3d721fee37380a44f9d9ce6c701b3960239f4fb3d5ceea7f31cbd43882edaa2f", size = 130306, upload-time = "2025-08-26T17:46:22.914Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/a1/1be02950f92c82e64602d3d284bd76d9fc82a6b92c9ce2a387e57a825a11/orjson-3.11.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73b92a5b69f31b1a58c0c7e31080aeaec49c6e01b9522e71ff38d08f15aa56de", size = 132383, upload-time = "2025-08-26T17:46:24.33Z" },
-    { url = "https://files.pythonhosted.org/packages/39/49/46766ac00c68192b516a15ffc44c2a9789ca3468b8dc8a500422d99bf0dd/orjson-3.11.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2489b241c19582b3f1430cc5d732caefc1aaf378d97e7fb95b9e56bed11725f", size = 135159, upload-time = "2025-08-26T17:46:25.741Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e1/27fd5e7600fdd82996329d48ee56f6e9e9ae4d31eadbc7f93fd2ff0d8214/orjson-3.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5189a5dab8b0312eadaf9d58d3049b6a52c454256493a557405e77a3d67ab7f", size = 132690, upload-time = "2025-08-26T17:46:27.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/21/f57ef08799a68c36ef96fe561101afeef735caa80814636b2e18c234e405/orjson-3.11.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9d8787bdfbb65a85ea76d0e96a3b1bed7bf0fbcb16d40408dc1172ad784a49d2", size = 131086, upload-time = "2025-08-26T17:46:33.067Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/84/a3a24306a9dc482e929232c65f5b8c69188136edd6005441d8cc4754f7ea/orjson-3.11.3-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:8e531abd745f51f8035e207e75e049553a86823d189a51809c078412cefb399a", size = 403884, upload-time = "2025-08-26T17:46:34.55Z" },
-    { url = "https://files.pythonhosted.org/packages/11/98/fdae5b2c28bc358e6868e54c8eca7398c93d6a511f0436b61436ad1b04dc/orjson-3.11.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:8ab962931015f170b97a3dd7bd933399c1bae8ed8ad0fb2a7151a5654b6941c7", size = 145837, upload-time = "2025-08-26T17:46:36.46Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a9/2fe5cd69ed231f3ed88b1ad36a6957e3d2c876eb4b2c6b17b8ae0a6681fc/orjson-3.11.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:124d5ba71fee9c9902c4a7baa9425e663f7f0aecf73d31d54fe3dd357d62c1a7", size = 135325, upload-time = "2025-08-26T17:46:38.03Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/7d4c8aefb45f6c8d7d527d84559a3a7e394b9fd1d424a2b5bcaf75fa68e7/orjson-3.11.3-cp39-cp39-win32.whl", hash = "sha256:22724d80ee5a815a44fc76274bb7ba2e7464f5564aacb6ecddaa9970a83e3225", size = 136184, upload-time = "2025-08-26T17:46:39.542Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1f/1d6a24d22001e96c0afcf1806b6eabee1109aebd2ef20ec6698f6a6012d7/orjson-3.11.3-cp39-cp39-win_amd64.whl", hash = "sha256:215c595c792a87d4407cb72dd5e0f6ee8e694ceeb7f9102b533c5a9bf2a916bb", size = 131373, upload-time = "2025-08-26T17:46:41.227Z" },
 ]
 
 [[package]]
@@ -4046,131 +3412,8 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "11.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/5d/45a3553a253ac8763f3561371432a90bdbe6000fbdcf1397ffe502aa206c/pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860", size = 5316554, upload-time = "2025-07-01T09:13:39.342Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/c8/67c12ab069ef586a25a4a79ced553586748fad100c77c0ce59bb4983ac98/pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad", size = 4686548, upload-time = "2025-07-01T09:13:41.835Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/bd/6741ebd56263390b382ae4c5de02979af7f8bd9807346d068700dd6d5cf9/pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0", size = 5859742, upload-time = "2025-07-03T13:09:47.439Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/0b/c412a9e27e1e6a829e6ab6c2dca52dd563efbedf4c9c6aa453d9a9b77359/pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b", size = 7633087, upload-time = "2025-07-03T13:09:51.796Z" },
-    { url = "https://files.pythonhosted.org/packages/59/9d/9b7076aaf30f5dd17e5e5589b2d2f5a5d7e30ff67a171eb686e4eecc2adf/pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50", size = 5963350, upload-time = "2025-07-01T09:13:43.865Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae", size = 6631840, upload-time = "2025-07-01T09:13:46.161Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e6/6ff7077077eb47fde78739e7d570bdcd7c10495666b6afcd23ab56b19a43/pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9", size = 6074005, upload-time = "2025-07-01T09:13:47.829Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/3a/b13f36832ea6d279a697231658199e0a03cd87ef12048016bdcc84131601/pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e", size = 6708372, upload-time = "2025-07-01T09:13:52.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/e4/61b2e1a7528740efbc70b3d581f33937e38e98ef3d50b05007267a55bcb2/pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6", size = 6277090, upload-time = "2025-07-01T09:13:53.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/d3/60c781c83a785d6afbd6a326ed4d759d141de43aa7365725cbcd65ce5e54/pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f", size = 6985988, upload-time = "2025-07-01T09:13:55.699Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/28/4f4a0203165eefb3763939c6789ba31013a2e90adffb456610f30f613850/pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f", size = 2422899, upload-time = "2025-07-01T09:13:57.497Z" },
-    { url = "https://files.pythonhosted.org/packages/db/26/77f8ed17ca4ffd60e1dcd220a6ec6d71210ba398cfa33a13a1cd614c5613/pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722", size = 5316531, upload-time = "2025-07-01T09:13:59.203Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/39/ee475903197ce709322a17a866892efb560f57900d9af2e55f86db51b0a5/pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288", size = 4686560, upload-time = "2025-07-01T09:14:01.101Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/90/442068a160fd179938ba55ec8c97050a612426fae5ec0a764e345839f76d/pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d", size = 5870978, upload-time = "2025-07-03T13:09:55.638Z" },
-    { url = "https://files.pythonhosted.org/packages/13/92/dcdd147ab02daf405387f0218dcf792dc6dd5b14d2573d40b4caeef01059/pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494", size = 7641168, upload-time = "2025-07-03T13:10:00.37Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/db/839d6ba7fd38b51af641aa904e2960e7a5644d60ec754c046b7d2aee00e5/pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58", size = 5973053, upload-time = "2025-07-01T09:14:04.491Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f", size = 6640273, upload-time = "2025-07-01T09:14:06.235Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ad/931694675ede172e15b2ff03c8144a0ddaea1d87adb72bb07655eaffb654/pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e", size = 6082043, upload-time = "2025-07-01T09:14:07.978Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/04/ba8f2b11fc80d2dd462d7abec16351b45ec99cbbaea4387648a44190351a/pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94", size = 6715516, upload-time = "2025-07-01T09:14:10.233Z" },
-    { url = "https://files.pythonhosted.org/packages/48/59/8cd06d7f3944cc7d892e8533c56b0acb68399f640786313275faec1e3b6f/pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0", size = 6274768, upload-time = "2025-07-01T09:14:11.921Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/cc/29c0f5d64ab8eae20f3232da8f8571660aa0ab4b8f1331da5c2f5f9a938e/pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac", size = 6986055, upload-time = "2025-07-01T09:14:13.623Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/df/90bd886fabd544c25addd63e5ca6932c86f2b701d5da6c7839387a076b4a/pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd", size = 2423079, upload-time = "2025-07-01T09:14:15.268Z" },
-    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
-    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
-    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328, upload-time = "2025-07-01T09:14:35.276Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652, upload-time = "2025-07-01T09:14:37.203Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443, upload-time = "2025-07-01T09:14:39.344Z" },
-    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474, upload-time = "2025-07-01T09:14:41.843Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038, upload-time = "2025-07-01T09:14:44.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407, upload-time = "2025-07-03T13:10:15.628Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094, upload-time = "2025-07-03T13:10:21.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503, upload-time = "2025-07-01T09:14:45.698Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574, upload-time = "2025-07-01T09:14:47.415Z" },
-    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060, upload-time = "2025-07-01T09:14:49.636Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407, upload-time = "2025-07-01T09:14:51.962Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841, upload-time = "2025-07-01T09:14:54.142Z" },
-    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450, upload-time = "2025-07-01T09:14:56.436Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055, upload-time = "2025-07-01T09:14:58.072Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110, upload-time = "2025-07-01T09:14:59.79Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547, upload-time = "2025-07-01T09:15:01.648Z" },
-    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554, upload-time = "2025-07-03T13:10:27.018Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132, upload-time = "2025-07-03T13:10:33.01Z" },
-    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001, upload-time = "2025-07-01T09:15:03.365Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814, upload-time = "2025-07-01T09:15:05.655Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124, upload-time = "2025-07-01T09:15:07.358Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186, upload-time = "2025-07-01T09:15:09.317Z" },
-    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546, upload-time = "2025-07-01T09:15:11.311Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102, upload-time = "2025-07-01T09:15:13.164Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803, upload-time = "2025-07-01T09:15:15.695Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520, upload-time = "2025-07-01T09:15:17.429Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116, upload-time = "2025-07-01T09:15:19.423Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597, upload-time = "2025-07-03T13:10:38.404Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246, upload-time = "2025-07-03T13:10:44.987Z" },
-    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336, upload-time = "2025-07-01T09:15:21.237Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699, upload-time = "2025-07-01T09:15:23.186Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789, upload-time = "2025-07-01T09:15:25.1Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386, upload-time = "2025-07-01T09:15:27.378Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911, upload-time = "2025-07-01T09:15:29.294Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383, upload-time = "2025-07-01T09:15:31.128Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385, upload-time = "2025-07-01T09:15:33.328Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129, upload-time = "2025-07-01T09:15:35.194Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580, upload-time = "2025-07-01T09:15:37.114Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860, upload-time = "2025-07-03T13:10:50.248Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694, upload-time = "2025-07-03T13:10:56.432Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888, upload-time = "2025-07-01T09:15:39.436Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330, upload-time = "2025-07-01T09:15:41.269Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089, upload-time = "2025-07-01T09:15:43.13Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206, upload-time = "2025-07-01T09:15:44.937Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370, upload-time = "2025-07-01T09:15:46.673Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500, upload-time = "2025-07-01T09:15:48.512Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835, upload-time = "2025-07-01T09:15:50.399Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8e/9c089f01677d1264ab8648352dcb7773f37da6ad002542760c80107da816/pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f", size = 5316478, upload-time = "2025-07-01T09:15:52.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/a9/5749930caf674695867eb56a581e78eb5f524b7583ff10b01b6e5048acb3/pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081", size = 4686522, upload-time = "2025-07-01T09:15:54.162Z" },
-    { url = "https://files.pythonhosted.org/packages/43/46/0b85b763eb292b691030795f9f6bb6fcaf8948c39413c81696a01c3577f7/pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4", size = 5853376, upload-time = "2025-07-03T13:11:01.066Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/c6/1a230ec0067243cbd60bc2dad5dc3ab46a8a41e21c15f5c9b52b26873069/pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc", size = 7626020, upload-time = "2025-07-03T13:11:06.479Z" },
-    { url = "https://files.pythonhosted.org/packages/63/dd/f296c27ffba447bfad76c6a0c44c1ea97a90cb9472b9304c94a732e8dbfb/pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06", size = 5956732, upload-time = "2025-07-01T09:15:56.111Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/a0/98a3630f0b57f77bae67716562513d3032ae70414fcaf02750279c389a9e/pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a", size = 6624404, upload-time = "2025-07-01T09:15:58.245Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e6/83dfba5646a290edd9a21964da07674409e410579c341fc5b8f7abd81620/pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978", size = 6067760, upload-time = "2025-07-01T09:16:00.003Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/41/15ab268fe6ee9a2bc7391e2bbb20a98d3974304ab1a406a992dcb297a370/pillow-11.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:97afb3a00b65cc0804d1c7abddbf090a81eaac02768af58cbdcaaa0a931e0b6d", size = 6700534, upload-time = "2025-07-01T09:16:02.29Z" },
-    { url = "https://files.pythonhosted.org/packages/64/79/6d4f638b288300bed727ff29f2a3cb63db054b33518a95f27724915e3fbc/pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71", size = 6277091, upload-time = "2025-07-01T09:16:04.4Z" },
-    { url = "https://files.pythonhosted.org/packages/46/05/4106422f45a05716fd34ed21763f8ec182e8ea00af6e9cb05b93a247361a/pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada", size = 6986091, upload-time = "2025-07-01T09:16:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/63/c6/287fd55c2c12761d0591549d48885187579b7c257bef0c6660755b0b59ae/pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb", size = 2422632, upload-time = "2025-07-01T09:16:08.142Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/8b/209bd6b62ce8367f47e68a218bffac88888fdf2c9fcf1ecadc6c3ec1ebc7/pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967", size = 5270556, upload-time = "2025-07-01T09:16:09.961Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/e6/231a0b76070c2cfd9e260a7a5b504fb72da0a95279410fa7afd99d9751d6/pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe", size = 4654625, upload-time = "2025-07-01T09:16:11.913Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f4/10cf94fda33cb12765f2397fc285fa6d8eb9c29de7f3185165b702fc7386/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c", size = 4874207, upload-time = "2025-07-03T13:11:10.201Z" },
-    { url = "https://files.pythonhosted.org/packages/72/c9/583821097dc691880c92892e8e2d41fe0a5a3d6021f4963371d2f6d57250/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25", size = 6583939, upload-time = "2025-07-03T13:11:15.68Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/8e/5c9d410f9217b12320efc7c413e72693f48468979a013ad17fd690397b9a/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27", size = 4957166, upload-time = "2025-07-01T09:16:13.74Z" },
-    { url = "https://files.pythonhosted.org/packages/62/bb/78347dbe13219991877ffb3a91bf09da8317fbfcd4b5f9140aeae020ad71/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a", size = 5581482, upload-time = "2025-07-01T09:16:16.107Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/28/1000353d5e61498aaeaaf7f1e4b49ddb05f2c6575f9d4f9f914a3538b6e1/pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f", size = 6984596, upload-time = "2025-07-01T09:16:18.07Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/6fa84033758276fb31da12e5fb66ad747ae83b93c67af17f8c6ff4cc8f34/pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6", size = 5270566, upload-time = "2025-07-01T09:16:19.801Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/ee/e8d2e1ab4892970b561e1ba96cbd59c0d28cf66737fc44abb2aec3795a4e/pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438", size = 4654618, upload-time = "2025-07-01T09:16:21.818Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6d/17f80f4e1f0761f02160fc433abd4109fa1548dcfdca46cfdadaf9efa565/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3", size = 4874248, upload-time = "2025-07-03T13:11:20.738Z" },
-    { url = "https://files.pythonhosted.org/packages/de/5f/c22340acd61cef960130585bbe2120e2fd8434c214802f07e8c03596b17e/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c", size = 6583963, upload-time = "2025-07-03T13:11:26.283Z" },
-    { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
-]
-
-[[package]]
-name = "pillow"
 version = "12.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/cace85a1b0c9775a9f8f5d5423c8261c858760e2466c79b2dd184638b056/pillow-12.0.0.tar.gz", hash = "sha256:87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353", size = 47008828, upload-time = "2025-10-15T18:24:14.008Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/08/26e68b6b5da219c2a2cb7b563af008b53bb8e6b6fcb3fa40715fcdb2523a/pillow-12.0.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:3adfb466bbc544b926d50fe8f4a4e6abd8c6bffd28a26177594e6e9b2b76572b", size = 5289809, upload-time = "2025-10-15T18:21:27.791Z" },
@@ -4267,27 +3510,8 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
-]
-
-[[package]]
-name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
@@ -4450,21 +3674,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/02/87b25304249a35c0915d236575bc3574a323f60b47939a2262b77632a3ee/propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85", size = 42546, upload-time = "2025-10-08T19:48:32.872Z" },
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/01/0ebaec9003f5d619a7475165961f8e3083cf8644d704b60395df3601632d/propcache-0.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3d233076ccf9e450c8b3bc6720af226b898ef5d051a2d145f7d765e6e9f9bcff", size = 80277, upload-time = "2025-10-08T19:48:36.647Z" },
-    { url = "https://files.pythonhosted.org/packages/34/58/04af97ac586b4ef6b9026c3fd36ee7798b737a832f5d3440a4280dcebd3a/propcache-0.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:357f5bb5c377a82e105e44bd3d52ba22b616f7b9773714bff93573988ef0a5fb", size = 45865, upload-time = "2025-10-08T19:48:37.859Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/19/b65d98ae21384518b291d9939e24a8aeac4fdb5101b732576f8f7540e834/propcache-0.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cbc3b6dfc728105b2a57c06791eb07a94229202ea75c59db644d7d496b698cac", size = 47636, upload-time = "2025-10-08T19:48:39.038Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/0f/317048c6d91c356c7154dca5af019e6effeb7ee15fa6a6db327cc19e12b4/propcache-0.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:182b51b421f0501952d938dc0b0eb45246a5b5153c50d42b495ad5fb7517c888", size = 201126, upload-time = "2025-10-08T19:48:40.774Z" },
-    { url = "https://files.pythonhosted.org/packages/71/69/0b2a7a5a6ee83292b4b997dbd80549d8ce7d40b6397c1646c0d9495f5a85/propcache-0.4.1-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4b536b39c5199b96fc6245eb5fb796c497381d3942f169e44e8e392b29c9ebcc", size = 209837, upload-time = "2025-10-08T19:48:42.167Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/92/c699ac495a6698df6e497fc2de27af4b6ace10d8e76528357ce153722e45/propcache-0.4.1-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:db65d2af507bbfbdcedb254a11149f894169d90488dd3e7190f7cdcb2d6cd57a", size = 215578, upload-time = "2025-10-08T19:48:43.56Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ee/14de81c5eb02c0ee4f500b4e39c4e1bd0677c06e72379e6ab18923c773fc/propcache-0.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd2dbc472da1f772a4dae4fa24be938a6c544671a912e30529984dd80400cd88", size = 197187, upload-time = "2025-10-08T19:48:45.309Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/94/48dce9aaa6d8dd5a0859bad75158ec522546d4ac23f8e2f05fac469477dd/propcache-0.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:daede9cd44e0f8bdd9e6cc9a607fc81feb80fae7a5fc6cecaff0e0bb32e42d00", size = 193478, upload-time = "2025-10-08T19:48:47.743Z" },
-    { url = "https://files.pythonhosted.org/packages/60/b5/0516b563e801e1ace212afde869a0596a0d7115eec0b12d296d75633fb29/propcache-0.4.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:71b749281b816793678ae7f3d0d84bd36e694953822eaad408d682efc5ca18e0", size = 190650, upload-time = "2025-10-08T19:48:49.373Z" },
-    { url = "https://files.pythonhosted.org/packages/24/89/e0f7d4a5978cd56f8cd67735f74052f257dc471ec901694e430f0d1572fe/propcache-0.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:0002004213ee1f36cfb3f9a42b5066100c44276b9b72b4e1504cddd3d692e86e", size = 200251, upload-time = "2025-10-08T19:48:51.4Z" },
-    { url = "https://files.pythonhosted.org/packages/06/7d/a1fac863d473876ed4406c914f2e14aa82d2f10dd207c9e16fc383cc5a24/propcache-0.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:fe49d0a85038f36ba9e3ffafa1103e61170b28e95b16622e11be0a0ea07c6781", size = 200919, upload-time = "2025-10-08T19:48:53.227Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/4e/f86a256ff24944cf5743e4e6c6994e3526f6acfcfb55e21694c2424f758c/propcache-0.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:99d43339c83aaf4d32bda60928231848eee470c6bda8d02599cc4cebe872d183", size = 193211, upload-time = "2025-10-08T19:48:55.027Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/3f/3fbad5f4356b068f1b047d300a6ff2c66614d7030f078cd50be3fec04228/propcache-0.4.1-cp39-cp39-win32.whl", hash = "sha256:a129e76735bc792794d5177069691c3217898b9f5cee2b2661471e52ffe13f19", size = 38314, upload-time = "2025-10-08T19:48:56.792Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/45/d78d136c3a3d215677abb886785aae744da2c3005bcb99e58640c56529b1/propcache-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:948dab269721ae9a87fd16c514a0a2c2a1bdb23a9a61b969b0f9d9ee2968546f", size = 41912, upload-time = "2025-10-08T19:48:57.995Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/2a/b0632941f25139f4e58450b307242951f7c2717a5704977c6d5323a800af/propcache-0.4.1-cp39-cp39-win_arm64.whl", hash = "sha256:5fd37c406dd6dc85aa743e214cef35dc54bbdd1419baac4f6ae5e5b1a2976938", size = 38450, upload-time = "2025-10-08T19:48:59.349Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
 ]
 
@@ -4491,8 +3700,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/73/10e1661c21f139f2c6ad9b23040ff36fee624310dc28fba20d33fdae124c/protobuf-5.29.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671", size = 418091, upload-time = "2025-05-28T23:51:45.907Z" },
     { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824, upload-time = "2025-05-28T23:51:47.545Z" },
     { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942, upload-time = "2025-05-28T23:51:49.11Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/59/ca89678bb0352f094fc92f2b358daa40e3acc91a93aa8f922b24762bf841/protobuf-5.29.5-cp39-cp39-win32.whl", hash = "sha256:6f642dc9a61782fa72b90878af134c5afe1917c89a568cd3476d758d3c3a0736", size = 423025, upload-time = "2025-05-28T23:51:54.003Z" },
-    { url = "https://files.pythonhosted.org/packages/96/8b/2c62731fe3e92ddbbeca0174f78f0f8739197cdeb7c75ceb5aad3706963b/protobuf-5.29.5-cp39-cp39-win_amd64.whl", hash = "sha256:470f3af547ef17847a28e1f47200a1cbf0ba3ff57b7de50d22776607cd2ea353", size = 434906, upload-time = "2025-05-28T23:51:55.782Z" },
     { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823, upload-time = "2025-05-28T23:51:58.157Z" },
 ]
 
@@ -4535,8 +3742,8 @@ name = "py-key-value-aio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beartype", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "beartype" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
@@ -4545,14 +3752,14 @@ wheels = [
 
 [package.optional-dependencies]
 filetree = [
-    { name = "aiofile", marker = "python_full_version >= '3.10'" },
-    { name = "anyio", marker = "python_full_version >= '3.10'" },
+    { name = "aiofile" },
+    { name = "anyio" },
 ]
 keyring = [
-    { name = "keyring", marker = "python_full_version >= '3.10'" },
+    { name = "keyring" },
 ]
 memory = [
-    { name = "cachetools", marker = "python_full_version >= '3.10'" },
+    { name = "cachetools" },
 ]
 
 [[package]]
@@ -4602,7 +3809,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "python_full_version >= '3.10'" },
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -4693,19 +3900,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
     { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
     { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/36/f86d582be5fb47d4014506cd9ddd10a3979b6d0f2d237aa6ad3e7033b3ea/pydantic_core-2.41.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:646e76293345954acea6966149683047b7b2ace793011922208c8e9da12b0062", size = 2112444, upload-time = "2025-10-14T10:22:16.165Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/e5/63c521dc2dd106ba6b5941c080617ea9db252f8a7d5625231e9d761bc28c/pydantic_core-2.41.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cc8e85a63085a137d286e2791037f5fdfff0aabb8b899483ca9c496dd5797338", size = 1938218, upload-time = "2025-10-14T10:22:19.443Z" },
-    { url = "https://files.pythonhosted.org/packages/30/56/c84b638a3e6e9f5a612b9f5abdad73182520423de43669d639ed4f14b011/pydantic_core-2.41.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:692c622c8f859a17c156492783902d8370ac7e121a611bd6fe92cc71acf9ee8d", size = 1971449, upload-time = "2025-10-14T10:22:21.567Z" },
-    { url = "https://files.pythonhosted.org/packages/99/c6/e974aade34fc7a0248fdfd0a373d62693502a407c596ab3470165e38183c/pydantic_core-2.41.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d1e2906efb1031a532600679b424ef1d95d9f9fb507f813951f23320903adbd7", size = 2054023, upload-time = "2025-10-14T10:22:24.229Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/91/2507dda801f50980a38d1353c313e8f51349a42b008e63a4e45bf4620562/pydantic_core-2.41.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e04e2f7f8916ad3ddd417a7abdd295276a0bf216993d9318a5d61cc058209166", size = 2251614, upload-time = "2025-10-14T10:22:26.498Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/ad/05d886bc96938f4d31bed24e8d3fc3496d9aea7e77bcff6e4b93127c6de7/pydantic_core-2.41.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df649916b81822543d1c8e0e1d079235f68acdc7d270c911e8425045a8cfc57e", size = 2378807, upload-time = "2025-10-14T10:22:28.733Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/0a/d26e1bb9a80b9fc12cc30d9288193fbc9e60a799e55843804ee37bd38a9c/pydantic_core-2.41.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66c529f862fdba70558061bb936fe00ddbaaa0c647fd26e4a4356ef1d6561891", size = 2076891, upload-time = "2025-10-14T10:22:30.853Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/66/af014e3a294d9933ebfecf11a5d858709014bd2315fa9616195374dd82f0/pydantic_core-2.41.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3b4c5a1fd3a311563ed866c2c9b62da06cb6398bee186484ce95c820db71cb", size = 2192179, upload-time = "2025-10-14T10:22:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3e/79783f97024037d0ea6e1b3ebcd761463a925199e04ce2625727e9f27d06/pydantic_core-2.41.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6e0fc40d84448f941df9b3334c4b78fe42f36e3bf631ad54c3047a0cdddc2514", size = 2153067, upload-time = "2025-10-14T10:22:35.792Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/97/ea83b0f87d9e742405fb687d5682e7a26334eef2c82a2de06bfbdc305fab/pydantic_core-2.41.4-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:44e7625332683b6c1c8b980461475cde9595eff94447500e80716db89b0da005", size = 2319048, upload-time = "2025-10-14T10:22:38.144Z" },
-    { url = "https://files.pythonhosted.org/packages/64/4a/36d8c966a0b086362ac10a7ee75978ed15c5f2dfdfc02a1578d19d3802fb/pydantic_core-2.41.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:170ee6835f6c71081d031ef1c3b4dc4a12b9efa6a9540f93f95b82f3c7571ae8", size = 2321830, upload-time = "2025-10-14T10:22:40.337Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/6e/d80cc4909dde5f6842861288aa1a7181e7afbfc50940c862ed2848df15bd/pydantic_core-2.41.4-cp39-cp39-win32.whl", hash = "sha256:3adf61415efa6ce977041ba9745183c0e1f637ca849773afa93833e04b163feb", size = 1976706, upload-time = "2025-10-14T10:22:42.61Z" },
-    { url = "https://files.pythonhosted.org/packages/29/ee/5bda8d960d4a8b24a7eeb8a856efa9c865a7a6cab714ed387b29507dc278/pydantic_core-2.41.4-cp39-cp39-win_amd64.whl", hash = "sha256:a238dd3feee263eeaeb7dc44aea4ba1364682c4f9f9467e6af5596ba322c2332", size = 2027640, upload-time = "2025-10-14T10:22:44.907Z" },
     { url = "https://files.pythonhosted.org/packages/b0/12/5ba58daa7f453454464f92b3ca7b9d7c657d8641c48e370c3ebc9a82dd78/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a1b2cfec3879afb742a7b0bcfa53e4f22ba96571c9e54d6a3afe1052d17d843b", size = 2122139, upload-time = "2025-10-14T10:22:47.288Z" },
     { url = "https://files.pythonhosted.org/packages/21/fb/6860126a77725c3108baecd10fd3d75fec25191d6381b6eb2ac660228eac/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:d175600d975b7c244af6eb9c9041f10059f20b8bbffec9e33fdd5ee3f67cdc42", size = 1936674, upload-time = "2025-10-14T10:22:49.555Z" },
     { url = "https://files.pythonhosted.org/packages/de/be/57dcaa3ed595d81f8757e2b44a38240ac5d37628bce25fb20d02c7018776/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f184d657fa4947ae5ec9c47bd7e917730fa1cbb78195037e32dcbab50aca5ee", size = 1956398, upload-time = "2025-10-14T10:22:52.19Z" },
@@ -4734,36 +3928,12 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.11.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "pydantic", marker = "python_full_version < '3.10'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/d6/887a1ff844e64aa823fb4905978d882a633cfe295c32eacad582b78a7d8b/pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c", size = 48608, upload-time = "2025-09-24T14:19:10.015Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
 version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
@@ -4809,7 +3979,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "python_full_version >= '3.10'" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -4822,11 +3992,9 @@ dependencies = [
     { name = "dill" },
     { name = "isort" },
     { name = "mccabe" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomlkit" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/9d/81c84a312d1fa8133b0db0c76148542a98349298a01747ab122f9314b04e/pylint-3.3.9.tar.gz", hash = "sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a", size = 1525946, upload-time = "2025-10-05T18:41:43.786Z" }
 wheels = [
@@ -4849,8 +4017,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
@@ -4959,9 +4126,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
-    { url = "https://files.pythonhosted.org/packages/59/42/b86689aac0cdaee7ae1c58d464b0ff04ca909c19bb6502d4973cdd9f9544/pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b", size = 8760837, upload-time = "2025-07-14T20:12:59.59Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/8a/1403d0353f8c5a2f0829d2b1c4becbf9da2f0a4d040886404fc4a5431e4d/pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91", size = 9590187, upload-time = "2025-07-14T20:13:01.419Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/e0e8d802f124772cec9c75430b01a212f86f9de7546bda715e54140d5aeb/pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d", size = 8778162, upload-time = "2025-07-14T20:13:03.544Z" },
 ]
 
 [[package]]
@@ -5035,15 +4199,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
 ]
 
 [[package]]
@@ -5107,16 +4262,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
     { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
     { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/4e/782eb6df91b6a9d9afa96c2dcfc5cac62562a68eb62a02210101f886014d/pyzmq-27.1.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:96c71c32fff75957db6ae33cd961439f386505c6e6b377370af9b24a1ef9eafb", size = 1330426, upload-time = "2025-09-08T23:09:21.03Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/ca/2b8693d06b1db4e0c084871e4c9d7842b561d0a6ff9d780640f5e3e9eb55/pyzmq-27.1.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:49d3980544447f6bd2968b6ac913ab963a49dcaa2d4a2990041f16057b04c429", size = 906559, upload-time = "2025-09-08T23:09:22.983Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b3/b99b39e2cfdcebd512959780e4d299447fd7f46010b1d88d63324e2481ec/pyzmq-27.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:849ca054d81aa1c175c49484afaaa5db0622092b5eccb2055f9f3bb8f703782d", size = 863816, upload-time = "2025-09-08T23:09:24.556Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b2/018fa8e8eefb34a625b1a45e2effcbc9885645b22cdd0a68283f758351e7/pyzmq-27.1.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3970778e74cb7f85934d2b926b9900e92bfe597e62267d7499acc39c9c28e345", size = 666735, upload-time = "2025-09-08T23:09:26.297Z" },
-    { url = "https://files.pythonhosted.org/packages/01/05/8ae778f7cd7c94030731ae2305e6a38f3a333b6825f56c0c03f2134ccf1b/pyzmq-27.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:da96ecdcf7d3919c3be2de91a8c513c186f6762aa6cf7c01087ed74fad7f0968", size = 1655425, upload-time = "2025-09-08T23:09:28.172Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/ad/d69478a97a3f3142f9dbbbd9daa4fcf42541913a85567c36d4cfc19b2218/pyzmq-27.1.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9541c444cfe1b1c0156c5c86ece2bb926c7079a18e7b47b0b1b3b1b875e5d098", size = 2033729, upload-time = "2025-09-08T23:09:30.097Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6d/e3c6ad05bc1cddd25094e66cc15ae8924e15c67e231e93ed2955c401007e/pyzmq-27.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:e30a74a39b93e2e1591b58eb1acef4902be27c957a8720b0e368f579b82dc22f", size = 1891803, upload-time = "2025-09-08T23:09:31.875Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/a7/97e8be0daaca157511563160b67a13d4fe76b195e3fa6873cb554ad46be3/pyzmq-27.1.0-cp39-cp39-win32.whl", hash = "sha256:b1267823d72d1e40701dcba7edc45fd17f71be1285557b7fe668887150a14b78", size = 567627, upload-time = "2025-09-08T23:09:33.98Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/91/70bbf3a7c5b04c904261ef5ba224d8a76315f6c23454251bf5f55573a8a1/pyzmq-27.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0c996ded912812a2fcd7ab6574f4ad3edc27cb6510349431e4930d4196ade7db", size = 632315, upload-time = "2025-09-08T23:09:36.097Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b5/a4173a83c7fd37f6bdb5a800ea338bc25603284e9ef8681377cec006ede4/pyzmq-27.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:346e9ba4198177a07e7706050f35d733e08c1c1f8ceacd5eb6389d653579ffbc", size = 559833, upload-time = "2025-09-08T23:09:38.183Z" },
     { url = "https://files.pythonhosted.org/packages/f3/81/a65e71c1552f74dec9dff91d95bafb6e0d33338a8dfefbc88aa562a20c92/pyzmq-27.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c17e03cbc9312bee223864f1a2b13a99522e0dc9f7c5df0177cd45210ac286e6", size = 836266, upload-time = "2025-09-08T23:09:40.048Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/0202ca350f4f2b69faa95c6d931e3c05c3a397c184cacb84cb4f8f42f287/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f328d01128373cb6763823b2b4e7f73bdf767834268c565151eacb3b7a392f90", size = 800206, upload-time = "2025-09-08T23:09:41.902Z" },
     { url = "https://files.pythonhosted.org/packages/47/42/1ff831fa87fe8f0a840ddb399054ca0009605d820e2b44ea43114f5459f4/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1790386614232e1b3a40a958454bdd42c6d1811837b15ddbb052a032a43f62", size = 567747, upload-time = "2025-09-08T23:09:43.741Z" },
@@ -5127,41 +4272,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747, upload-time = "2025-09-08T23:09:52.698Z" },
     { url = "https://files.pythonhosted.org/packages/a1/cf/f2b3784d536250ffd4be70e049f3b60981235d70c6e8ce7e3ef21e1adb25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f605d884e7c8be8fe1aa94e0a783bf3f591b84c24e4bc4f3e7564c82ac25e271", size = 747371, upload-time = "2025-09-08T23:09:54.563Z" },
     { url = "https://files.pythonhosted.org/packages/01/1b/5dbe84eefc86f48473947e2f41711aded97eecef1231f4558f1f02713c12/pyzmq-27.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c9f7f6e13dff2e44a6afeaf2cf54cee5929ad64afaf4d40b50f93c58fc687355", size = 544862, upload-time = "2025-09-08T23:09:56.509Z" },
-    { url = "https://files.pythonhosted.org/packages/57/f4/c2e978cf6b833708bad7d6396c3a20c19750585a1775af3ff13c435e1912/pyzmq-27.1.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:722ea791aa233ac0a819fc2c475e1292c76930b31f1d828cb61073e2fe5e208f", size = 836257, upload-time = "2025-09-08T23:10:07.635Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5f/4e10c7f57a4c92ab0fbb2396297aa8d618e6f5b9b8f8e9756d56f3e6fc52/pyzmq-27.1.0-pp39-pypy39_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:01f9437501886d3a1dd4b02ef59fb8cc384fa718ce066d52f175ee49dd5b7ed8", size = 800203, upload-time = "2025-09-08T23:10:09.436Z" },
-    { url = "https://files.pythonhosted.org/packages/19/72/a74a007cd636f903448c6ab66628104b1fc5f2ba018733d5eabb94a0a6fb/pyzmq-27.1.0-pp39-pypy39_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4a19387a3dddcc762bfd2f570d14e2395b2c9701329b266f83dd87a2b3cbd381", size = 758756, upload-time = "2025-09-08T23:10:11.733Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/d4/30c25b91f2b4786026372f5ef454134d7f576fcf4ac58539ad7dd5de4762/pyzmq-27.1.0-pp39-pypy39_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c618fbcd069e3a29dcd221739cacde52edcc681f041907867e0f5cc7e85f172", size = 567742, upload-time = "2025-09-08T23:10:14.732Z" },
-    { url = "https://files.pythonhosted.org/packages/92/aa/ee86edad943438cd0316964020c4b6d09854414f9f945f8e289ea6fcc019/pyzmq-27.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ff8d114d14ac671d88c89b9224c63d6c4e5a613fe8acd5594ce53d752a3aafe9", size = 544857, upload-time = "2025-09-08T23:10:16.431Z" },
-]
-
-[[package]]
-name = "redis"
-version = "7.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/8f/f125feec0b958e8d22c8f0b492b30b1991d9499a4315dfde466cf4289edc/redis-7.0.1.tar.gz", hash = "sha256:c949df947dca995dc68fdf5a7863950bf6df24f8d6022394585acc98e81624f1", size = 4755322, upload-time = "2025-10-27T14:34:00.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/97/9f22a33c475cda519f20aba6babb340fb2f2254a02fb947816960d1e669a/redis-7.0.1-py3-none-any.whl", hash = "sha256:4977af3c7d67f8f0eb8b6fec0dafc9605db9343142f634041fb0235f67c0588a", size = 339938, upload-time = "2025-10-27T14:33:58.553Z" },
 ]
 
 [[package]]
 name = "redis"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version >= '3.10' and python_full_version < '3.11.3'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", size = 4796669, upload-time = "2025-11-19T15:54:39.961Z" }
 wheels = [
@@ -5175,14 +4293,12 @@ source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },
     { name = "ml-dtypes" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "python-ulid" },
     { name = "pyyaml" },
-    { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "redis", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "redis" },
     { name = "tenacity" },
 ]
 
@@ -5195,19 +4311,16 @@ all = [
     { name = "mistralai" },
     { name = "nltk" },
     { name = "openai" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pillow" },
     { name = "protobuf" },
     { name = "sentence-transformers" },
     { name = "sql-redis" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
     { name = "voyageai" },
 ]
 bedrock = [
     { name = "boto3" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 cohere = [
     { name = "cohere" },
@@ -5216,9 +4329,8 @@ langcache = [
     { name = "langcache" },
 ]
 mcp = [
-    { name = "fastmcp", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic-settings", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic-settings", version = "2.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "fastmcp" },
+    { name = "pydantic-settings" },
 ]
 mistralai = [
     { name = "mistralai" },
@@ -5230,8 +4342,7 @@ openai = [
     { name = "openai" },
 ]
 pillow = [
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pillow" },
 ]
 sentence-transformers = [
     { name = "sentence-transformers" },
@@ -5251,7 +4362,7 @@ voyageai = [
 dev = [
     { name = "black" },
     { name = "codespell" },
-    { name = "cryptography", marker = "python_full_version >= '3.10'" },
+    { name = "cryptography" },
     { name = "isort" },
     { name = "langcache" },
     { name = "mypy" },
@@ -5282,7 +4393,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.36.0,<2" },
     { name = "cohere", marker = "extra == 'all'", specifier = ">=4.44" },
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=4.44" },
-    { name = "fastmcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=2.0.0" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'all'", specifier = ">=1.26,<2.0.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertexai'", specifier = ">=1.26,<2.0.0" },
     { name = "jsonpath-ng", specifier = ">=1.5.0" },
@@ -5321,7 +4432,7 @@ provides-extras = ["mcp", "mistralai", "openai", "nltk", "cohere", "voyageai", "
 dev = [
     { name = "black", specifier = ">=25.1.0,<26" },
     { name = "codespell", specifier = ">=2.4.1,<3" },
-    { name = "cryptography", marker = "python_full_version >= '3.10'", specifier = ">=44.0.1" },
+    { name = "cryptography", specifier = ">=44.0.1" },
     { name = "isort", specifier = ">=5.6.4,<6" },
     { name = "langcache", specifier = ">=0.9.0" },
     { name = "mypy", specifier = ">=1.11.0,<2" },
@@ -5348,36 +4459,12 @@ docs = [
 
 [[package]]
 name = "referencing"
-version = "0.36.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.10'" },
-    { name = "rpds-py", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
-]
-
-[[package]]
-name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "attrs", marker = "python_full_version >= '3.10'" },
-    { name = "rpds-py", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -5489,21 +4576,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/8d/edf1c5d5aa98f99a692313db813ec487732946784f8f93145e0153d910e5/regex-2025.9.18-cp314-cp314t-win32.whl", hash = "sha256:2e1eddc06eeaffd249c0adb6fafc19e2118e6308c60df9db27919e96b5656096", size = 273029, upload-time = "2025-09-19T00:38:02.383Z" },
     { url = "https://files.pythonhosted.org/packages/a7/24/02d4e4f88466f17b145f7ea2b2c11af3a942db6222429c2c146accf16054/regex-2025.9.18-cp314-cp314t-win_amd64.whl", hash = "sha256:8620d247fb8c0683ade51217b459cb4a1081c0405a3072235ba43a40d355c09a", size = 282680, upload-time = "2025-09-19T00:38:04.102Z" },
     { url = "https://files.pythonhosted.org/packages/1f/a3/c64894858aaaa454caa7cc47e2f225b04d3ed08ad649eacf58d45817fad2/regex-2025.9.18-cp314-cp314t-win_arm64.whl", hash = "sha256:b7531a8ef61de2c647cdf68b3229b071e46ec326b3138b2180acb4275f470b01", size = 273034, upload-time = "2025-09-19T00:38:05.807Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/d2/5b0ded10467d6e96f78de5e6f195b7f9b57251f411b1090004597cffe5d9/regex-2025.9.18-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3dbcfcaa18e9480669030d07371713c10b4f1a41f791ffa5cb1a99f24e777f40", size = 484847, upload-time = "2025-09-19T00:38:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/55/35/051da2c0ae6124e3f1aa1442ecc2bb4e2de930e95433bce1301a2e7ae255/regex-2025.9.18-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1e85f73ef7095f0380208269055ae20524bfde3f27c5384126ddccf20382a638", size = 288995, upload-time = "2025-09-19T00:38:09.253Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4b/4bfc51cad95263d25b6ed8c5253831b2536e8e279e6736d0a08c9f7ffe98/regex-2025.9.18-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9098e29b3ea4ffffeade423f6779665e2a4f8db64e699c0ed737ef0db6ba7b12", size = 286642, upload-time = "2025-09-19T00:38:11.012Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/67/d2f3e2483e09d1e9f7d93b4fe106b04933fba5e619bc901530d1c90d62da/regex-2025.9.18-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90b6b7a2d0f45b7ecaaee1aec6b362184d6596ba2092dd583ffba1b78dd0231c", size = 779896, upload-time = "2025-09-19T00:38:12.732Z" },
-    { url = "https://files.pythonhosted.org/packages/14/5e/49a4f07ce6f5563de02b0e321220b9534f3fd3bae275311b785dd618aea5/regex-2025.9.18-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c81b892af4a38286101502eae7aec69f7cd749a893d9987a92776954f3943408", size = 848954, upload-time = "2025-09-19T00:38:14.716Z" },
-    { url = "https://files.pythonhosted.org/packages/00/8d/f5995ae51225c77ca9215d78ceb1dc30c52fa2b22c41dac977214e8b4bbd/regex-2025.9.18-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3b524d010973f2e1929aeb635418d468d869a5f77b52084d9f74c272189c251d", size = 896770, upload-time = "2025-09-19T00:38:16.381Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/15/2a3a744d73a557337c7561db2114bab10b4e9941c626c03169ea62f42c8f/regex-2025.9.18-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b498437c026a3d5d0be0020023ff76d70ae4d77118e92f6f26c9d0423452446", size = 789484, upload-time = "2025-09-19T00:38:18.183Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/27/e425f3d17d32062a657b836d0c8a68f5e71a9e6295fa637159f265eaa609/regex-2025.9.18-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0716e4d6e58853d83f6563f3cf25c281ff46cf7107e5f11879e32cb0b59797d9", size = 780150, upload-time = "2025-09-19T00:38:19.879Z" },
-    { url = "https://files.pythonhosted.org/packages/62/28/79dfae89b6fd7901b82611ac1a96ec25deceb7e918e9c5eb3f96cf5ad654/regex-2025.9.18-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:065b6956749379d41db2625f880b637d4acc14c0a4de0d25d609a62850e96d36", size = 773160, upload-time = "2025-09-19T00:38:21.641Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/67/df83d6ae608f487448e9be7ac26211af2afa2b6e34465fde3e07d1f11290/regex-2025.9.18-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d4a691494439287c08ddb9b5793da605ee80299dd31e95fa3f323fac3c33d9d4", size = 843555, upload-time = "2025-09-19T00:38:23.696Z" },
-    { url = "https://files.pythonhosted.org/packages/32/67/c65f56f3edd3f213d3aa41e9b9b07cc2247721a23d34bcfb2947dc0f4685/regex-2025.9.18-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:ef8d10cc0989565bcbe45fb4439f044594d5c2b8919d3d229ea2c4238f1d55b0", size = 834169, upload-time = "2025-09-19T00:38:25.997Z" },
-    { url = "https://files.pythonhosted.org/packages/95/90/7fca37435e3aa1a032c38fa1e171fdaf809c8dbf2717508e3f6a92c75446/regex-2025.9.18-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4baeb1b16735ac969a7eeecc216f1f8b7caf60431f38a2671ae601f716a32d25", size = 778024, upload-time = "2025-09-19T00:38:28.043Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/05/c2ee512cdf34d6be5ac5cf938a58c1b79a9d96cbad404bc4d70404212edb/regex-2025.9.18-cp39-cp39-win32.whl", hash = "sha256:8e5f41ad24a1e0b5dfcf4c4e5d9f5bd54c895feb5708dd0c1d0d35693b24d478", size = 264151, upload-time = "2025-09-19T00:38:30.23Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/2f/8414fb46181b6108484f04d670ece196db6734cc4c683f41125043fd3280/regex-2025.9.18-cp39-cp39-win_amd64.whl", hash = "sha256:50e8290707f2fb8e314ab3831e594da71e062f1d623b05266f8cfe4db4949afd", size = 276232, upload-time = "2025-09-19T00:38:31.981Z" },
-    { url = "https://files.pythonhosted.org/packages/61/63/f40931d477e1ed4b53105d506758a58cfec1b052c12972054930ec743ee5/regex-2025.9.18-cp39-cp39-win_arm64.whl", hash = "sha256:039a9d7195fd88c943d7c777d4941e8ef736731947becce773c31a1009cb3c35", size = 268505, upload-time = "2025-09-19T00:38:34.015Z" },
 ]
 
 [[package]]
@@ -5514,8 +4586,7 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "idna" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -5539,8 +4610,8 @@ name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
@@ -5552,8 +4623,8 @@ name = "rich-rst"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.10'" },
-    { name = "rich", marker = "python_full_version >= '3.10'" },
+    { name = "docutils" },
+    { name = "rich" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
 wheels = [
@@ -5668,20 +4739,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/10/6b283707780a81919f71625351182b4f98932ac89a09023cb61865136244/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f39f58a27cc6e59f432b568ed8429c7e1641324fbe38131de852cd77b2d534b0", size = 555813, upload-time = "2025-08-27T12:15:00.334Z" },
     { url = "https://files.pythonhosted.org/packages/04/2e/30b5ea18c01379da6272a92825dd7e53dc9d15c88a19e97932d35d430ef7/rpds_py-0.27.1-cp314-cp314t-win32.whl", hash = "sha256:d5fa0ee122dc09e23607a28e6d7b150da16c662e66409bbe85230e4c85bb528a", size = 217385, upload-time = "2025-08-27T12:15:01.937Z" },
     { url = "https://files.pythonhosted.org/packages/32/7d/97119da51cb1dd3f2f3c0805f155a3aa4a95fa44fe7d78ae15e69edf4f34/rpds_py-0.27.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6567d2bb951e21232c2f660c24cf3470bb96de56cdcb3f071a83feeaff8a2772", size = 230097, upload-time = "2025-08-27T12:15:03.961Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/6c/252e83e1ce7583c81f26d1d884b2074d40a13977e1b6c9c50bbf9a7f1f5a/rpds_py-0.27.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c918c65ec2e42c2a78d19f18c553d77319119bf43aa9e2edf7fb78d624355527", size = 372140, upload-time = "2025-08-27T12:15:05.441Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/71/949c195d927c5aeb0d0629d329a20de43a64c423a6aa53836290609ef7ec/rpds_py-0.27.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1fea2b1a922c47c51fd07d656324531adc787e415c8b116530a1d29c0516c62d", size = 354086, upload-time = "2025-08-27T12:15:07.404Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/02/e43e332ad8ce4f6c4342d151a471a7f2900ed1d76901da62eb3762663a71/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbf94c58e8e0cd6b6f38d8de67acae41b3a515c26169366ab58bdca4a6883bb8", size = 382117, upload-time = "2025-08-27T12:15:09.275Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/05/b0fdeb5b577197ad72812bbdfb72f9a08fa1e64539cc3940b1b781cd3596/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c2a8fed130ce946d5c585eddc7c8eeef0051f58ac80a8ee43bd17835c144c2cc", size = 394520, upload-time = "2025-08-27T12:15:10.727Z" },
-    { url = "https://files.pythonhosted.org/packages/67/1f/4cfef98b2349a7585181e99294fa2a13f0af06902048a5d70f431a66d0b9/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:037a2361db72ee98d829bc2c5b7cc55598ae0a5e0ec1823a56ea99374cfd73c1", size = 522657, upload-time = "2025-08-27T12:15:12.613Z" },
-    { url = "https://files.pythonhosted.org/packages/44/55/ccf37ddc4c6dce7437b335088b5ca18da864b334890e2fe9aa6ddc3f79a9/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5281ed1cc1d49882f9997981c88df1a22e140ab41df19071222f7e5fc4e72125", size = 402967, upload-time = "2025-08-27T12:15:14.113Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e5/5903f92e41e293b07707d5bf00ef39a0eb2af7190aff4beaf581a6591510/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd50659a069c15eef8aa3d64bbef0d69fd27bb4a50c9ab4f17f83a16cbf8905", size = 384372, upload-time = "2025-08-27T12:15:15.842Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e3/fbb409e18aeefc01e49f5922ac63d2d914328430e295c12183ce56ebf76b/rpds_py-0.27.1-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:c4b676c4ae3921649a15d28ed10025548e9b561ded473aa413af749503c6737e", size = 401264, upload-time = "2025-08-27T12:15:17.388Z" },
-    { url = "https://files.pythonhosted.org/packages/55/79/529ad07794e05cb0f38e2f965fc5bb20853d523976719400acecc447ec9d/rpds_py-0.27.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:079bc583a26db831a985c5257797b2b5d3affb0386e7ff886256762f82113b5e", size = 418691, upload-time = "2025-08-27T12:15:19.144Z" },
-    { url = "https://files.pythonhosted.org/packages/33/39/6554a7fd6d9906fda2521c6d52f5d723dca123529fb719a5b5e074c15e01/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e44099bd522cba71a2c6b97f68e19f40e7d85399de899d66cdb67b32d7cb786", size = 558989, upload-time = "2025-08-27T12:15:21.087Z" },
-    { url = "https://files.pythonhosted.org/packages/19/b2/76fa15173b6f9f445e5ef15120871b945fb8dd9044b6b8c7abe87e938416/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e202e6d4188e53c6661af813b46c37ca2c45e497fc558bacc1a7630ec2695aec", size = 589835, upload-time = "2025-08-27T12:15:22.696Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/9e/5560a4b39bab780405bed8a88ee85b30178061d189558a86003548dea045/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f41f814b8eaa48768d1bb551591f6ba45f87ac76899453e8ccd41dba1289b04b", size = 555227, upload-time = "2025-08-27T12:15:24.278Z" },
-    { url = "https://files.pythonhosted.org/packages/52/d7/cd9c36215111aa65724c132bf709c6f35175973e90b32115dedc4ced09cb/rpds_py-0.27.1-cp39-cp39-win32.whl", hash = "sha256:9e71f5a087ead99563c11fdaceee83ee982fd39cf67601f4fd66cb386336ee52", size = 217899, upload-time = "2025-08-27T12:15:25.926Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e0/d75ab7b4dd8ba777f6b365adbdfc7614bbfe7c5f05703031dfa4b61c3d6c/rpds_py-0.27.1-cp39-cp39-win_amd64.whl", hash = "sha256:71108900c9c3c8590697244b9519017a400d9ba26a36c48381b3f64743a44aab", size = 228725, upload-time = "2025-08-27T12:15:27.398Z" },
     { url = "https://files.pythonhosted.org/packages/d5/63/b7cc415c345625d5e62f694ea356c58fb964861409008118f1245f8c3347/rpds_py-0.27.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7ba22cb9693df986033b91ae1d7a979bc399237d45fccf875b76f62bb9e52ddf", size = 371360, upload-time = "2025-08-27T12:15:29.218Z" },
     { url = "https://files.pythonhosted.org/packages/e5/8c/12e1b24b560cf378b8ffbdb9dc73abd529e1adcfcf82727dfd29c4a7b88d/rpds_py-0.27.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5b640501be9288c77738b5492b3fd3abc4ba95c50c2e41273c8a1459f08298d3", size = 353933, upload-time = "2025-08-27T12:15:30.837Z" },
     { url = "https://files.pythonhosted.org/packages/9b/85/1bb2210c1f7a1b99e91fea486b9f0f894aa5da3a5ec7097cbad7dec6d40f/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb08b65b93e0c6dd70aac7f7890a9c0938d5ec71d5cb32d45cf844fb8ae47636", size = 382962, upload-time = "2025-08-27T12:15:32.348Z" },
@@ -5707,19 +4764,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/24/e3e72d265121e00b063aef3e3501e5b2473cf1b23511d56e529531acf01e/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:94c44ee01fd21c9058f124d2d4f0c9dc7634bec93cd4b38eefc385dabe71acbf", size = 560003, upload-time = "2025-08-27T12:16:08.06Z" },
     { url = "https://files.pythonhosted.org/packages/26/ca/f5a344c534214cc2d41118c0699fffbdc2c1bc7046f2a2b9609765ab9c92/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:df8b74962e35c9249425d90144e721eed198e6555a0e22a563d29fe4486b51f6", size = 590482, upload-time = "2025-08-27T12:16:10.137Z" },
     { url = "https://files.pythonhosted.org/packages/ce/08/4349bdd5c64d9d193c360aa9db89adeee6f6682ab8825dca0a3f535f434f/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:dc23e6820e3b40847e2f4a7726462ba0cf53089512abe9ee16318c366494c17a", size = 556523, upload-time = "2025-08-27T12:16:12.188Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ea/5463cd5048a7a2fcdae308b6e96432802132c141bfb9420260142632a0f1/rpds_py-0.27.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:aa8933159edc50be265ed22b401125c9eebff3171f570258854dbce3ecd55475", size = 371778, upload-time = "2025-08-27T12:16:13.851Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c8/f38c099db07f5114029c1467649d308543906933eebbc226d4527a5f4693/rpds_py-0.27.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:a50431bf02583e21bf273c71b89d710e7a710ad5e39c725b14e685610555926f", size = 354394, upload-time = "2025-08-27T12:16:15.609Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/79/b76f97704d9dd8ddbd76fed4c4048153a847c5d6003afe20a6b5c3339065/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78af06ddc7fe5cc0e967085a9115accee665fb912c22a3f54bad70cc65b05fe6", size = 382348, upload-time = "2025-08-27T12:16:17.251Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3f/ef23d3c1be1b837b648a3016d5bbe7cfe711422ad110b4081c0a90ef5a53/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:70d0738ef8fee13c003b100c2fbd667ec4f133468109b3472d249231108283a3", size = 394159, upload-time = "2025-08-27T12:16:19.251Z" },
-    { url = "https://files.pythonhosted.org/packages/74/8a/9e62693af1a34fd28b1a190d463d12407bd7cf561748cb4745845d9548d3/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2f6fd8a1cea5bbe599b6e78a6e5ee08db434fc8ffea51ff201c8765679698b3", size = 522775, upload-time = "2025-08-27T12:16:20.929Z" },
-    { url = "https://files.pythonhosted.org/packages/36/0d/8d5bb122bf7a60976b54c5c99a739a3819f49f02d69df3ea2ca2aff47d5c/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8177002868d1426305bb5de1e138161c2ec9eb2d939be38291d7c431c4712df8", size = 402633, upload-time = "2025-08-27T12:16:22.548Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/0e/237948c1f425e23e0cf5a566d702652a6e55c6f8fbd332a1792eb7043daf/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:008b839781d6c9bf3b6a8984d1d8e56f0ec46dc56df61fd669c49b58ae800400", size = 384867, upload-time = "2025-08-27T12:16:24.29Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/0a/da0813efcd998d260cbe876d97f55b0f469ada8ba9cbc47490a132554540/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:a55b9132bb1ade6c734ddd2759c8dc132aa63687d259e725221f106b83a0e485", size = 401791, upload-time = "2025-08-27T12:16:25.954Z" },
-    { url = "https://files.pythonhosted.org/packages/51/78/c6c9e8a8aaca416a6f0d1b6b4a6ee35b88fe2c5401d02235d0a056eceed2/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a46fdec0083a26415f11d5f236b79fa1291c32aaa4a17684d82f7017a1f818b1", size = 419525, upload-time = "2025-08-27T12:16:27.659Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/69/5af37e1d71487cf6d56dd1420dc7e0c2732c1b6ff612aa7a88374061c0a8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8a63b640a7845f2bdd232eb0d0a4a2dd939bcdd6c57e6bb134526487f3160ec5", size = 559255, upload-time = "2025-08-27T12:16:29.343Z" },
-    { url = "https://files.pythonhosted.org/packages/40/7f/8b7b136069ef7ac3960eda25d832639bdb163018a34c960ed042dd1707c8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:7e32721e5d4922deaaf963469d795d5bde6093207c52fec719bd22e5d1bedbc4", size = 590384, upload-time = "2025-08-27T12:16:31.005Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/06/c316d3f6ff03f43ccb0eba7de61376f8ec4ea850067dddfafe98274ae13c/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:2c426b99a068601b5f4623573df7a7c3d72e87533a2dd2253353a03e7502566c", size = 555959, upload-time = "2025-08-27T12:16:32.73Z" },
-    { url = "https://files.pythonhosted.org/packages/60/94/384cf54c430b9dac742bbd2ec26c23feb78ded0d43d6d78563a281aec017/rpds_py-0.27.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4fc9b7fe29478824361ead6e14e4f5aed570d477e06088826537e202d25fe859", size = 228784, upload-time = "2025-08-27T12:16:34.428Z" },
 ]
 
 [[package]]
@@ -5770,68 +4814,15 @@ wheels = [
 
 [[package]]
 name = "scikit-learn"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/3a/f4597eb41049110b21ebcbb0bcb43e4035017545daa5eedcfeb45c08b9c5/scikit_learn-1.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d056391530ccd1e501056160e3c9673b4da4805eb67eb2bdf4e983e1f9c9204e", size = 12067702, upload-time = "2025-01-10T08:05:56.515Z" },
-    { url = "https://files.pythonhosted.org/packages/37/19/0423e5e1fd1c6ec5be2352ba05a537a473c1677f8188b9306097d684b327/scikit_learn-1.6.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0c8d036eb937dbb568c6242fa598d551d88fb4399c0344d95c001980ec1c7d36", size = 11112765, upload-time = "2025-01-10T08:06:00.272Z" },
-    { url = "https://files.pythonhosted.org/packages/70/95/d5cb2297a835b0f5fc9a77042b0a2d029866379091ab8b3f52cc62277808/scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8634c4bd21a2a813e0a7e3900464e6d593162a29dd35d25bdf0103b3fce60ed5", size = 12643991, upload-time = "2025-01-10T08:06:04.813Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/91/ab3c697188f224d658969f678be86b0968ccc52774c8ab4a86a07be13c25/scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:775da975a471c4f6f467725dff0ced5c7ac7bda5e9316b260225b48475279a1b", size = 13497182, upload-time = "2025-01-10T08:06:08.42Z" },
-    { url = "https://files.pythonhosted.org/packages/17/04/d5d556b6c88886c092cc989433b2bab62488e0f0dafe616a1d5c9cb0efb1/scikit_learn-1.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:8a600c31592bd7dab31e1c61b9bbd6dea1b3433e67d264d17ce1017dbdce8002", size = 11125517, upload-time = "2025-01-10T08:06:12.783Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/2a/e291c29670795406a824567d1dfc91db7b699799a002fdaa452bceea8f6e/scikit_learn-1.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:72abc587c75234935e97d09aa4913a82f7b03ee0b74111dcc2881cba3c5a7b33", size = 12102620, upload-time = "2025-01-10T08:06:16.675Z" },
-    { url = "https://files.pythonhosted.org/packages/25/92/ee1d7a00bb6b8c55755d4984fd82608603a3cc59959245068ce32e7fb808/scikit_learn-1.6.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b3b00cdc8f1317b5f33191df1386c0befd16625f49d979fe77a8d44cae82410d", size = 11116234, upload-time = "2025-01-10T08:06:21.83Z" },
-    { url = "https://files.pythonhosted.org/packages/30/cd/ed4399485ef364bb25f388ab438e3724e60dc218c547a407b6e90ccccaef/scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc4765af3386811c3ca21638f63b9cf5ecf66261cc4815c1db3f1e7dc7b79db2", size = 12592155, upload-time = "2025-01-10T08:06:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/62fc9a5a659bb58a03cdd7e258956a5824bdc9b4bb3c5d932f55880be569/scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25fc636bdaf1cc2f4a124a116312d837148b5e10872147bdaf4887926b8c03d8", size = 13497069, upload-time = "2025-01-10T08:06:32.515Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/a6/c5b78606743a1f28eae8f11973de6613a5ee87366796583fb74c67d54939/scikit_learn-1.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:fa909b1a36e000a03c382aade0bd2063fd5680ff8b8e501660c0f59f021a6415", size = 11139809, upload-time = "2025-01-10T08:06:35.514Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/18/c797c9b8c10380d05616db3bfb48e2a3358c767affd0857d56c2eb501caa/scikit_learn-1.6.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:926f207c804104677af4857b2c609940b743d04c4c35ce0ddc8ff4f053cddc1b", size = 12104516, upload-time = "2025-01-10T08:06:40.009Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b7/2e35f8e289ab70108f8cbb2e7a2208f0575dc704749721286519dcf35f6f/scikit_learn-1.6.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2c2cae262064e6a9b77eee1c8e768fc46aa0b8338c6a8297b9b6759720ec0ff2", size = 11167837, upload-time = "2025-01-10T08:06:43.305Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/f6/ff7beaeb644bcad72bcfd5a03ff36d32ee4e53a8b29a639f11bcb65d06cd/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1061b7c028a8663fb9a1a1baf9317b64a257fcb036dae5c8752b2abef31d136f", size = 12253728, upload-time = "2025-01-10T08:06:47.618Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7a/8bce8968883e9465de20be15542f4c7e221952441727c4dad24d534c6d99/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e69fab4ebfc9c9b580a7a80111b43d214ab06250f8a7ef590a4edf72464dd86", size = 13147700, upload-time = "2025-01-10T08:06:50.888Z" },
-    { url = "https://files.pythonhosted.org/packages/62/27/585859e72e117fe861c2079bcba35591a84f801e21bc1ab85bce6ce60305/scikit_learn-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:70b1d7e85b1c96383f872a519b3375f92f14731e279a7b4c6cfd650cf5dffc52", size = 11110613, upload-time = "2025-01-10T08:06:54.115Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/59/8eb1872ca87009bdcdb7f3cdc679ad557b992c12f4b61f9250659e592c63/scikit_learn-1.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ffa1e9e25b3d93990e74a4be2c2fc61ee5af85811562f1288d5d055880c4322", size = 12010001, upload-time = "2025-01-10T08:06:58.613Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/05/f2fc4effc5b32e525408524c982c468c29d22f828834f0625c5ef3d601be/scikit_learn-1.6.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1", size = 11096360, upload-time = "2025-01-10T08:07:01.556Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/e4/4195d52cf4f113573fb8ebc44ed5a81bd511a92c0228889125fac2f4c3d1/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348", size = 12209004, upload-time = "2025-01-10T08:07:06.931Z" },
-    { url = "https://files.pythonhosted.org/packages/94/be/47e16cdd1e7fcf97d95b3cb08bde1abb13e627861af427a3651fcb80b517/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97", size = 13171776, upload-time = "2025-01-10T08:07:11.715Z" },
-    { url = "https://files.pythonhosted.org/packages/34/b0/ca92b90859070a1487827dbc672f998da95ce83edce1270fc23f96f1f61a/scikit_learn-1.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:7a1c43c8ec9fde528d664d947dc4c0789be4077a3647f232869f41d9bf50e0fb", size = 11071865, upload-time = "2025-01-10T08:07:16.088Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ae/993b0fb24a356e71e9a894e42b8a9eec528d4c70217353a1cd7a48bc25d4/scikit_learn-1.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a17c1dea1d56dcda2fac315712f3651a1fea86565b64b48fa1bc090249cbf236", size = 11955804, upload-time = "2025-01-10T08:07:20.385Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/54/32fa2ee591af44507eac86406fa6bba968d1eb22831494470d0a2e4a1eb1/scikit_learn-1.6.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a7aa5f9908f0f28f4edaa6963c0a6183f1911e63a69aa03782f0d924c830a35", size = 11100530, upload-time = "2025-01-10T08:07:23.675Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/58/55856da1adec655bdce77b502e94a267bf40a8c0b89f8622837f89503b5a/scikit_learn-1.6.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0650e730afb87402baa88afbf31c07b84c98272622aaba002559b614600ca691", size = 12433852, upload-time = "2025-01-10T08:07:26.817Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/4f/c83853af13901a574f8f13b645467285a48940f185b690936bb700a50863/scikit_learn-1.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:3f59fe08dc03ea158605170eb52b22a105f238a5d512c4470ddeca71feae8e5f", size = 11337256, upload-time = "2025-01-10T08:07:31.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/37/b305b759cc65829fe1b8853ff3e308b12cdd9d8884aa27840835560f2b42/scikit_learn-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6849dd3234e87f55dce1db34c89a810b489ead832aaf4d4550b7ea85628be6c1", size = 12101868, upload-time = "2025-01-10T08:07:34.189Z" },
-    { url = "https://files.pythonhosted.org/packages/83/74/f64379a4ed5879d9db744fe37cfe1978c07c66684d2439c3060d19a536d8/scikit_learn-1.6.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:e7be3fa5d2eb9be7d77c3734ff1d599151bb523674be9b834e8da6abe132f44e", size = 11144062, upload-time = "2025-01-10T08:07:37.67Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/dc/d5457e03dc9c971ce2b0d750e33148dd060fefb8b7dc71acd6054e4bb51b/scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44a17798172df1d3c1065e8fcf9019183f06c87609b49a124ebdf57ae6cb0107", size = 12693173, upload-time = "2025-01-10T08:07:42.713Z" },
-    { url = "https://files.pythonhosted.org/packages/79/35/b1d2188967c3204c78fa79c9263668cf1b98060e8e58d1a730fe5b2317bb/scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b7a3b86e411e4bce21186e1c180d792f3d99223dcfa3b4f597ecc92fa1a422", size = 13518605, upload-time = "2025-01-10T08:07:46.551Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d8/8d603bdd26601f4b07e2363032b8565ab82eb857f93d86d0f7956fcf4523/scikit_learn-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:7a73d457070e3318e32bdb3aa79a8d990474f19035464dfd8bede2883ab5dc3b", size = 11155078, upload-time = "2025-01-10T08:07:51.376Z" },
-]
-
-[[package]]
-name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.10'" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -5869,51 +4860,13 @@ wheels = [
 
 [[package]]
 name = "scipy"
-version = "1.13.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/59/41b2529908c002ade869623b87eecff3e11e3ce62e996d0bdcb536984187/scipy-1.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:20335853b85e9a49ff7572ab453794298bcf0354d8068c5f6775a0eabf350aca", size = 39328076, upload-time = "2024-05-23T03:19:01.687Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/33/f1307601f492f764062ce7dd471a14750f3360e33cd0f8c614dae208492c/scipy-1.13.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d605e9c23906d1994f55ace80e0125c587f96c020037ea6aa98d01b4bd2e222f", size = 30306232, upload-time = "2024-05-23T03:19:09.089Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/66/9cd4f501dd5ea03e4a4572ecd874936d0da296bd04d1c45ae1a4a75d9c3a/scipy-1.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cfa31f1def5c819b19ecc3a8b52d28ffdcc7ed52bb20c9a7589669dd3c250989", size = 33743202, upload-time = "2024-05-23T03:19:15.138Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ba/7255e5dc82a65adbe83771c72f384d99c43063648456796436c9a5585ec3/scipy-1.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26264b282b9da0952a024ae34710c2aff7d27480ee91a2e82b7b7073c24722f", size = 38577335, upload-time = "2024-05-23T03:19:21.984Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a5/bb9ded8326e9f0cdfdc412eeda1054b914dfea952bda2097d174f8832cc0/scipy-1.13.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eccfa1906eacc02de42d70ef4aecea45415f5be17e72b61bafcfd329bdc52e94", size = 38820728, upload-time = "2024-05-23T03:19:28.225Z" },
-    { url = "https://files.pythonhosted.org/packages/12/30/df7a8fcc08f9b4a83f5f27cfaaa7d43f9a2d2ad0b6562cced433e5b04e31/scipy-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:2831f0dc9c5ea9edd6e51e6e769b655f08ec6db6e2e10f86ef39bd32eb11da54", size = 46210588, upload-time = "2024-05-23T03:19:35.661Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/15/4a4bb1b15bbd2cd2786c4f46e76b871b28799b67891f23f455323a0cdcfb/scipy-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:27e52b09c0d3a1d5b63e1105f24177e544a222b43611aaf5bc44d4a0979e32f9", size = 39333805, upload-time = "2024-05-23T03:19:43.081Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/92/42476de1af309c27710004f5cdebc27bec62c204db42e05b23a302cb0c9a/scipy-1.13.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:54f430b00f0133e2224c3ba42b805bfd0086fe488835effa33fa291561932326", size = 30317687, upload-time = "2024-05-23T03:19:48.799Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ba/8be64fe225360a4beb6840f3cbee494c107c0887f33350d0a47d55400b01/scipy-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299", size = 33694638, upload-time = "2024-05-23T03:19:55.104Z" },
-    { url = "https://files.pythonhosted.org/packages/36/07/035d22ff9795129c5a847c64cb43c1fa9188826b59344fee28a3ab02e283/scipy-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78b4b3345f1b6f68a763c6e25c0c9a23a9fd0f39f5f3d200efe8feda560a5fa", size = 38569931, upload-time = "2024-05-23T03:20:01.82Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/10/f9b43de37e5ed91facc0cfff31d45ed0104f359e4f9a68416cbf4e790241/scipy-1.13.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:45484bee6d65633752c490404513b9ef02475b4284c4cfab0ef946def50b3f59", size = 38838145, upload-time = "2024-05-23T03:20:09.173Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/48/4513a1a5623a23e95f94abd675ed91cfb19989c58e9f6f7d03990f6caf3d/scipy-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:5713f62f781eebd8d597eb3f88b8bf9274e79eeabf63afb4a737abc6c84ad37b", size = 46196227, upload-time = "2024-05-23T03:20:16.433Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7b/fb6b46fbee30fc7051913068758414f2721003a89dd9a707ad49174e3843/scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1", size = 39357301, upload-time = "2024-05-23T03:20:23.538Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/5a/2043a3bde1443d94014aaa41e0b50c39d046dda8360abd3b2a1d3f79907d/scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d", size = 30363348, upload-time = "2024-05-23T03:20:29.885Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/cb/26e4a47364bbfdb3b7fb3363be6d8a1c543bcd70a7753ab397350f5f189a/scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627", size = 33406062, upload-time = "2024-05-23T03:20:36.012Z" },
-    { url = "https://files.pythonhosted.org/packages/88/ab/6ecdc526d509d33814835447bbbeedbebdec7cca46ef495a61b00a35b4bf/scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884", size = 38218311, upload-time = "2024-05-23T03:20:42.086Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/00/9f54554f0f8318100a71515122d8f4f503b1a2c4b4cfab3b4b68c0eb08fa/scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16", size = 38442493, upload-time = "2024-05-23T03:20:48.292Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/df/963384e90733e08eac978cd103c34df181d1fec424de383cdc443f418dd4/scipy-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949", size = 45910955, upload-time = "2024-05-23T03:20:55.091Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/29/c2ea58c9731b9ecb30b6738113a95d147e83922986b34c685b8f6eefde21/scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5", size = 39352927, upload-time = "2024-05-23T03:21:01.95Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c0/e71b94b20ccf9effb38d7147c0064c08c622309fd487b1b677771a97d18c/scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24", size = 30324538, upload-time = "2024-05-23T03:21:07.634Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/0f/aaa55b06d474817cea311e7b10aab2ea1fd5d43bc6a2861ccc9caec9f418/scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004", size = 33732190, upload-time = "2024-05-23T03:21:14.41Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f5/d0ad1a96f80962ba65e2ce1de6a1e59edecd1f0a7b55990ed208848012e0/scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d", size = 38612244, upload-time = "2024-05-23T03:21:21.827Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/02/1165905f14962174e6569076bcc3315809ae1291ed14de6448cc151eedfd/scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c", size = 38845637, upload-time = "2024-05-23T03:21:28.729Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/77/dab54fe647a08ee4253963bcd8f9cf17509c8ca64d6335141422fe2e2114/scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2", size = 46227440, upload-time = "2024-05-23T03:21:35.888Z" },
-]
-
-[[package]]
-name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6046,8 +4999,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.10'" },
-    { name = "jeepney", marker = "python_full_version >= '3.10'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6060,15 +5013,11 @@ version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "pillow" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "torch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -6088,61 +5037,10 @@ wheels = [
 
 [[package]]
 name = "shapely"
-version = "2.0.7"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/c0/a911d1fd765d07a2b6769ce155219a281bfbe311584ebe97340d75c5bdb1/shapely-2.0.7.tar.gz", hash = "sha256:28fe2997aab9a9dc026dc6a355d04e85841546b2a5d232ed953e3321ab958ee5", size = 283413, upload-time = "2025-01-31T01:10:20.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/2e/02c694d6ddacd4f13b625722d313d2838f23c5b988cbc680132983f73ce3/shapely-2.0.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:33fb10e50b16113714ae40adccf7670379e9ccf5b7a41d0002046ba2b8f0f691", size = 1478310, upload-time = "2025-01-31T02:42:18.134Z" },
-    { url = "https://files.pythonhosted.org/packages/87/69/b54a08bcd25e561bdd5183c008ace4424c25e80506e80674032504800efd/shapely-2.0.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f44eda8bd7a4bccb0f281264b34bf3518d8c4c9a8ffe69a1a05dabf6e8461147", size = 1336082, upload-time = "2025-01-31T02:42:19.986Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/f9/40473fcb5b66ff849e563ca523d2a26dafd6957d52dd876ffd0eded39f1c/shapely-2.0.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf6c50cd879831955ac47af9c907ce0310245f9d162e298703f82e1785e38c98", size = 2371047, upload-time = "2025-01-31T02:42:22.724Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f3/c9cc07a7a03b5f5e83bd059f9adf3e21cf086b0e41d7f95e6464b151e798/shapely-2.0.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04a65d882456e13c8b417562c36324c0cd1e5915f3c18ad516bb32ee3f5fc895", size = 2469112, upload-time = "2025-01-31T02:42:26.739Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b9/fc63d6b0b25063a3ff806857a5dc88851d54d1c278288f18cef1b322b449/shapely-2.0.7-cp310-cp310-win32.whl", hash = "sha256:7e97104d28e60b69f9b6a957c4d3a2a893b27525bc1fc96b47b3ccef46726bf2", size = 1296057, upload-time = "2025-01-31T02:42:29.156Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/d1/8df43f94cf4cda0edbab4545f7cdd67d3f1d02910eaff152f9f45c6d00d8/shapely-2.0.7-cp310-cp310-win_amd64.whl", hash = "sha256:35524cc8d40ee4752520819f9894b9f28ba339a42d4922e92c99b148bed3be39", size = 1441787, upload-time = "2025-01-31T02:42:31.412Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ad/21798c2fec013e289f8ab91d42d4d3299c315b8c4460c08c75fef0901713/shapely-2.0.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5cf23400cb25deccf48c56a7cdda8197ae66c0e9097fcdd122ac2007e320bc34", size = 1473091, upload-time = "2025-01-31T02:42:33.595Z" },
-    { url = "https://files.pythonhosted.org/packages/15/63/eef4f180f1b5859c70e7f91d2f2570643e5c61e7d7c40743d15f8c6cbc42/shapely-2.0.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d8f1da01c04527f7da59ee3755d8ee112cd8967c15fab9e43bba936b81e2a013", size = 1332921, upload-time = "2025-01-31T02:42:34.993Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/67/77851dd17738bbe7762a0ef1acf7bc499d756f68600dd68a987d78229412/shapely-2.0.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f623b64bb219d62014781120f47499a7adc30cf7787e24b659e56651ceebcb0", size = 2427949, upload-time = "2025-01-31T02:42:37.578Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/a5/2c8dbb0f383519771df19164e3bf3a8895d195d2edeab4b6040f176ee28e/shapely-2.0.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6d95703efaa64aaabf278ced641b888fc23d9c6dd71f8215091afd8a26a66e3", size = 2529282, upload-time = "2025-01-31T02:42:39.504Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/4e/e1d608773c7fe4cde36d48903c0d6298e3233dc69412403783ac03fa5205/shapely-2.0.7-cp311-cp311-win32.whl", hash = "sha256:2f6e4759cf680a0f00a54234902415f2fa5fe02f6b05546c662654001f0793a2", size = 1295751, upload-time = "2025-01-31T02:42:41.107Z" },
-    { url = "https://files.pythonhosted.org/packages/27/57/8ec7c62012bed06731f7ee979da7f207bbc4b27feed5f36680b6a70df54f/shapely-2.0.7-cp311-cp311-win_amd64.whl", hash = "sha256:b52f3ab845d32dfd20afba86675c91919a622f4627182daec64974db9b0b4608", size = 1442684, upload-time = "2025-01-31T02:42:43.181Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/3e/ea100eec5811bafd0175eb21828a3be5b0960f65250f4474391868be7c0f/shapely-2.0.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4c2b9859424facbafa54f4a19b625a752ff958ab49e01bc695f254f7db1835fa", size = 1482451, upload-time = "2025-01-31T02:42:44.902Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/53/c6a3487716fd32e1f813d2a9608ba7b72a8a52a6966e31c6443480a1d016/shapely-2.0.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5aed1c6764f51011d69a679fdf6b57e691371ae49ebe28c3edb5486537ffbd51", size = 1345765, upload-time = "2025-01-31T02:42:46.625Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/dd/b35d7891d25cc11066a70fb8d8169a6a7fca0735dd9b4d563a84684969a3/shapely-2.0.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:73c9ae8cf443187d784d57202199bf9fd2d4bb7d5521fe8926ba40db1bc33e8e", size = 2421540, upload-time = "2025-01-31T02:42:49.971Z" },
-    { url = "https://files.pythonhosted.org/packages/62/de/8dbd7df60eb23cb983bb698aac982944b3d602ef0ce877a940c269eae34e/shapely-2.0.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9469f49ff873ef566864cb3516091881f217b5d231c8164f7883990eec88b73", size = 2525741, upload-time = "2025-01-31T02:42:53.882Z" },
-    { url = "https://files.pythonhosted.org/packages/96/64/faf0413ebc7a84fe7a0790bf39ec0b02b40132b68e57aba985c0b6e4e7b6/shapely-2.0.7-cp312-cp312-win32.whl", hash = "sha256:6bca5095e86be9d4ef3cb52d56bdd66df63ff111d580855cb8546f06c3c907cd", size = 1296552, upload-time = "2025-01-31T02:42:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/05/8a1c279c226d6ad7604d9e237713dd21788eab96db97bf4ce0ea565e5596/shapely-2.0.7-cp312-cp312-win_amd64.whl", hash = "sha256:f86e2c0259fe598c4532acfcf638c1f520fa77c1275912bbc958faecbf00b108", size = 1443464, upload-time = "2025-01-31T02:42:57.696Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/21/abea43effbfe11f792e44409ee9ad7635aa93ef1c8ada0ef59b3c1c3abad/shapely-2.0.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a0c09e3e02f948631c7763b4fd3dd175bc45303a0ae04b000856dedebefe13cb", size = 1481618, upload-time = "2025-01-31T02:42:59.915Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/71/af688798da36fe355a6e6ffe1d4628449cb5fa131d57fc169bcb614aeee7/shapely-2.0.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:06ff6020949b44baa8fc2e5e57e0f3d09486cd5c33b47d669f847c54136e7027", size = 1345159, upload-time = "2025-01-31T02:43:01.611Z" },
-    { url = "https://files.pythonhosted.org/packages/67/47/f934fe2b70d31bb9774ad4376e34f81666deed6b811306ff574faa3d115e/shapely-2.0.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d6dbf096f961ca6bec5640e22e65ccdec11e676344e8157fe7d636e7904fd36", size = 2410267, upload-time = "2025-01-31T02:43:05.83Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/8a/2545cc2a30afc63fc6176c1da3b76af28ef9c7358ed4f68f7c6a9d86cf5b/shapely-2.0.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adeddfb1e22c20548e840403e5e0b3d9dc3daf66f05fa59f1fcf5b5f664f0e98", size = 2514128, upload-time = "2025-01-31T02:43:08.427Z" },
-    { url = "https://files.pythonhosted.org/packages/87/54/2344ce7da39676adec94e84fbaba92a8f1664e4ae2d33bd404dafcbe607f/shapely-2.0.7-cp313-cp313-win32.whl", hash = "sha256:a7f04691ce1c7ed974c2f8b34a1fe4c3c5dfe33128eae886aa32d730f1ec1913", size = 1295783, upload-time = "2025-01-31T02:43:10.608Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/1e/6461e5cfc8e73ae165b8cff6eb26a4d65274fad0e1435137c5ba34fe4e88/shapely-2.0.7-cp313-cp313-win_amd64.whl", hash = "sha256:aaaf5f7e6cc234c1793f2a2760da464b604584fb58c6b6d7d94144fd2692d67e", size = 1442300, upload-time = "2025-01-31T02:43:12.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/de/dc856cf99a981b83aa041d1a240a65b36618657d5145d1c0c7ffb4263d5b/shapely-2.0.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4abeb44b3b946236e4e1a1b3d2a0987fb4d8a63bfb3fdefb8a19d142b72001e5", size = 1478794, upload-time = "2025-01-31T02:43:38.532Z" },
-    { url = "https://files.pythonhosted.org/packages/53/ea/70fec89a9f6fa84a8bf6bd2807111a9175cee22a3df24470965acdd5fb74/shapely-2.0.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cd0e75d9124b73e06a42bf1615ad3d7d805f66871aa94538c3a9b7871d620013", size = 1336402, upload-time = "2025-01-31T02:43:40.134Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/22/f6b074b08748d6f6afedd79f707d7eb88b79fa0121369246c25bbc721776/shapely-2.0.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7977d8a39c4cf0e06247cd2dca695ad4e020b81981d4c82152c996346cf1094b", size = 2376673, upload-time = "2025-01-31T02:43:41.922Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/f0/befc440a6c90c577300f5f84361bad80919e7c7ac381ae4960ce3195cedc/shapely-2.0.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0145387565fcf8f7c028b073c802956431308da933ef41d08b1693de49990d27", size = 2474380, upload-time = "2025-01-31T02:43:43.671Z" },
-    { url = "https://files.pythonhosted.org/packages/13/b8/edaf33dfb97e281d9de3871810de131b01e4f33d38d8f613515abc89d91e/shapely-2.0.7-cp39-cp39-win32.whl", hash = "sha256:98697c842d5c221408ba8aa573d4f49caef4831e9bc6b6e785ce38aca42d1999", size = 1297939, upload-time = "2025-01-31T02:43:46.287Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/95/4d164c2fcb19c51e50537aafb99ecfda82f62356bfdb6f4ca620a3932bad/shapely-2.0.7-cp39-cp39-win_amd64.whl", hash = "sha256:a3fb7fbae257e1b042f440289ee7235d03f433ea880e73e687f108d044b24db5", size = 1443665, upload-time = "2025-01-31T02:43:47.889Z" },
-]
-
-[[package]]
-name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
@@ -6251,7 +5149,6 @@ dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "docutils" },
     { name = "imagesize" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
     { name = "packaging" },
     { name = "pygments" },
@@ -6378,8 +5275,7 @@ name = "sql-redis"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "redis", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "redis" },
     { name = "sqlglot" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/2f/1a2c8e66af30af2d78375715f813ae62af834277ed806576c43f331b546e/sql_redis-0.4.0.tar.gz", hash = "sha256:c4cae163989a435c1b0b931dbd69f9783fb5593202b2ccdfbd5d62d95ecf425e", size = 158753, upload-time = "2026-04-06T16:26:34.852Z" }
@@ -6429,14 +5325,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ee/4afb39a8ee4fc786e2d716c20ab87b5b1fb33d4ac4129a1aaa574ae8a585/sqlalchemy-2.0.44-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e77faf6ff919aa8cd63f1c4e561cac1d9a454a191bb864d5dd5e545935e5a40", size = 3226248, upload-time = "2025-10-10T15:43:51.862Z" },
     { url = "https://files.pythonhosted.org/packages/32/d5/0e66097fc64fa266f29a7963296b40a80d6a997b7ac13806183700676f86/sqlalchemy-2.0.44-cp313-cp313-win32.whl", hash = "sha256:ee51625c2d51f8baadf2829fae817ad0b66b140573939dd69284d2ba3553ae73", size = 2101275, upload-time = "2025-10-10T15:03:26.096Z" },
     { url = "https://files.pythonhosted.org/packages/03/51/665617fe4f8c6450f42a6d8d69243f9420f5677395572c2fe9d21b493b7b/sqlalchemy-2.0.44-cp313-cp313-win_amd64.whl", hash = "sha256:c1c80faaee1a6c3428cecf40d16a2365bcf56c424c92c2b6f0f9ad204b899e9e", size = 2127901, upload-time = "2025-10-10T15:03:27.548Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1c/819435b7cb66dac6192e6af8b7d0896b9507edf798f3826b9590c7e980db/sqlalchemy-2.0.44-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7027414f2b88992877573ab780c19ecb54d3a536bef3397933573d6b5068be4", size = 2138850, upload-time = "2025-10-10T16:20:45.841Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/06/e8637ce5c4fdc027c00a9611052329169ef5a99feb22efd38866e27caf27/sqlalchemy-2.0.44-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3fe166c7d00912e8c10d3a9a0ce105569a31a3d0db1a6e82c4e0f4bf16d5eca9", size = 2128842, upload-time = "2025-10-10T16:20:47.209Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/5b/86f7cc573254bbfa50b339d8c72c5c026ceaa0adaa114237884886a0e14b/sqlalchemy-2.0.44-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3caef1ff89b1caefc28f0368b3bde21a7e3e630c2eddac16abd9e47bd27cc36a", size = 3216858, upload-time = "2025-10-10T15:38:33.535Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/ee/c9e582288edb41a47df7525f9fcae775d9f0b7da8eda8732f9d22f0c383e/sqlalchemy-2.0.44-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc2856d24afa44295735e72f3c75d6ee7fdd4336d8d3a8f3d44de7aa6b766df2", size = 3217019, upload-time = "2025-10-10T15:45:13.678Z" },
-    { url = "https://files.pythonhosted.org/packages/71/a1/449f3bea46769b31443eac4152452af684c0ddd64e3c4719b636f85a5604/sqlalchemy-2.0.44-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:11bac86b0deada30b6b5f93382712ff0e911fe8d31cb9bf46e6b149ae175eff0", size = 3155491, upload-time = "2025-10-10T15:38:35.317Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/34/f99b584a0bf94ff2e822bcb4951dcc24a7967476b35b9b3c35bc11cbd6bc/sqlalchemy-2.0.44-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4d18cd0e9a0f37c9f4088e50e3839fcb69a380a0ec957408e0b57cff08ee0a26", size = 3179978, upload-time = "2025-10-10T15:45:15.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/43/71a22aa66a1ef974f4e34982ce55d5f38d4770d2f0091eb210374e860b8e/sqlalchemy-2.0.44-cp39-cp39-win32.whl", hash = "sha256:9e9018544ab07614d591a26c1bd4293ddf40752cc435caf69196740516af7100", size = 2106888, upload-time = "2025-10-10T15:45:58.079Z" },
-    { url = "https://files.pythonhosted.org/packages/08/fb/cc98eb1ab3c5ad92b51c0db17ee86d1c33379a7490da376567b902222dcf/sqlalchemy-2.0.44-cp39-cp39-win_amd64.whl", hash = "sha256:8e0e4e66fd80f277a8c3de016a81a554e76ccf6b8d881ee0b53200305a8433f6", size = 2130728, upload-time = "2025-10-10T15:45:59.7Z" },
     { url = "https://files.pythonhosted.org/packages/9c/5e/6a29fa884d9fb7ddadf6b69490a9d45fded3b38541713010dad16b77d015/sqlalchemy-2.0.44-py3-none-any.whl", hash = "sha256:19de7ca1246fbef9f9d1bff8f1ab25641569df226364a0e40457dc5457c54b05", size = 1928718, upload-time = "2025-10-10T15:29:45.32Z" },
 ]
 
@@ -6454,8 +5342,8 @@ name = "sse-starlette"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.10'" },
-    { name = "starlette", marker = "python_full_version >= '3.10'" },
+    { name = "anyio" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/9f/c3695c2d2d4ef70072c3a06992850498b01c6bc9be531950813716b426fa/sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd", size = 32326, upload-time = "2026-02-28T11:24:34.36Z" }
 wheels = [
@@ -6481,8 +5369,8 @@ name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
@@ -6527,8 +5415,7 @@ dependencies = [
     { name = "docker" },
     { name = "python-dotenv" },
     { name = "typing-extensions" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
     { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/51/edac83edab339d8b4dce9a7b659163afb1ea7e011bfed1d5573d495a4485/testcontainers-4.13.2.tar.gz", hash = "sha256:2315f1e21b059427a9d11e8921f85fef322fbe0d50749bcca4eaa11271708ba4", size = 78692, upload-time = "2025-10-07T21:53:07.531Z" }
@@ -6642,97 +5529,33 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "fsspec", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", version = "2.27.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sympy", marker = "python_full_version < '3.10'" },
-    { name = "triton", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/28/110f7274254f1b8476c561dada127173f994afa2b1ffc044efb773c15650/torch-2.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0be92c08b44009d4131d1ff7a8060d10bafdb7ddcb7359ef8d8c5169007ea905", size = 102052793, upload-time = "2025-08-06T14:53:15.852Z" },
-    { url = "https://files.pythonhosted.org/packages/70/1c/58da560016f81c339ae14ab16c98153d51c941544ae568da3cb5b1ceb572/torch-2.8.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:89aa9ee820bb39d4d72b794345cccef106b574508dd17dbec457949678c76011", size = 888025420, upload-time = "2025-08-06T14:54:18.014Z" },
-    { url = "https://files.pythonhosted.org/packages/70/87/f69752d0dd4ba8218c390f0438130c166fa264a33b7025adb5014b92192c/torch-2.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e8e5bf982e87e2b59d932769938b698858c64cc53753894be25629bdf5cf2f46", size = 241363614, upload-time = "2025-08-06T14:53:31.496Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/d6/e6d4c57e61c2b2175d3aafbfb779926a2cfd7c32eeda7c543925dceec923/torch-2.8.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:a3f16a58a9a800f589b26d47ee15aca3acf065546137fc2af039876135f4c760", size = 73611154, upload-time = "2025-08-06T14:53:10.919Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/c4/3e7a3887eba14e815e614db70b3b529112d1513d9dae6f4d43e373360b7f/torch-2.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:220a06fd7af8b653c35d359dfe1aaf32f65aa85befa342629f716acb134b9710", size = 102073391, upload-time = "2025-08-06T14:53:20.937Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/63/4fdc45a0304536e75a5e1b1bbfb1b56dd0e2743c48ee83ca729f7ce44162/torch-2.8.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c12fa219f51a933d5f80eeb3a7a5d0cbe9168c0a14bbb4055f1979431660879b", size = 888063640, upload-time = "2025-08-06T14:55:05.325Z" },
-    { url = "https://files.pythonhosted.org/packages/84/57/2f64161769610cf6b1c5ed782bd8a780e18a3c9d48931319f2887fa9d0b1/torch-2.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:8c7ef765e27551b2fbfc0f41bcf270e1292d9bf79f8e0724848b1682be6e80aa", size = 241366752, upload-time = "2025-08-06T14:53:38.692Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5e/05a5c46085d9b97e928f3f037081d3d2b87fb4b4195030fc099aaec5effc/torch-2.8.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:5ae0524688fb6707c57a530c2325e13bb0090b745ba7b4a2cd6a3ce262572916", size = 73621174, upload-time = "2025-08-06T14:53:25.44Z" },
-    { url = "https://files.pythonhosted.org/packages/49/0c/2fd4df0d83a495bb5e54dca4474c4ec5f9c62db185421563deeb5dabf609/torch-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2fab4153768d433f8ed9279c8133a114a034a61e77a3a104dcdf54388838705", size = 101906089, upload-time = "2025-08-06T14:53:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a8/6acf48d48838fb8fe480597d98a0668c2beb02ee4755cc136de92a0a956f/torch-2.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2aca0939fb7e4d842561febbd4ffda67a8e958ff725c1c27e244e85e982173c", size = 887913624, upload-time = "2025-08-06T14:56:44.33Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8a/5c87f08e3abd825c7dfecef5a0f1d9aa5df5dd0e3fd1fa2f490a8e512402/torch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:2f4ac52f0130275d7517b03a33d2493bab3693c83dcfadf4f81688ea82147d2e", size = 241326087, upload-time = "2025-08-06T14:53:46.503Z" },
-    { url = "https://files.pythonhosted.org/packages/be/66/5c9a321b325aaecb92d4d1855421e3a055abd77903b7dab6575ca07796db/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:619c2869db3ada2c0105487ba21b5008defcc472d23f8b80ed91ac4a380283b0", size = 73630478, upload-time = "2025-08-06T14:53:57.144Z" },
-    { url = "https://files.pythonhosted.org/packages/10/4e/469ced5a0603245d6a19a556e9053300033f9c5baccf43a3d25ba73e189e/torch-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2b2f96814e0345f5a5aed9bf9734efa913678ed19caf6dc2cddb7930672d6128", size = 101936856, upload-time = "2025-08-06T14:54:01.526Z" },
-    { url = "https://files.pythonhosted.org/packages/16/82/3948e54c01b2109238357c6f86242e6ecbf0c63a1af46906772902f82057/torch-2.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:65616ca8ec6f43245e1f5f296603e33923f4c30f93d65e103d9e50c25b35150b", size = 887922844, upload-time = "2025-08-06T14:55:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/54/941ea0a860f2717d86a811adf0c2cd01b3983bdd460d0803053c4e0b8649/torch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:659df54119ae03e83a800addc125856effda88b016dfc54d9f65215c3975be16", size = 241330968, upload-time = "2025-08-06T14:54:45.293Z" },
-    { url = "https://files.pythonhosted.org/packages/de/69/8b7b13bba430f5e21d77708b616f767683629fc4f8037564a177d20f90ed/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:1a62a1ec4b0498930e2543535cf70b1bef8c777713de7ceb84cd79115f553767", size = 73915128, upload-time = "2025-08-06T14:54:34.769Z" },
-    { url = "https://files.pythonhosted.org/packages/15/0e/8a800e093b7f7430dbaefa80075aee9158ec22e4c4fc3c1a66e4fb96cb4f/torch-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:83c13411a26fac3d101fe8035a6b0476ae606deb8688e904e796a3534c197def", size = 102020139, upload-time = "2025-08-06T14:54:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/15/5e488ca0bc6162c86a33b58642bc577c84ded17c7b72d97e49b5833e2d73/torch-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8f0a9d617a66509ded240add3754e462430a6c1fc5589f86c17b433dd808f97a", size = 887990692, upload-time = "2025-08-06T14:56:18.286Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a8/6a04e4b54472fc5dba7ca2341ab219e529f3c07b6941059fbf18dccac31f/torch-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a7242b86f42be98ac674b88a4988643b9bc6145437ec8f048fea23f72feb5eca", size = 241603453, upload-time = "2025-08-06T14:55:22.945Z" },
-    { url = "https://files.pythonhosted.org/packages/04/6e/650bb7f28f771af0cb791b02348db8b7f5f64f40f6829ee82aa6ce99aabe/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7b677e17f5a3e69fdef7eb3b9da72622f8d322692930297e4ccb52fefc6c8211", size = 73632395, upload-time = "2025-08-06T14:55:28.645Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/b0/a321f27270049baa12f5c3fb0d6ceea005634787e3af9a8d75dce8306b0a/torch-2.8.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:da6afa31c13b669d4ba49d8a2169f0db2c3ec6bec4af898aa714f401d4c38904", size = 102059214, upload-time = "2025-08-06T14:55:33.433Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/dd/1630cb51b10d3d2e97db95e5a84c32def81fc26b005bce6fc880b0e6db81/torch-2.8.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:06fcee8000e5c62a9f3e52a688b9c5abb7c6228d0e56e3452983416025c41381", size = 888024302, upload-time = "2025-08-06T14:57:28.23Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/dc/1f1f621afe15e3c496e1e8f94f8903f75f87e7d642d5a985e92210cc208d/torch-2.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:5128fe752a355d9308e56af1ad28b15266fe2da5948660fad44de9e3a9e36e8c", size = 241249338, upload-time = "2025-08-06T14:57:05.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/95/ae26263aceb3d57b821179f827d0e321373ed49423e603dd5906ab14a730/torch-2.8.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:e9f071f5b52a9f6970dc8a919694b27a91ae9dc08898b2b988abbef5eddfd1ae", size = 73610795, upload-time = "2025-08-06T14:57:11.513Z" },
-]
-
-[[package]]
-name = "torch"
 version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "filelock", version = "3.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "fsspec", marker = "python_full_version >= '3.10'" },
-    { name = "jinja2", marker = "python_full_version >= '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", version = "2.27.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy", marker = "python_full_version >= '3.10'" },
-    { name = "triton", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/86/245c240d2138c17ed572c943c289056c2721abab70810d772c6bf5495b28/torch-2.9.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:030bbfe367379ae6a4ae4042b6c44da25383343b8b3c68abaa9c7231efbaf2dd", size = 104213554, upload-time = "2025-10-15T15:45:59.798Z" },
@@ -6810,11 +5633,9 @@ name = "transformers"
 version = "4.57.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -6831,35 +5652,8 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "setuptools", marker = "python_full_version < '3.10'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/39/43325b3b651d50187e591eefa22e236b2981afcebaefd4f2fc0ea99df191/triton-3.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b70f5e6a41e52e48cfc087436c8a28c17ff98db369447bcaff3b887a3ab4467", size = 155531138, upload-time = "2025-07-30T19:58:29.908Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
-    { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
-    { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
-    { url = "https://files.pythonhosted.org/packages/12/34/1251beb5a3cb93f3950ebe68732752014646003ef6eb11eb5f1a37ca78cd/triton-3.4.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e5c1442eaeabae2e2452ae765801bd53cd4ce873cab0d1bdd59a32ab2d9397", size = 155430799, upload-time = "2025-07-30T19:58:57.664Z" },
-]
-
-[[package]]
-name = "triton"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/eb/09e31d107a5d00eb281aa7e6635ca463e9bca86515944e399480eadb71f8/triton-3.5.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5d3b3d480debf24eaa739623c9a42446b0b77f95593d30eb1f64cd2278cc1f0", size = 170333110, upload-time = "2025-10-13T16:37:49.588Z" },
     { url = "https://files.pythonhosted.org/packages/3d/78/949a04391c21956c816523678f0e5fa308eb5b1e7622d88c4e4ef5fceca0/triton-3.5.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f34bfa21c5b3a203c0f0eab28dcc1e49bd1f67d22724e77fb6665a659200a4ec", size = 170433488, upload-time = "2025-10-13T16:37:57.132Z" },
@@ -6906,32 +5700,10 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.31.0.6"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "types-urllib3", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/b8/c1e8d39996b4929b918aba10dba5de07a8b3f4c8487bb61bb79882544e69/types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0", size = 15535, upload-time = "2023-09-27T06:19:38.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/a1/6f8dc74d9069e790d604ddae70cb46dcbac668f1bb08136e7b0f2f5cd3bf/types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9", size = 14516, upload-time = "2023-09-27T06:19:36.373Z" },
-]
-
-[[package]]
-name = "types-requests"
 version = "2.32.4.20250913"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "urllib3", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113, upload-time = "2025-09-13T02:40:02.309Z" }
 wheels = [
@@ -6945,15 +5717,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/bd/1e5f949b7cb740c9f0feaac430e301b8f1c5f11a81e26324299ea671a237/types_setuptools-80.9.0.20250822.tar.gz", hash = "sha256:070ea7716968ec67a84c7f7768d9952ff24d28b65b6594797a464f1b3066f965", size = 41296, upload-time = "2025-08-22T03:02:08.771Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/2d/475bf15c1cdc172e7a0d665b6e373ebfb1e9bf734d3f2f543d668b07a142/types_setuptools-80.9.0.20250822-py3-none-any.whl", hash = "sha256:53bf881cb9d7e46ed12c76ef76c0aaf28cfe6211d3fab12e0b83620b1a8642c3", size = 63179, upload-time = "2025-08-22T03:02:07.643Z" },
-]
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239, upload-time = "2023-07-20T15:19:31.307Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377, upload-time = "2023-07-20T15:19:30.379Z" },
 ]
 
 [[package]]
@@ -6988,27 +5751,8 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
-]
-
-[[package]]
-name = "urllib3"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/36/dd/a6b232f449e1bc71802a5b7950dc3675d32c6dbc2a1bd6d71f065551adb6/urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54", size = 263900, upload-time = "2023-11-13T12:29:45.049Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3", size = 104579, upload-time = "2023-11-13T12:29:42.719Z" },
@@ -7019,9 +5763,9 @@ name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "h11", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
@@ -7034,10 +5778,8 @@ version = "20.35.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock" },
+    { name = "platformdirs" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a4/d5/b0ccd381d55c8f45d46f77df6ae59fbc23d19e901e2d523395598e5f4c93/virtualenv-20.35.3.tar.gz", hash = "sha256:4f1a845d131133bdff10590489610c98c168ff99dc75d6c96853801f7f67af44", size = 6002907, upload-time = "2025-10-10T21:23:33.178Z" }
@@ -7053,13 +5795,10 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiolimiter" },
     { name = "ffmpeg-python" },
-    { name = "langchain-text-splitters", version = "0.3.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "langchain-text-splitters", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "langchain-text-splitters" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "tenacity" },
@@ -7075,7 +5814,7 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.10'" },
+    { name = "anyio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -7163,18 +5902,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/68/a7303a15cc797ab04d58f1fea7f67c50bd7f80090dfd7e750e7576e07582/watchfiles-1.1.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c882d69f6903ef6092bedfb7be973d9319940d56b8427ab9187d1ecd73438a70", size = 409220, upload-time = "2025-10-14T15:05:51.917Z" },
-    { url = "https://files.pythonhosted.org/packages/99/b8/d1857ce9ac76034c053fa7ef0e0ef92d8bd031e842ea6f5171725d31e88f/watchfiles-1.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d6ff426a7cb54f310d51bfe83fe9f2bbe40d540c741dc974ebc30e6aa238f52e", size = 396712, upload-time = "2025-10-14T15:05:53.437Z" },
-    { url = "https://files.pythonhosted.org/packages/41/7a/da7ada566f48beaa6a30b13335b49d1f6febaf3a5ddbd1d92163a1002cf4/watchfiles-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79ff6c6eadf2e3fc0d7786331362e6ef1e51125892c75f1004bd6b52155fb956", size = 451462, upload-time = "2025-10-14T15:05:54.742Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/b2/7cb9e0d5445a8d45c4cccd68a590d9e3a453289366b96ff37d1075aaebef/watchfiles-1.1.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c1f5210f1b8fc91ead1283c6fd89f70e76fb07283ec738056cf34d51e9c1d62c", size = 460811, upload-time = "2025-10-14T15:05:55.743Z" },
-    { url = "https://files.pythonhosted.org/packages/04/9d/b07d4491dde6db6ea6c680fdec452f4be363d65c82004faf2d853f59b76f/watchfiles-1.1.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9c4702f29ca48e023ffd9b7ff6b822acdf47cb1ff44cb490a3f1d5ec8987e9c", size = 490576, upload-time = "2025-10-14T15:05:56.983Z" },
-    { url = "https://files.pythonhosted.org/packages/56/03/e64dcab0a1806157db272a61b7891b062f441a30580a581ae72114259472/watchfiles-1.1.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:acb08650863767cbc58bca4813b92df4d6c648459dcaa3d4155681962b2aa2d3", size = 597726, upload-time = "2025-10-14T15:05:57.986Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/8e/a827cf4a8d5f2903a19a934dcf512082eb07675253e154d4cd9367978a58/watchfiles-1.1.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08af70fd77eee58549cd69c25055dc344f918d992ff626068242259f98d598a2", size = 474900, upload-time = "2025-10-14T15:05:59.378Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a6/94fed0b346b85b22303a12eee5f431006fae6af70d841cac2f4403245533/watchfiles-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c3631058c37e4a0ec440bf583bc53cdbd13e5661bb6f465bc1d88ee9a0a4d02", size = 457521, upload-time = "2025-10-14T15:06:00.419Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/64/bc3331150e8f3c778d48a4615d4b72b3d2d87868635e6c54bbd924946189/watchfiles-1.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cf57a27fb986c6243d2ee78392c503826056ffe0287e8794503b10fb51b881be", size = 632191, upload-time = "2025-10-14T15:06:01.621Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/84/f39e19549c2f3ec97225dcb2ceb9a7bb3c5004ed227aad1f321bf0ff2051/watchfiles-1.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d7e7067c98040d646982daa1f37a33d3544138ea155536c2e0e63e07ff8a7e0f", size = 623923, upload-time = "2025-10-14T15:06:02.671Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/24/0759ae15d9a0c9c5fe946bd4cf45ab9e7bad7cfede2c06dc10f59171b29f/watchfiles-1.1.1-cp39-cp39-win32.whl", hash = "sha256:6c9c9262f454d1c4d8aaa7050121eb4f3aea197360553699520767daebf2180b", size = 274010, upload-time = "2025-10-14T15:06:03.779Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/3b/eb26cddd4dfa081e2bf6918be3b2fc05ee3b55c1d21331d5562ee0c6aaad/watchfiles-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:74472234c8370669850e1c312490f6026d132ca2d396abfad8830b4f1c096957", size = 289090, upload-time = "2025-10-14T15:06:04.821Z" },
     { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
     { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
     { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
@@ -7183,10 +5910,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
-    { url = "https://files.pythonhosted.org/packages/00/db/38a2c52fdbbfe2fc7ffaaaaaebc927d52b9f4d5139bba3186c19a7463001/watchfiles-1.1.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cdab464fee731e0884c35ae3588514a9bcf718d0e2c82169c1c4a85cc19c3c7f", size = 409210, upload-time = "2025-10-14T15:06:14.492Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/43/d7e8b71f6c21ff813ee8da1006f89b6c7fff047fb4c8b16ceb5e840599c5/watchfiles-1.1.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:3dbd8cbadd46984f802f6d479b7e3afa86c42d13e8f0f322d669d79722c8ec34", size = 397286, upload-time = "2025-10-14T15:06:16.177Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/5d/884074a5269317e75bd0b915644b702b89de73e61a8a7446e2b225f45b1f/watchfiles-1.1.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5524298e3827105b61951a29c3512deb9578586abf3a7c5da4a8069df247cccc", size = 451768, upload-time = "2025-10-14T15:06:18.266Z" },
-    { url = "https://files.pythonhosted.org/packages/17/71/7ffcaa9b5e8961a25026058058c62ec8f604d2a6e8e1e94bee8a09e1593f/watchfiles-1.1.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b943d3668d61cfa528eb949577479d3b077fd25fb83c641235437bc0b5bc60e", size = 458561, upload-time = "2025-10-14T15:06:19.323Z" },
 ]
 
 [[package]]
@@ -7257,29 +5980,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/36/db/3fff0bcbe339a6fa6a3b9e3fbc2bfb321ec2f4cd233692272c5a8d6cf801/websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5", size = 175424, upload-time = "2025-03-05T20:02:56.505Z" },
-    { url = "https://files.pythonhosted.org/packages/46/e6/519054c2f477def4165b0ec060ad664ed174e140b0d1cbb9fafa4a54f6db/websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a", size = 173077, upload-time = "2025-03-05T20:02:58.37Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/21/c0712e382df64c93a0d16449ecbf87b647163485ca1cc3f6cbadb36d2b03/websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b", size = 173324, upload-time = "2025-03-05T20:02:59.773Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/cb/51ba82e59b3a664df54beed8ad95517c1b4dc1a913730e7a7db778f21291/websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770", size = 182094, upload-time = "2025-03-05T20:03:01.827Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/0f/bf3788c03fec679bcdaef787518dbe60d12fe5615a544a6d4cf82f045193/websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb", size = 181094, upload-time = "2025-03-05T20:03:03.123Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/da/9fb8c21edbc719b66763a571afbaf206cb6d3736d28255a46fc2fe20f902/websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054", size = 181397, upload-time = "2025-03-05T20:03:04.443Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/65/65f379525a2719e91d9d90c38fe8b8bc62bd3c702ac651b7278609b696c4/websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee", size = 181794, upload-time = "2025-03-05T20:03:06.708Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/26/31ac2d08f8e9304d81a1a7ed2851c0300f636019a57cbaa91342015c72cc/websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed", size = 181194, upload-time = "2025-03-05T20:03:08.844Z" },
-    { url = "https://files.pythonhosted.org/packages/98/72/1090de20d6c91994cd4b357c3f75a4f25ee231b63e03adea89671cc12a3f/websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880", size = 181164, upload-time = "2025-03-05T20:03:10.242Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/37/098f2e1c103ae8ed79b0e77f08d83b0ec0b241cf4b7f2f10edd0126472e1/websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411", size = 176381, upload-time = "2025-03-05T20:03:12.77Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8b/a32978a3ab42cebb2ebdd5b05df0696a09f4d436ce69def11893afa301f0/websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4", size = 176841, upload-time = "2025-03-05T20:03:14.367Z" },
     { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
     { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
     { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
     { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/48/4b67623bac4d79beb3a6bb27b803ba75c1bdedc06bd827e465803690a4b2/websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940", size = 173106, upload-time = "2025-03-05T20:03:29.404Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f0/adb07514a49fe5728192764e04295be78859e4a537ab8fcc518a3dbb3281/websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e", size = 173339, upload-time = "2025-03-05T20:03:30.755Z" },
-    { url = "https://files.pythonhosted.org/packages/87/28/bd23c6344b18fb43df40d0700f6d3fffcd7cef14a6995b4f976978b52e62/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9", size = 174597, upload-time = "2025-03-05T20:03:32.247Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/79/ca288495863d0f23a60f546f0905ae8f3ed467ad87f8b6aceb65f4c013e4/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b", size = 174205, upload-time = "2025-03-05T20:03:33.731Z" },
-    { url = "https://files.pythonhosted.org/packages/04/e4/120ff3180b0872b1fe6637f6f995bcb009fb5c87d597c1fc21456f50c848/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f", size = 174150, upload-time = "2025-03-05T20:03:35.757Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c3/30e2f9c539b8da8b1d76f64012f3b19253271a63413b2d3adb94b143407f/websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123", size = 176877, upload-time = "2025-03-05T20:03:37.199Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
@@ -7373,18 +6079,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/d7/df9e2d8040a3af618ff9496261cf90ca4f886fd226af0f4a69ac0c020c3b/wrapt-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:9b15940ae9debc8b40b15dc57e1ce4433f7fb9d3f8761c7fab1ddd94cb999d99", size = 60557, upload-time = "2025-10-19T23:47:26.73Z" },
     { url = "https://files.pythonhosted.org/packages/b4/c2/502bd4557a3a9199ea73cc5932cf83354bd362682162f0b14164d2e90216/wrapt-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7a0efbbc06d3e2077476a04f55859819d23206600b4c33f791359a8e6fa3c362", size = 63988, upload-time = "2025-10-19T23:47:23.826Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f2/632b13942f45db7af709f346ff38b8992c8c21b004e61ab320b0dec525fe/wrapt-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7fec8a9455c029c8cf4ff143a53b6e7c463268d42be6c17efa847ebd2f809965", size = 60584, upload-time = "2025-10-19T23:47:25.396Z" },
-    { url = "https://files.pythonhosted.org/packages/49/4d/8a4f359ee09aacb97b9b67181d3ff55581190626e5606dc4fb2dd16da816/wrapt-2.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:094d348ce7e6ce37bf6ed9a6ecc11886c96f447b3ffebc7539ca197daa9a997e", size = 77428, upload-time = "2025-10-19T23:47:38.897Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/9c/448c563781bac190bab9f033b62f8bba79170408808bc720b12149a2be0d/wrapt-2.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:98223acaa25b1449d993a3f4ffc8b5a03535e4041b37bf6a25459a0c74ee4cfc", size = 60640, upload-time = "2025-10-19T23:47:40.015Z" },
-    { url = "https://files.pythonhosted.org/packages/16/4c/7cfc16225870f29f68d4f0fdc4f46941ce03bc6f3252dfd4f88ef412a3ef/wrapt-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b79bf04c722035b1c474980dc1a64369feab7b703d6fe67da2d8664ed0bc980", size = 61521, upload-time = "2025-10-19T23:47:41.152Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/23/c3946b7384a88831e332f45a7f0793659bf5268359219ed610dd3485663d/wrapt-2.0.0-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:623242959cb0c53f76baeb929be79f5f6a9a1673ef51628072b91bf299af2212", size = 113346, upload-time = "2025-10-19T23:47:43.705Z" },
-    { url = "https://files.pythonhosted.org/packages/14/8a/bce87537bfe6c8667ea8f20801cbfef0d7f3f80719c83e8e165ac0ae6a47/wrapt-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59dc94afc4542c7d9b9447fb2ae1168b5a29064eca4061dbbf3b3c26df268334", size = 115313, upload-time = "2025-10-19T23:47:45.086Z" },
-    { url = "https://files.pythonhosted.org/packages/00/82/423457541f729a4a98f14cad0e04abbe4259cbcfdc8440e1be968ac1d9ef/wrapt-2.0.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7c532cc9f0a9e6017f8d3c37f478a3e3a5dffa955ebba556274e5e916c058f7", size = 111732, upload-time = "2025-10-19T23:47:42.258Z" },
-    { url = "https://files.pythonhosted.org/packages/58/7a/1c3054e7df8708dec622daa61d0af326eb0c86fedc4a3574ba61ded122c3/wrapt-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9d72c725cefbcc8ebab85c8352e5062ae87b6e323858e934e16b54ced580435a", size = 114513, upload-time = "2025-10-19T23:47:46.255Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c0/bc4fa45368d636606487846a5d05cde0cae0e93d053d77b45a3bb194d794/wrapt-2.0.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:2ca35b83497276c2ca0b072d2c00da2edde4c2a6c8c650eafcd1a006c17ab231", size = 110951, upload-time = "2025-10-19T23:47:47.384Z" },
-    { url = "https://files.pythonhosted.org/packages/da/05/a6d8446c757540ffe5200e47da6446b9f84ad5d3240bef8650265ad29a37/wrapt-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2fc55d0da29318a5da33c2827aef8946bba046ac609a4784a90faff73c511174", size = 113117, upload-time = "2025-10-19T23:47:48.519Z" },
-    { url = "https://files.pythonhosted.org/packages/83/1f/c5533d34bdc72d7ec8c0bf620caad5646caf75c9481c618e9565e1af3fd9/wrapt-2.0.0-cp39-cp39-win32.whl", hash = "sha256:9c100b0598f3763274f2033bcc0454de7486409f85bc6da58b49e5971747eb36", size = 57955, upload-time = "2025-10-19T23:47:51.796Z" },
-    { url = "https://files.pythonhosted.org/packages/27/75/02f89a2fbba8266253241cbd1e454c66a6bc12f4521d211ab084224d2e36/wrapt-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:1316972a72c67936a07dbb48e2464356d91dd9674335aaec087b60094d87750b", size = 60309, upload-time = "2025-10-19T23:47:49.653Z" },
-    { url = "https://files.pythonhosted.org/packages/88/c0/575127859ac2b1213e3558ec59d99f7fa705ce58e5f0890f22d485781efe/wrapt-2.0.0-cp39-cp39-win_arm64.whl", hash = "sha256:5aad54ff45da9784573099696fd84841c7e559ce312f02afa6aa7e89b58e2c2f", size = 58823, upload-time = "2025-10-19T23:47:50.721Z" },
     { url = "https://files.pythonhosted.org/packages/00/5c/c34575f96a0a038579683c7f10fca943c15c7946037d1d254ab9db1536ec/wrapt-2.0.0-py3-none-any.whl", hash = "sha256:02482fb0df89857e35427dfb844319417e14fae05878f295ee43fa3bf3b15502", size = 43998, upload-time = "2025-10-19T23:47:52.858Z" },
 ]
 
@@ -7511,22 +6205,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/18/55e6011f7c044dc80b98893060773cefcfdbf60dfefb8cb2f58b9bacbd83/yarl-1.22.0-cp314-cp314t-win32.whl", hash = "sha256:8009b3173bcd637be650922ac455946197d858b3630b6d8787aa9e5c4564533e", size = 89056, upload-time = "2025-10-06T14:12:13.317Z" },
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
-    { url = "https://files.pythonhosted.org/packages/94/fd/6480106702a79bcceda5fd9c63cb19a04a6506bd5ce7fd8d9b63742f0021/yarl-1.22.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3aa27acb6de7a23785d81557577491f6c38a5209a254d1191519d07d8fe51748", size = 141301, upload-time = "2025-10-06T14:12:19.01Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e1/6d95d21b17a93e793e4ec420a925fe1f6a9342338ca7a563ed21129c0990/yarl-1.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:af74f05666a5e531289cb1cc9c883d1de2088b8e5b4de48004e5ca8a830ac859", size = 93864, upload-time = "2025-10-06T14:12:21.05Z" },
-    { url = "https://files.pythonhosted.org/packages/32/58/b8055273c203968e89808413ea4c984988b6649baabf10f4522e67c22d2f/yarl-1.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:62441e55958977b8167b2709c164c91a6363e25da322d87ae6dd9c6019ceecf9", size = 94706, upload-time = "2025-10-06T14:12:23.287Z" },
-    { url = "https://files.pythonhosted.org/packages/18/91/d7bfbc28a88c2895ecd0da6a874def0c147de78afc52c773c28e1aa233a3/yarl-1.22.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b580e71cac3f8113d3135888770903eaf2f507e9421e5697d6ee6d8cd1c7f054", size = 347100, upload-time = "2025-10-06T14:12:28.527Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/e8/37a1e7b99721c0564b1fc7b0a4d1f595ef6fb8060d82ca61775b644185f7/yarl-1.22.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e81fda2fb4a07eda1a2252b216aa0df23ebcd4d584894e9612e80999a78fd95b", size = 318902, upload-time = "2025-10-06T14:12:30.528Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/ef/34724449d7ef2db4f22df644f2dac0b8a275d20f585e526937b3ae47b02d/yarl-1.22.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99b6fc1d55782461b78221e95fc357b47ad98b041e8e20f47c1411d0aacddc60", size = 363302, upload-time = "2025-10-06T14:12:32.295Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/04/88a39a5dad39889f192cce8d66cc4c58dbeca983e83f9b6bf23822a7ed91/yarl-1.22.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:088e4e08f033db4be2ccd1f34cf29fe994772fb54cfe004bbf54db320af56890", size = 370816, upload-time = "2025-10-06T14:12:34.01Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/1f/5e895e547129413f56c76be2c3ce4b96c797d2d0ff3e16a817d9269b12e6/yarl-1.22.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e4e1f6f0b4da23e61188676e3ed027ef0baa833a2e633c29ff8530800edccba", size = 346465, upload-time = "2025-10-06T14:12:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/11/13/a750e9fd6f9cc9ed3a52a70fe58ffe505322f0efe0d48e1fd9ffe53281f5/yarl-1.22.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:84fc3ec96fce86ce5aa305eb4aa9358279d1aa644b71fab7b8ed33fe3ba1a7ca", size = 341506, upload-time = "2025-10-06T14:12:37.788Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/67/bb6024de76e7186611ebe626aec5b71a2d2ecf9453e795f2dbd80614784c/yarl-1.22.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5dbeefd6ca588b33576a01b0ad58aa934bc1b41ef89dee505bf2932b22ddffba", size = 335030, upload-time = "2025-10-06T14:12:39.775Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/be/50b38447fd94a7992996a62b8b463d0579323fcfc08c61bdba949eef8a5d/yarl-1.22.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:14291620375b1060613f4aab9ebf21850058b6b1b438f386cc814813d901c60b", size = 358560, upload-time = "2025-10-06T14:12:41.547Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/89/c020b6f547578c4e3dbb6335bf918f26e2f34ad0d1e515d72fd33ac0c635/yarl-1.22.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:a4fcfc8eb2c34148c118dfa02e6427ca278bfd0f3df7c5f99e33d2c0e81eae3e", size = 357290, upload-time = "2025-10-06T14:12:43.861Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/52/c49a619ee35a402fa3a7019a4fa8d26878fec0d1243f6968bbf516789578/yarl-1.22.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:029866bde8d7b0878b9c160e72305bbf0a7342bcd20b9999381704ae03308dc8", size = 350700, upload-time = "2025-10-06T14:12:46.868Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c9/f5042d87777bf6968435f04a2bbb15466b2f142e6e47fa4f34d1a3f32f0c/yarl-1.22.0-cp39-cp39-win32.whl", hash = "sha256:4dcc74149ccc8bba31ce1944acee24813e93cfdee2acda3c172df844948ddf7b", size = 82323, upload-time = "2025-10-06T14:12:48.633Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/58/d00f7cad9eba20c4eefac2682f34661d1d1b3a942fc0092eb60e78cfb733/yarl-1.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:10619d9fdee46d20edc49d3479e2f8269d0779f1b031e6f7c2aa1c76be04b7ed", size = 87145, upload-time = "2025-10-06T14:12:50.241Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/a3/70904f365080780d38b919edd42d224b8c4ce224a86950d2eaa2a24366ad/yarl-1.22.0-cp39-cp39-win_arm64.whl", hash = "sha256:dd7afd3f8b0bfb4e0d9fc3c31bfe8a4ec7debe124cfd90619305def3c8ca8cd2", size = 82173, upload-time = "2025-10-06T14:12:51.869Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
 ]
 
@@ -7627,20 +6305,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
     { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0d/d0a405dad6ab6f9f759c26d866cca66cb209bff6f8db656074d662a953dd/zstandard-0.25.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b9af1fe743828123e12b41dd8091eca1074d0c1569cc42e6e1eee98027f2bbd0", size = 795263, upload-time = "2025-09-14T22:18:21.683Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/aa/ceb8d79cbad6dabd4cb1178ca853f6a4374d791c5e0241a0988173e2a341/zstandard-0.25.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b14abacf83dfb5c25eb4e4a79520de9e7e205f72c9ee7702f91233ae57d33a2", size = 640560, upload-time = "2025-09-14T22:18:22.867Z" },
-    { url = "https://files.pythonhosted.org/packages/88/cd/2cf6d476131b509cc122d25d3416a2d0aa17687ddbada7599149f9da620e/zstandard-0.25.0-cp39-cp39-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:a51ff14f8017338e2f2e5dab738ce1ec3b5a851f23b18c1ae1359b1eecbee6df", size = 5344244, upload-time = "2025-09-14T22:18:24.724Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/71/e14820b61a1c137966b7667b400b72fa4a45c836257e443f3d77607db268/zstandard-0.25.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3b870ce5a02d4b22286cf4944c628e0f0881b11b3f14667c1d62185a99e04f53", size = 5054550, upload-time = "2025-09-14T22:18:26.445Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ce/26dc5a6fa956be41d0e984909224ed196ee6f91d607f0b3fd84577741a77/zstandard-0.25.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:05353cef599a7b0b98baca9b068dd36810c3ef0f42bf282583f438caf6ddcee3", size = 5401150, upload-time = "2025-09-14T22:18:28.745Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/1b/402cab5edcfe867465daf869d5ac2a94930931c0989633bc01d6a7d8bd68/zstandard-0.25.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19796b39075201d51d5f5f790bf849221e58b48a39a5fc74837675d8bafc7362", size = 5448595, upload-time = "2025-09-14T22:18:30.475Z" },
-    { url = "https://files.pythonhosted.org/packages/86/b2/fc50c58271a1ead0e5a0a0e6311f4b221f35954dce438ce62751b3af9b68/zstandard-0.25.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:53e08b2445a6bc241261fea89d065536f00a581f02535f8122eba42db9375530", size = 5555290, upload-time = "2025-09-14T22:18:32.336Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/20/5f72d6ba970690df90fdd37195c5caa992e70cb6f203f74cc2bcc0b8cf30/zstandard-0.25.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1f3689581a72eaba9131b1d9bdbfe520ccd169999219b41000ede2fca5c1bfdb", size = 5043898, upload-time = "2025-09-14T22:18:34.215Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f1/131a0382b8b8d11e84690574645f528f5c5b9343e06cefd77f5fd730cd2b/zstandard-0.25.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d8c56bb4e6c795fc77d74d8e8b80846e1fb8292fc0b5060cd8131d522974b751", size = 5571173, upload-time = "2025-09-14T22:18:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f6/2a37931023f737fd849c5c28def57442bbafadb626da60cf9ed58461fe24/zstandard-0.25.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:53f94448fe5b10ee75d246497168e5825135d54325458c4bfffbaafabcc0a577", size = 4958261, upload-time = "2025-09-14T22:18:38.098Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/52/ca76ed6dbfd8845a5563d3af4e972da3b9da8a9308ca6b56b0b929d93e23/zstandard-0.25.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c2ba942c94e0691467ab901fc51b6f2085ff48f2eea77b1a48240f011e8247c7", size = 5265680, upload-time = "2025-09-14T22:18:39.834Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/59/edd117dedb97a768578b49fb2f1156defb839d1aa5b06200a62be943667f/zstandard-0.25.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:07b527a69c1e1c8b5ab1ab14e2afe0675614a09182213f21a0717b62027b5936", size = 5439747, upload-time = "2025-09-14T22:18:41.647Z" },
-    { url = "https://files.pythonhosted.org/packages/75/71/c2e9234643dcfbd6c5e975e9a2b0050e1b2afffda6c3a959e1b87997bc80/zstandard-0.25.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:51526324f1b23229001eb3735bc8c94f9c578b1bd9e867a0a646a3b17109f388", size = 5818805, upload-time = "2025-09-14T22:18:43.602Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/93/8ebc19f0a31c44ea0e7348f9b0d4b326ed413b6575a3c6ff4ed50222abb6/zstandard-0.25.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89c4b48479a43f820b749df49cd7ba2dbc2b1b78560ecb5ab52985574fd40b27", size = 5362280, upload-time = "2025-09-14T22:18:45.625Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/e9/29cc59d4a9d51b3fd8b477d858d0bd7ab627f700908bf1517f46ddd470ae/zstandard-0.25.0-cp39-cp39-win32.whl", hash = "sha256:1cd5da4d8e8ee0e88be976c294db744773459d51bb32f707a0f166e5ad5c8649", size = 436460, upload-time = "2025-09-14T22:18:49.077Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b5/bc7a92c116e2ef32dc8061c209d71e97ff6df37487d7d39adb51a343ee89/zstandard-0.25.0-cp39-cp39-win_amd64.whl", hash = "sha256:37daddd452c0ffb65da00620afb8e17abd4adaae6ce6310702841760c2c26860", size = 506097, upload-time = "2025-09-14T22:18:47.342Z" },
 ]


### PR DESCRIPTION
## Summary

This PR drops Python 3.9 support from RedisVL and makes Python 3.10 the project minimum. That change is carried through package metadata, the lockfile, CI configuration, repo-owned documentation, and the codebase’s type annotations so the stated support policy and the implementation match.

## Motivation

Supporting Python 3.9 was already imposing ongoing cost in a few different ways. It required extra compatibility handling, kept the project split between core-package and MCP-specific runtime messaging, and forced older annotation syntax across large parts of the repository. Python 3.9 is also past its official end-of-life, so continuing to carry support for it no longer has a strong maintenance or ecosystem justification. The project already targets newer runtimes in practice, which makes keeping 3.9 mostly maintenance overhead.

## Changes

The support-floor change starts in packaging and CI. `pyproject.toml`, `uv.lock`, and the GitHub Actions workflows now treat Python 3.10 as the minimum supported version, while preserving current newer-runtime coverage, including Python 3.14 in lint and test configuration. This aligns the declared support policy with the environments the project is expected to run and validate against.

The library code has also been updated to use Python 3.10-native typing syntax throughout repo-owned Python sources. Legacy `typing` container aliases and `Optional`/`Union` forms were replaced with built-in generics and `|` unions where valid, while runtime-sensitive sites were adjusted manually so forward references, type checks, and schema/type-introspection behavior remain valid without adding `from __future__ import annotations`.

Additional follow-up changes include:
- Moving `Annotated` imports to the standard library where supported
- Keeping `typing_extensions.Self` in place where it is still required for Python 3.10 compatibility
- Removing the redundant MCP CLI runtime guard that duplicated the package-level Python requirement
- Updating README content, installation guidance, MCP docs, notebook prose, and tests that assert exact type-hint shapes so they align with the new support floor and modernized annotations

## Note for Reviewers

The docs build still reports existing Sphinx warnings that are unrelated to this PR.

## Testing

The following checks were run during development:
- `make check-sort-imports`
- `make check-format`
- `make check-types`
- `uv run python -m tests.test_imports redisvl`
- `uv run python -m pytest tests/unit/test_validation.py tests/unit/test_index_schema_type_issue.py tests/unit/test_base_vectorizer.py tests/unit/test_cli_utils.py tests/unit/test_hybrid_types.py tests/unit/test_mcp/test_search_tool_unit.py tests/unit/test_mcp/test_upsert_tool_unit.py tests/integration/test_mcp/test_server_startup.py tests/integration/test_mcp/test_upsert_tool.py -q`
- `make docs-build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it is a breaking support-policy change (Python >=3.10) and touches broad, core surfaces (index/storage/cache/router/CLI) via widespread type-annotation refactors that could affect runtime edge cases if any typing changes leaked into behavior.
> 
> **Overview**
> Drops Python 3.9 support across the project: updates `pyproject.toml` (`requires-python` >=3.10), removes 3.9 from classifiers/Black targets, and adjusts optional dependency markers now that the whole package requires 3.10+.
> 
> Aligns CI and docs with the new minimum by removing 3.9 from the test matrix, adding 3.14 to lint, and updating installation/MCP documentation and a notebook to state Python 3.10+.
> 
> Modernizes repo-owned Python sources to Python 3.10 typing syntax (built-in generics and `|` unions) across caches, message history, router, and the core `SearchIndex`/storage layer, and removes the redundant MCP CLI runtime version guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bb3515b9e4cdcd197d1e5c55215c4a9d311d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->