### PR TITLE
Fix/cli: standardize exit codes, messages and streams

### DIFF
--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -2,13 +2,10 @@ import argparse
 import sys
 from argparse import Namespace
 
-from redisvl.cli.utils import (
-    SCHEMA_INPUT_ERRORS,
-    add_index_parsing_options,
-    create_redis_url,
-    exit_redis_search_error,
-    exit_schema_input_error,
-)
+import yaml
+from pydantic import ValidationError
+
+from redisvl.cli.utils import add_index_parsing_options, create_redis_url
 from redisvl.exceptions import RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.redis.connection import RedisConnectionFactory
@@ -17,6 +14,36 @@ from redisvl.schema.schema import IndexSchema
 from redisvl.utils.log import get_logger
 
 logger = get_logger("[RedisVL]")
+
+# Exceptions commonly raised when loading or validating a schema path (-s).
+SCHEMA_INPUT_ERRORS = (
+    FileNotFoundError,
+    ValueError,
+    yaml.YAMLError,
+    ValidationError,
+)
+
+
+def exit_schema_input_error(args: Namespace, exc: BaseException) -> None:
+    if not args.schema:
+        raise exc
+    print(str(exc), file=sys.stderr)
+    sys.exit(2)
+
+
+def exit_redis_search_error(
+    args: Namespace, index: SearchIndex | None, exc: RedisSearchError
+) -> None:
+    name = (
+        index.schema.index.name
+        if index is not None
+        else (args.index or args.schema or "unknown")
+    )
+    print(
+        f"Redis search operation failed for index {name!r}. {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 class Index:

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -2,7 +2,14 @@ import argparse
 import sys
 from argparse import Namespace
 
-from redisvl.cli.utils import add_index_parsing_options, create_redis_url
+from redisvl.cli.utils import (
+    SCHEMA_INPUT_ERRORS,
+    add_index_parsing_options,
+    create_redis_url,
+    exit_redis_search_error,
+    exit_schema_input_error,
+)
+from redisvl.exceptions import RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.redis.connection import RedisConnectionFactory
 from redisvl.redis.utils import convert_bytes, make_dict
@@ -33,26 +40,37 @@ class Index:
         parser = add_index_parsing_options(parser)
 
         args = parser.parse_args(sys.argv[2:])
+
         if not hasattr(self, args.command):
-            parser.print_help()
-            exit(0)
+            print(f"Unknown command: {args.command}\n", file=sys.stderr)
+            parser.print_help(sys.stderr)
+            sys.exit(2)
+            
         try:
             getattr(self, args.command)(args)
         except Exception as e:
-            logger.error(e)
-            exit(0)
+            logger.error(e, exc_info=True)
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
 
     def create(self, args: Namespace):
         """Create an index.
 
         Usage:
-            rvl index create -i <index_name> | -s <schema_path>
+            rvl index create -s <schema_path>
         """
         if not args.schema:
-            print("Schema must be provided to create an index")
-            exit(1)
-        index = SearchIndex.from_yaml(args.schema, redis_url=create_redis_url(args))
-        index.create()
+            print("Schema must be provided to create an index", file=sys.stderr)
+            sys.exit(2)
+
+        index: SearchIndex | None = None
+        try:
+            index = SearchIndex.from_yaml(args.schema, redis_url=create_redis_url(args))
+            index.create()
+        except SCHEMA_INPUT_ERRORS as e:
+            exit_schema_input_error(args, e)
+        except RedisSearchError as e:
+            exit_redis_search_error(args, index, e)
         print("Index created successfully")
 
     def info(self, args: Namespace):
@@ -61,8 +79,14 @@ class Index:
         Usage:
             rvl index info -i <index_name> | -s <schema_path>
         """
-        index = self._connect_to_index(args)
-        _display_in_table(index.info())
+        index: SearchIndex | None = None
+        try:
+            index = self._connect_to_index(args)
+            _display_in_table(index.info())
+        except SCHEMA_INPUT_ERRORS as e:
+            exit_schema_input_error(args, e)
+        except RedisSearchError as e:
+            exit_redis_search_error(args, index, e)
 
     def listall(self, args: Namespace):
         """List all indices.
@@ -83,8 +107,14 @@ class Index:
         Usage:
             rvl index delete -i <index_name> | -s <schema_path>
         """
-        index = self._connect_to_index(args)
-        index.delete(drop=drop)
+        index: SearchIndex | None = None
+        try:
+            index = self._connect_to_index(args)
+            index.delete(drop=drop)
+        except SCHEMA_INPUT_ERRORS as e:
+            exit_schema_input_error(args, e)
+        except RedisSearchError as e:
+            exit_redis_search_error(args, index, e)
         print("Index deleted successfully")
 
     def destroy(self, args: Namespace):
@@ -105,8 +135,8 @@ class Index:
         elif args.schema:
             index = SearchIndex.from_yaml(args.schema, redis_url=redis_url)
         else:
-            print("Index name or schema must be provided")
-            exit(1)
+            print("Index name or schema must be provided", file=sys.stderr)
+            sys.exit(2)
 
         return index
 

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -63,12 +63,13 @@ class Index:
             print("Schema must be provided to create an index", file=sys.stderr)
             sys.exit(2)
 
-        index: SearchIndex | None = None
+        redis_url = create_redis_url(args)
         try:
-            index = SearchIndex.from_yaml(args.schema, redis_url=create_redis_url(args))
-            index.create()
+            index = SearchIndex.from_yaml(args.schema, redis_url=redis_url)
         except SCHEMA_INPUT_ERRORS as e:
             exit_schema_input_error(args, e)
+        try:
+            index.create()
         except RedisSearchError as e:
             exit_redis_search_error(args, index, e)
         print("Index created successfully")
@@ -79,12 +80,9 @@ class Index:
         Usage:
             rvl index info -i <index_name> | -s <schema_path>
         """
-        index: SearchIndex | None = None
+        index = self._connect_to_index(args)
         try:
-            index = self._connect_to_index(args)
             _display_in_table(index.info())
-        except SCHEMA_INPUT_ERRORS as e:
-            exit_schema_input_error(args, e)
         except RedisSearchError as e:
             exit_redis_search_error(args, index, e)
 
@@ -107,12 +105,9 @@ class Index:
         Usage:
             rvl index delete -i <index_name> | -s <schema_path>
         """
-        index: SearchIndex | None = None
+        index = self._connect_to_index(args)
         try:
-            index = self._connect_to_index(args)
             index.delete(drop=drop)
-        except SCHEMA_INPUT_ERRORS as e:
-            exit_schema_input_error(args, e)
         except RedisSearchError as e:
             exit_redis_search_error(args, index, e)
         print("Index deleted successfully")
@@ -126,19 +121,23 @@ class Index:
         self.delete(args, drop=True)
 
     def _connect_to_index(self, args: Namespace) -> SearchIndex:
-        # connect to redis
         redis_url = create_redis_url(args)
 
         if args.index:
-            schema = IndexSchema.from_dict({"index": {"name": args.index}})
-            index = SearchIndex(schema=schema, redis_url=redis_url)
-        elif args.schema:
-            index = SearchIndex.from_yaml(args.schema, redis_url=redis_url)
-        else:
-            print("Index name or schema must be provided", file=sys.stderr)
-            sys.exit(2)
+            try:
+                schema = IndexSchema.from_dict({"index": {"name": args.index}})
+                return SearchIndex(schema=schema, redis_url=redis_url)
+            except SCHEMA_INPUT_ERRORS as e:
+                exit_schema_input_error(args, e)
 
-        return index
+        if args.schema:
+            try:
+                return SearchIndex.from_yaml(args.schema, redis_url=redis_url)
+            except SCHEMA_INPUT_ERRORS as e:
+                exit_schema_input_error(args, e)
+
+        print("Index name or schema must be provided", file=sys.stderr)
+        sys.exit(2)
 
 
 def _display_in_table(index_info):

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -45,7 +45,7 @@ class Index:
             print(f"Unknown command: {args.command}\n", file=sys.stderr)
             parser.print_help(sys.stderr)
             sys.exit(2)
-            
+
         try:
             getattr(self, args.command)(args)
         except Exception as e:

--- a/redisvl/cli/main.py
+++ b/redisvl/cli/main.py
@@ -30,29 +30,35 @@ class RedisVlCLI:
         parser.add_argument("command", help="Subcommand to run")
 
         if len(sys.argv) < 2:
-            parser.print_help()
-            exit(0)
+            parser.print_help(sys.stdout)
+            sys.exit(0)
 
         args = parser.parse_args(sys.argv[1:2])
+        
         if not hasattr(self, args.command):
-            parser.print_help()
-            exit(0)
-        getattr(self, args.command)()
+            print(f"Unknown command: {args.command}\n", file=sys.stderr)
+            parser.print_help(sys.stderr)
+            sys.exit(2)
+        
+        try:
+            getattr(self, args.command)()
+        except Exception as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
 
     def index(self):
         Index()
-        exit(0)
+        sys.exit(0)
 
     def mcp(self):
         from redisvl.cli.mcp import MCP
-
         MCP()
-        exit(0)
+        sys.exit(0)
 
     def version(self):
         Version()
-        exit(0)
+        sys.exit(0)
 
     def stats(self):
         Stats()
-        exit(0)
+        sys.exit(0)

--- a/redisvl/cli/main.py
+++ b/redisvl/cli/main.py
@@ -34,12 +34,12 @@ class RedisVlCLI:
             sys.exit(0)
 
         args = parser.parse_args(sys.argv[1:2])
-        
+
         if not hasattr(self, args.command):
             print(f"Unknown command: {args.command}\n", file=sys.stderr)
             parser.print_help(sys.stderr)
             sys.exit(2)
-        
+
         try:
             getattr(self, args.command)()
         except Exception as e:
@@ -52,6 +52,7 @@ class RedisVlCLI:
 
     def mcp(self):
         from redisvl.cli.mcp import MCP
+
         MCP()
         sys.exit(0)
 

--- a/redisvl/cli/mcp.py
+++ b/redisvl/cli/mcp.py
@@ -7,11 +7,11 @@ import sys
 
 
 class _MCPArgumentParser(argparse.ArgumentParser):
-    """ArgumentParser variant that reports usage errors with exit code 1."""
+    """ArgumentParser variant that reports usage errors with exit code 2."""
 
     def error(self, message):
         self.print_usage(sys.stderr)
-        self.exit(1, "%s: error: %s\n" % (self.prog, message))
+        self.exit(2, "%s: error: %s\n" % (self.prog, message))
 
 
 class MCP:

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -2,19 +2,46 @@ import argparse
 import sys
 from argparse import Namespace
 
-from redisvl.cli.utils import (
-    SCHEMA_INPUT_ERRORS,
-    add_index_parsing_options,
-    create_redis_url,
-    exit_redis_search_error,
-    exit_schema_input_error,
-)
+import yaml
+from pydantic import ValidationError
+
+from redisvl.cli.utils import add_index_parsing_options, create_redis_url
 from redisvl.exceptions import RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.schema.schema import IndexSchema
 from redisvl.utils.log import get_logger
 
 logger = get_logger("[RedisVL]")
+
+# Exceptions commonly raised when loading or validating a schema path (-s).
+SCHEMA_INPUT_ERRORS = (
+    FileNotFoundError,
+    ValueError,
+    yaml.YAMLError,
+    ValidationError,
+)
+
+
+def exit_schema_input_error(args: Namespace, exc: BaseException) -> None:
+    if not args.schema:
+        raise exc
+    print(str(exc), file=sys.stderr)
+    sys.exit(2)
+
+
+def exit_redis_search_error(
+    args: Namespace, index: SearchIndex | None, exc: RedisSearchError
+) -> None:
+    name = (
+        index.schema.index.name
+        if index is not None
+        else (args.index or args.schema or "unknown")
+    )
+    print(
+        f"Redis search operation failed for index {name!r}. {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 STATS_KEYS = [
     "num_docs",

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -43,6 +43,7 @@ def exit_redis_search_error(
     )
     sys.exit(1)
 
+
 STATS_KEYS = [
     "num_docs",
     "num_terms",

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -2,7 +2,14 @@ import argparse
 import sys
 from argparse import Namespace
 
-from redisvl.cli.utils import add_index_parsing_options, create_redis_url
+from redisvl.cli.utils import (
+    SCHEMA_INPUT_ERRORS,
+    add_index_parsing_options,
+    create_redis_url,
+    exit_redis_search_error,
+    exit_schema_input_error,
+)
+from redisvl.exceptions import RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.schema.schema import IndexSchema
 from redisvl.utils.log import get_logger
@@ -43,11 +50,13 @@ class Stats:
         parser = argparse.ArgumentParser(usage=self.usage)
         parser = add_index_parsing_options(parser)
         args = parser.parse_args(sys.argv[2:])
+        
         try:
             self.stats(args)
         except Exception as e:
-            logger.error(e)
-            exit(0)
+            logger.error(e, exc_info=True)
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
 
     def stats(self, args: Namespace):
         """Obtain stats about an index.
@@ -55,8 +64,14 @@ class Stats:
         Usage:
             rvl stats -i <index_name> | -s <schema_path>
         """
-        index = self._connect_to_index(args)
-        _display_stats(index.info())
+        index: SearchIndex | None = None
+        try:
+            index = self._connect_to_index(args)
+            _display_stats(index.info())
+        except SCHEMA_INPUT_ERRORS as e:
+            exit_schema_input_error(args, e)
+        except RedisSearchError as e:
+            exit_redis_search_error(args, index, e)
 
     def _connect_to_index(self, args: Namespace) -> SearchIndex:
         # connect to redis
@@ -68,8 +83,8 @@ class Stats:
         elif args.schema:
             index = SearchIndex.from_yaml(args.schema, redis_url=redis_url)
         else:
-            logger.error("Index name or schema must be provided")
-            exit(0)
+            print("Index name or schema must be provided", file=sys.stderr)
+            sys.exit(2)
 
         return index
 

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -50,7 +50,7 @@ class Stats:
         parser = argparse.ArgumentParser(usage=self.usage)
         parser = add_index_parsing_options(parser)
         args = parser.parse_args(sys.argv[2:])
-        
+
         try:
             self.stats(args)
         except Exception as e:

--- a/redisvl/cli/stats.py
+++ b/redisvl/cli/stats.py
@@ -64,29 +64,30 @@ class Stats:
         Usage:
             rvl stats -i <index_name> | -s <schema_path>
         """
-        index: SearchIndex | None = None
+        index = self._connect_to_index(args)
         try:
-            index = self._connect_to_index(args)
             _display_stats(index.info())
-        except SCHEMA_INPUT_ERRORS as e:
-            exit_schema_input_error(args, e)
         except RedisSearchError as e:
             exit_redis_search_error(args, index, e)
 
     def _connect_to_index(self, args: Namespace) -> SearchIndex:
-        # connect to redis
         redis_url = create_redis_url(args)
 
         if args.index:
-            schema = IndexSchema.from_dict({"index": {"name": args.index}})
-            index = SearchIndex(schema=schema, redis_url=redis_url)
-        elif args.schema:
-            index = SearchIndex.from_yaml(args.schema, redis_url=redis_url)
-        else:
-            print("Index name or schema must be provided", file=sys.stderr)
-            sys.exit(2)
+            try:
+                schema = IndexSchema.from_dict({"index": {"name": args.index}})
+                return SearchIndex(schema=schema, redis_url=redis_url)
+            except SCHEMA_INPUT_ERRORS as e:
+                exit_schema_input_error(args, e)
 
-        return index
+        if args.schema:
+            try:
+                return SearchIndex.from_yaml(args.schema, redis_url=redis_url)
+            except SCHEMA_INPUT_ERRORS as e:
+                exit_schema_input_error(args, e)
+
+        print("Index name or schema must be provided", file=sys.stderr)
+        sys.exit(2)
 
 
 def _display_stats(index_info):

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,13 +1,7 @@
 import os
-import sys
 from argparse import ArgumentParser, Namespace
 from urllib.parse import quote, urlparse, urlunparse
 
-import yaml
-from pydantic import ValidationError
-
-from redisvl.exceptions import RedisSearchError
-from redisvl.index import SearchIndex
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
 
@@ -97,36 +91,3 @@ def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
         default=None,
     )
     return parser
-
-
-# Exceptions commonly raised when loading or validating a schema path (-s).
-SCHEMA_INPUT_ERRORS = (
-    FileNotFoundError,
-    ValueError,
-    yaml.YAMLError,
-    ValidationError,
-)
-
-
-def cli_index_target_name(args: Namespace, index: SearchIndex | None) -> str:
-    if index is not None:
-        return index.schema.index.name
-    return args.index or args.schema or "unknown"
-
-
-def exit_schema_input_error(args: Namespace, exc: BaseException) -> None:
-    if not args.schema:
-        raise exc
-    print(str(exc), file=sys.stderr)
-    sys.exit(2)
-
-
-def exit_redis_search_error(
-    args: Namespace, index: SearchIndex | None, exc: RedisSearchError
-) -> None:
-    name = cli_index_target_name(args, index)
-    print(
-        f"Redis search operation failed for index {name!r}. {exc}",
-        file=sys.stderr,
-    )
-    sys.exit(1)

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -117,7 +117,7 @@ def cli_index_target_name(args: Namespace, index: SearchIndex | None) -> str:
 def exit_schema_input_error(args: Namespace, exc: BaseException) -> None:
     if not args.schema:
         raise exc
-    print(f"Invalid schema file or path ({args.schema!r}): {exc}", file=sys.stderr)
+    print(str(exc), file=sys.stderr)
     sys.exit(2)
 
 
@@ -126,7 +126,7 @@ def exit_redis_search_error(
 ) -> None:
     name = cli_index_target_name(args, index)
     print(
-        f"Redis search operation failed for index {name!r}: {exc}",
+        f"Redis search operation failed for index {name!r}. {exc}",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/redisvl/cli/utils.py
+++ b/redisvl/cli/utils.py
@@ -1,7 +1,13 @@
 import os
+import sys
 from argparse import ArgumentParser, Namespace
 from urllib.parse import quote, urlparse, urlunparse
 
+import yaml
+from pydantic import ValidationError
+
+from redisvl.exceptions import RedisSearchError
+from redisvl.index import SearchIndex
 from redisvl.redis.constants import REDIS_URL_ENV_VAR
 from redisvl.utils.log import get_logger
 
@@ -91,3 +97,36 @@ def add_index_parsing_options(parser: ArgumentParser) -> ArgumentParser:
         default=None,
     )
     return parser
+
+
+# Exceptions commonly raised when loading or validating a schema path (-s).
+SCHEMA_INPUT_ERRORS = (
+    FileNotFoundError,
+    ValueError,
+    yaml.YAMLError,
+    ValidationError,
+)
+
+
+def cli_index_target_name(args: Namespace, index: SearchIndex | None) -> str:
+    if index is not None:
+        return index.schema.index.name
+    return args.index or args.schema or "unknown"
+
+
+def exit_schema_input_error(args: Namespace, exc: BaseException) -> None:
+    if not args.schema:
+        raise exc
+    print(f"Invalid schema file or path ({args.schema!r}): {exc}", file=sys.stderr)
+    sys.exit(2)
+
+
+def exit_redis_search_error(
+    args: Namespace, index: SearchIndex | None, exc: RedisSearchError
+) -> None:
+    name = cli_index_target_name(args, index)
+    print(
+        f"Redis search operation failed for index {name!r}: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/redisvl/cli/version.py
+++ b/redisvl/cli/version.py
@@ -3,9 +3,6 @@ import sys
 from argparse import Namespace
 
 from redisvl import __version__
-from redisvl.utils.log import get_logger
-
-logger = get_logger("[RedisVL]")
 
 
 class Version:
@@ -29,4 +26,4 @@ class Version:
         if args.short:
             print(__version__)
         else:
-            logger.info(f"RedisVL version {__version__}")
+            print(f"RedisVL version {__version__}")

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -464,7 +464,7 @@ def test_mcp_command_rejects_invalid_transport(monkeypatch, capsys):
     with pytest.raises(SystemExit) as exc_info:
         module.MCP()
 
-    assert exc_info.value.code == 1
+    assert exc_info.value.code == 2
     out = capsys.readouterr()
     assert "invalid choice" in out.err or "invalid choice" in out.out
 


### PR DESCRIPTION
- Standardize non-MCP rvl CLI behavior: exit 0 for success/help, exit 2 for usage/argument and schema input issues, exit 1 for runtime failures; stderr for errors and stdout for normal output or help.

- Catch specific exception types in the CLI to map to the right exit code (e.g. invalid path vs Redis search)

- Version: print version to stdout (not only via logger).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI exit codes/streams and error mapping, which can break existing scripts that depend on previous behavior. Logic changes are localized to CLI wrappers and do not modify core indexing/search functionality.
> 
> **Overview**
> Standardizes `rvl` CLI exit behavior and messaging: **success/help exit 0**, **usage/schema input problems exit 2**, and **runtime/Redis failures exit 1**, with errors consistently printed to *stderr*.
> 
> `index` and `stats` now explicitly catch schema-loading/validation errors (YAML/Pydantic/path issues) separately from `RedisSearchError`, and provide more actionable, index-scoped failure messages. Top-level command dispatch in `main.py` also reports unknown commands as usage errors (exit 2), and `version` now prints directly to stdout instead of logging.
> 
> Updates MCP argparse usage errors to exit 2 and adjusts the corresponding unit test expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d20ffbe643ceb5e58462ba5cbe86a79b457e1e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->