### PR TITLE
docs(user-guide): clean notebook outputs (#588, #589)

### DIFF
--- a/docs/user_guide/04_vectorizers.ipynb
+++ b/docs/user_guide/04_vectorizers.ipynb
@@ -1,841 +1,793 @@
 {
- "cells": [
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Create Embeddings with Vectorizers\n",
-    "\n",
-    "This guide demonstrates how to create embeddings using RedisVL's built-in text vectorizers. RedisVL supports multiple embedding providers: OpenAI, HuggingFace, Vertex AI, Cohere, Mistral AI, Amazon Bedrock, VoyageAI, and custom vectorizers.\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "Before you begin, ensure you have:\n",
-    "- Installed RedisVL: `pip install redisvl`\n",
-    "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
-    "- API keys for the embedding providers you plan to use\n",
-    "\n",
-    "## What You'll Learn\n",
-    "\n",
-    "By the end of this guide, you will be able to:\n",
-    "- Create embeddings using multiple providers (OpenAI, HuggingFace, Cohere, etc.)\n",
-    "- Use synchronous and asynchronous embedding methods\n",
-    "- Batch embed multiple texts efficiently\n",
-    "- Build custom vectorizers for your own embedding functions\n",
-    "- Integrate vectorizers with RedisVL indexes for semantic search"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import necessary modules\n",
-    "import os"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Creating Text Embeddings\n",
-    "\n",
-    "This example will show how to create an embedding from 3 simple sentences with a number of different text vectorizers in RedisVL.\n",
-    "\n",
-    "- \"That is a happy dog\"\n",
-    "- \"That is a happy person\"\n",
-    "- \"Today is a nice day\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### OpenAI\n",
-    "\n",
-    "The ``OpenAITextVectorizer`` makes it simple to use RedisVL with the embeddings models at OpenAI. For this you will need to install ``openai``. \n",
-    "\n",
-    "```bash\n",
-    "pip install openai\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import getpass\n",
-    "\n",
-    "# setup the API Key\n",
-    "api_key = os.environ.get(\"OPENAI_API_KEY\") or getpass.getpass(\"Enter your OpenAI API key: \")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Vector dimensions:  1536\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Create Embeddings with Vectorizers\n",
+        "\n",
+        "This guide demonstrates how to create embeddings using RedisVL's built-in text vectorizers. RedisVL supports multiple embedding providers: OpenAI, HuggingFace, Vertex AI, Cohere, Mistral AI, Amazon Bedrock, VoyageAI, and custom vectorizers.\n",
+        "\n",
+        "## Prerequisites\n",
+        "\n",
+        "Before you begin, ensure you have:\n",
+        "- Installed RedisVL: `pip install redisvl`\n",
+        "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
+        "- API keys for the embedding providers you plan to use\n",
+        "\n",
+        "## What You'll Learn\n",
+        "\n",
+        "By the end of this guide, you will be able to:\n",
+        "- Create embeddings using multiple providers (OpenAI, HuggingFace, Cohere, etc.)\n",
+        "- Use synchronous and asynchronous embedding methods\n",
+        "- Batch embed multiple texts efficiently\n",
+        "- Build custom vectorizers for your own embedding functions\n",
+        "- Integrate vectorizers with RedisVL indexes for semantic search"
+      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "[-0.0011391325388103724,\n",
-       " -0.003206387162208557,\n",
-       " 0.002380132209509611,\n",
-       " -0.004501554183661938,\n",
-       " -0.010328996926546097,\n",
-       " 0.012922565452754498,\n",
-       " -0.005491119809448719,\n",
-       " -0.0029864837415516376,\n",
-       " -0.007327961269766092,\n",
-       " -0.03365817293524742]"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# import necessary modules\n",
+        "import os"
       ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from redisvl.utils.vectorize import OpenAITextVectorizer\n",
-    "\n",
-    "# create a vectorizer\n",
-    "oai = OpenAITextVectorizer(\n",
-    "    model=\"text-embedding-ada-002\",\n",
-    "    api_config={\"api_key\": api_key},\n",
-    ")\n",
-    "\n",
-    "test = oai.embed(\"This is a test sentence.\")\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "test[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "[-0.017466850578784943,\n",
-       " 1.8471690054866485e-05,\n",
-       " 0.00129731057677418,\n",
-       " -0.02555876597762108,\n",
-       " -0.019842341542243958,\n",
-       " 0.01603139191865921,\n",
-       " -0.0037347301840782166,\n",
-       " 0.0009670283179730177,\n",
-       " 0.006618348415941,\n",
-       " -0.02497442066669464]"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Creating Text Embeddings\n",
+        "\n",
+        "This example will show how to create an embedding from 3 simple sentences with a number of different text vectorizers in RedisVL.\n",
+        "\n",
+        "- \"That is a happy dog\"\n",
+        "- \"That is a happy person\"\n",
+        "- \"Today is a nice day\"\n"
       ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Create many embeddings at once\n",
-    "sentences = [\n",
-    "    \"That is a happy dog\",\n",
-    "    \"That is a happy person\",\n",
-    "    \"Today is a sunny day\"\n",
-    "]\n",
-    "\n",
-    "embeddings = oai.embed_many(sentences)\n",
-    "embeddings[0][:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of Embeddings: 3\n"
-     ]
-    }
-   ],
-   "source": [
-    "# openai also supports asynchronous requests, which we can use to speed up the vectorization process.\n",
-    "embeddings = await oai.aembed_many(sentences)\n",
-    "print(\"Number of Embeddings:\", len(embeddings))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Azure OpenAI\n",
-    "\n",
-    "The ``AzureOpenAITextVectorizer`` is a variation of the OpenAI vectorizer that calls OpenAI models within Azure. If you've already installed ``openai``, then you're ready to use Azure OpenAI.\n",
-    "\n",
-    "The only practical difference between OpenAI and Azure OpenAI is the variables required to call the API."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# additionally to the API Key, setup the API endpoint and version\n",
-    "api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") or getpass.getpass(\"Enter your AzureOpenAI API key: \")\n",
-    "api_version = os.environ.get(\"OPENAI_API_VERSION\") or getpass.getpass(\"Enter your AzureOpenAI API version: \")\n",
-    "azure_endpoint = os.environ.get(\"AZURE_OPENAI_ENDPOINT\") or getpass.getpass(\"Enter your AzureOpenAI API endpoint: \")\n",
-    "deployment_name = os.environ.get(\"AZURE_OPENAI_DEPLOYMENT_NAME\", \"text-embedding-ada-002\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### OpenAI\n",
+        "\n",
+        "The ``OpenAITextVectorizer`` makes it simple to use RedisVL with the embeddings models at OpenAI. For this you will need to install ``openai``. \n",
+        "\n",
+        "```bash\n",
+        "pip install openai\n",
+        "```\n"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)\n",
-      "Cell \u001b[0;32mIn[7], line 4\u001b[0m\n",
-      "\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mredisvl\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvectorize\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m AzureOpenAITextVectorizer\n",
-      "\u001b[1;32m      3\u001b[0m \u001b[38;5;66;03m# create a vectorizer\u001b[39;00m\n",
-      "\u001b[0;32m----> 4\u001b[0m az_oai \u001b[38;5;241m=\u001b[39m \u001b[43mAzureOpenAITextVectorizer\u001b[49m\u001b[43m(\u001b[49m\n",
-      "\u001b[1;32m      5\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmodel\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdeployment_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;66;43;03m# Must be your CUSTOM deployment name\u001b[39;49;00m\n",
-      "\u001b[1;32m      6\u001b[0m \u001b[43m    \u001b[49m\u001b[43mapi_config\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m{\u001b[49m\n",
-      "\u001b[1;32m      7\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mapi_key\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mapi_key\u001b[49m\u001b[43m,\u001b[49m\n",
-      "\u001b[1;32m      8\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mapi_version\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mapi_version\u001b[49m\u001b[43m,\u001b[49m\n",
-      "\u001b[1;32m      9\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mazure_endpoint\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mazure_endpoint\u001b[49m\n",
-      "\u001b[1;32m     10\u001b[0m \u001b[43m    \u001b[49m\u001b[43m}\u001b[49m\u001b[43m,\u001b[49m\n",
-      "\u001b[1;32m     11\u001b[0m \u001b[43m)\u001b[49m\n",
-      "\u001b[1;32m     13\u001b[0m test \u001b[38;5;241m=\u001b[39m az_oai\u001b[38;5;241m.\u001b[39membed(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThis is a test sentence.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[1;32m     14\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mVector dimensions: \u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28mlen\u001b[39m(test))\n",
-      "File \u001b[0;32m~/src/redis-vl-python/redisvl/utils/vectorize/text/azureopenai.py:78\u001b[0m, in \u001b[0;36mAzureOpenAITextVectorizer.__init__\u001b[0;34m(self, model, api_config, dtype)\u001b[0m\n",
-      "\u001b[1;32m     54\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m__init__\u001b[39m(\n",
-      "\u001b[1;32m     55\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n",
-      "\u001b[1;32m     56\u001b[0m     model: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtext-embedding-ada-002\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n",
-      "\u001b[1;32m     57\u001b[0m     api_config: Optional[Dict] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n",
-      "\u001b[1;32m     58\u001b[0m     dtype: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfloat32\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n",
-      "\u001b[1;32m     59\u001b[0m ):\n",
-      "\u001b[1;32m     60\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Initialize the AzureOpenAI vectorizer.\u001b[39;00m\n",
-      "\u001b[1;32m     61\u001b[0m \n",
-      "\u001b[1;32m     62\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n",
-      "\u001b[0;32m   (...)\u001b[0m\n",
-      "\u001b[1;32m     76\u001b[0m \u001b[38;5;124;03m        ValueError: If an invalid dtype is provided.\u001b[39;00m\n",
-      "\u001b[1;32m     77\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n",
-      "\u001b[0;32m---> 78\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_initialize_clients\u001b[49m\u001b[43m(\u001b[49m\u001b[43mapi_config\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[1;32m     79\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(model\u001b[38;5;241m=\u001b[39mmodel, dims\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_set_model_dims(model), dtype\u001b[38;5;241m=\u001b[39mdtype)\n",
-      "File \u001b[0;32m~/src/redis-vl-python/redisvl/utils/vectorize/text/azureopenai.py:106\u001b[0m, in \u001b[0;36mAzureOpenAITextVectorizer._initialize_clients\u001b[0;34m(self, api_config)\u001b[0m\n",
-      "\u001b[1;32m     99\u001b[0m azure_endpoint \u001b[38;5;241m=\u001b[39m (\n",
-      "\u001b[1;32m    100\u001b[0m     api_config\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mazure_endpoint\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[1;32m    101\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m api_config\n",
-      "\u001b[1;32m    102\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m os\u001b[38;5;241m.\u001b[39mgetenv(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAZURE_OPENAI_ENDPOINT\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[1;32m    103\u001b[0m )\n",
-      "\u001b[1;32m    105\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m azure_endpoint:\n",
-      "\u001b[0;32m--> 106\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n",
-      "\u001b[1;32m    107\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAzureOpenAI API endpoint is required. \u001b[39m\u001b[38;5;124m\"\u001b[39m\n",
-      "\u001b[1;32m    108\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProvide it in api_config or set the AZURE_OPENAI_ENDPOINT\u001b[39m\u001b[38;5;130;01m\\\u001b[39;00m\n",
-      "\u001b[1;32m    109\u001b[0m \u001b[38;5;124m            environment variable.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n",
-      "\u001b[1;32m    110\u001b[0m     )\n",
-      "\u001b[1;32m    112\u001b[0m api_version \u001b[38;5;241m=\u001b[39m (\n",
-      "\u001b[1;32m    113\u001b[0m     api_config\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mapi_version\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[1;32m    114\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m api_config\n",
-      "\u001b[1;32m    115\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m os\u001b[38;5;241m.\u001b[39mgetenv(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mOPENAI_API_VERSION\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[1;32m    116\u001b[0m )\n",
-      "\u001b[1;32m    118\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m api_version:\n",
-      "\u001b[0;31mValueError\u001b[0m: AzureOpenAI API endpoint is required. Provide it in api_config or set the AZURE_OPENAI_ENDPOINT                    environment variable."
-     ]
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import getpass\n",
+        "\n",
+        "# setup the API Key\n",
+        "api_key = os.environ.get(\"OPENAI_API_KEY\") or getpass.getpass(\"Enter your OpenAI API key: \")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Vector dimensions:  1536\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "[-0.0011391325388103724,\n",
+              " -0.003206387162208557,\n",
+              " 0.002380132209509611,\n",
+              " -0.004501554183661938,\n",
+              " -0.010328996926546097,\n",
+              " 0.012922565452754498,\n",
+              " -0.005491119809448719,\n",
+              " -0.0029864837415516376,\n",
+              " -0.007327961269766092,\n",
+              " -0.03365817293524742]"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "from redisvl.utils.vectorize import OpenAITextVectorizer\n",
+        "\n",
+        "# create a vectorizer\n",
+        "oai = OpenAITextVectorizer(\n",
+        "    model=\"text-embedding-ada-002\",\n",
+        "    api_config={\"api_key\": api_key},\n",
+        ")\n",
+        "\n",
+        "test = oai.embed(\"This is a test sentence.\")\n",
+        "print(\"Vector dimensions: \", len(test))\n",
+        "test[:10]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[-0.017466850578784943,\n",
+              " 1.8471690054866485e-05,\n",
+              " 0.00129731057677418,\n",
+              " -0.02555876597762108,\n",
+              " -0.019842341542243958,\n",
+              " 0.01603139191865921,\n",
+              " -0.0037347301840782166,\n",
+              " 0.0009670283179730177,\n",
+              " 0.006618348415941,\n",
+              " -0.02497442066669464]"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Create many embeddings at once\n",
+        "sentences = [\n",
+        "    \"That is a happy dog\",\n",
+        "    \"That is a happy person\",\n",
+        "    \"Today is a sunny day\"\n",
+        "]\n",
+        "\n",
+        "embeddings = oai.embed_many(sentences)\n",
+        "embeddings[0][:10]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of Embeddings: 3\n"
+          ]
+        }
+      ],
+      "source": [
+        "# openai also supports asynchronous requests, which we can use to speed up the vectorization process.\n",
+        "embeddings = await oai.aembed_many(sentences)\n",
+        "print(\"Number of Embeddings:\", len(embeddings))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Azure OpenAI\n",
+        "\n",
+        "The ``AzureOpenAITextVectorizer`` is a variation of the OpenAI vectorizer that calls OpenAI models within Azure. If you've already installed ``openai``, then you're ready to use Azure OpenAI.\n",
+        "\n",
+        "The only practical difference between OpenAI and Azure OpenAI is the variables required to call the API."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# additionally to the API Key, setup the API endpoint and version\n",
+        "api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") or getpass.getpass(\"Enter your AzureOpenAI API key: \")\n",
+        "api_version = os.environ.get(\"OPENAI_API_VERSION\") or getpass.getpass(\"Enter your AzureOpenAI API version: \")\n",
+        "azure_endpoint = os.environ.get(\"AZURE_OPENAI_ENDPOINT\") or getpass.getpass(\"Enter your AzureOpenAI API endpoint: \")\n",
+        "deployment_name = os.environ.get(\"AZURE_OPENAI_DEPLOYMENT_NAME\", \"text-embedding-ada-002\")\n",
+        "\n",
+        "# Skip Azure examples when required values are missing (e.g. CI or Run All without Azure).\n",
+        "_azure_configured = bool(azure_endpoint and api_key and api_version)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import AzureOpenAITextVectorizer\n",
+        "\n",
+        "if not _azure_configured:\n",
+        "    print(\"Skipping Azure OpenAI example: set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY and OPENAI_API_VERSION\")\n",
+        "    az_oai = None\n",
+        "else:\n",
+        "    az_oai = AzureOpenAITextVectorizer(\n",
+        "        model=deployment_name,  # Must be your CUSTOM deployment name\n",
+        "        api_config={\n",
+        "            \"api_key\": api_key,\n",
+        "            \"api_version\": api_version,\n",
+        "            \"azure_endpoint\": azure_endpoint,\n",
+        "        },\n",
+        "    )\n",
+        "\n",
+        "    test = az_oai.embed(\"This is a test sentence.\")\n",
+        "    print(\"Vector dimensions: \", len(test))\n",
+        "    test[:10]\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Just like OpenAI, AzureOpenAI supports batching embeddings and asynchronous requests.\n",
+        "sentences = [\n",
+        "    \"That is a happy dog\",\n",
+        "    \"That is a happy person\",\n",
+        "    \"Today is a sunny day\",\n",
+        "]\n",
+        "\n",
+        "if _azure_configured and az_oai is not None:\n",
+        "    embeddings = await az_oai.aembed_many(sentences)\n",
+        "    embeddings[0][:10]\n",
+        "else:\n",
+        "    print(\"Skipping: run the Azure cells above with valid configuration.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Huggingface\n",
+        "\n",
+        "[Huggingface](https://huggingface.co/models) is a popular NLP platform that has a number of pre-trained models you can use off the shelf. RedisVL supports using Huggingface \"Sentence Transformers\" to create embeddings from text. To use Huggingface, you will need to install the ``sentence-transformers`` library.\n",
+        "\n",
+        "```bash\n",
+        "pip install sentence-transformers\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
+        "from redisvl.utils.vectorize import HFTextVectorizer\n",
+        "\n",
+        "\n",
+        "# create a vectorizer\n",
+        "# choose your model from the huggingface website\n",
+        "hf = HFTextVectorizer(model=\"sentence-transformers/all-mpnet-base-v2\")\n",
+        "\n",
+        "# embed a sentence\n",
+        "test = hf.embed(\"This is a test sentence.\")\n",
+        "test[:10]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# You can also create many embeddings at once\n",
+        "embeddings = hf.embed_many(sentences, as_buffer=True)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### VertexAI\n",
+        "\n",
+        "[VertexAI](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings) is GCP's fully-featured AI platform including a number of pretrained LLMs. RedisVL supports using VertexAI to create embeddings from these models. To use VertexAI, you will first need to install the ``google-cloud-aiplatform`` library.\n",
+        "\n",
+        "```bash\n",
+        "pip install google-cloud-aiplatform>=1.26\n",
+        "```\n",
+        "\n",
+        "1. Then you need to gain access to a [Google Cloud Project](https://cloud.google.com/gcp?hl=en) and provide [access to credentials](https://cloud.google.com/docs/authentication/application-default-credentials). This is accomplished by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing to the path of a JSON key file downloaded from your service account on GCP.\n",
+        "2. Lastly, you need to find your [project ID](https://support.google.com/googleapi/answer/7014113?hl=en) and [geographic region for VertexAI](https://cloud.google.com/vertex-ai/docs/general/locations).\n",
+        "\n",
+        "\n",
+        "**Make sure the following env vars are set:**\n",
+        "\n",
+        "```\n",
+        "GOOGLE_APPLICATION_CREDENTIALS=<path to your gcp JSON creds>\n",
+        "GCP_PROJECT_ID=<your gcp project id>\n",
+        "GCP_LOCATION=<your gcp geo region for vertex ai>\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import VertexAIVectorizer\n",
+        "\n",
+        "\n",
+        "# create a vectorizer\n",
+        "vtx = VertexAIVectorizer(api_config={\n",
+        "    \"project_id\": os.environ.get(\"GCP_PROJECT_ID\") or getpass.getpass(\"Enter your GCP Project ID: \"),\n",
+        "    \"location\": os.environ.get(\"GCP_LOCATION\") or getpass.getpass(\"Enter your GCP Location: \"),\n",
+        "    \"google_application_credentials\": os.environ.get(\"GOOGLE_APPLICATION_CREDENTIALS\") or getpass.getpass(\"Enter your Google App Credentials path: \")\n",
+        "})\n",
+        "\n",
+        "# embed a sentence\n",
+        "test = vtx.embed(\"This is a test sentence.\")\n",
+        "test[:10]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Cohere\n",
+        "\n",
+        "[Cohere](https://dashboard.cohere.ai/) allows you to implement language AI into your product. The `CohereTextVectorizer` makes it simple to use RedisVL with the embeddings models at Cohere. For this you will need to install `cohere`.\n",
+        "\n",
+        "```bash\n",
+        "pip install cohere\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import getpass\n",
+        "# setup the API Key\n",
+        "api_key = os.environ.get(\"COHERE_API_KEY\") or getpass.getpass(\"Enter your Cohere API key: \")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "Special attention needs to be paid to the `input_type` parameter for each `embed` call. For example, for embedding \n",
+        "queries, you should set `input_type='search_query'`; for embedding documents, set `input_type='search_document'`. See\n",
+        "more information [here](https://docs.cohere.com/reference/embed)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import CohereTextVectorizer\n",
+        "\n",
+        "# create a vectorizer\n",
+        "co = CohereTextVectorizer(\n",
+        "    model=\"embed-english-v3.0\",\n",
+        "    api_config={\"api_key\": api_key},\n",
+        ")\n",
+        "\n",
+        "# embed a search query\n",
+        "test = co.embed(\"This is a test sentence.\", input_type='search_query')\n",
+        "print(\"Vector dimensions: \", len(test))\n",
+        "print(test[:10])\n",
+        "\n",
+        "# embed a document\n",
+        "test = co.embed(\"This is a test sentence.\", input_type='search_document')\n",
+        "print(\"Vector dimensions: \", len(test))\n",
+        "print(test[:10])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Learn more about using RedisVL and Cohere together through [this dedicated user guide](https://docs.cohere.com/docs/redis-and-cohere)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### VoyageAI\n",
+        "\n",
+        "[VoyageAI](https://dash.voyageai.com/) allows you to implement language AI into your product. The `VoyageAIVectorizer` makes it simple to use RedisVL with the embeddings models at VoyageAI. For this you will need to install `voyageai`.\n",
+        "\n",
+        "```bash\n",
+        "pip install voyageai\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import getpass\n",
+        "# setup the API Key\n",
+        "api_key = os.environ.get(\"VOYAGE_API_KEY\") or getpass.getpass(\"Enter your VoyageAI API key: \")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "Special attention needs to be paid to the `input_type` parameter for each `embed` call. For example, for embedding \n",
+        "queries, you should set `input_type='query'`; for embedding documents, set `input_type='document'`. See\n",
+        "more information [here](https://docs.voyageai.com/docs/embeddings)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import VoyageAIVectorizer\n",
+        "\n",
+        "# create a vectorizer\n",
+        "vo = VoyageAIVectorizer(\n",
+        "    model=\"voyage-law-2\",  # Please check the available models at https://docs.voyageai.com/docs/embeddings\n",
+        "    api_config={\"api_key\": api_key},\n",
+        ")\n",
+        "\n",
+        "# embed a search query\n",
+        "test = vo.embed(\"This is a test sentence.\", input_type='query')\n",
+        "print(\"Vector dimensions: \", len(test))\n",
+        "print(test[:10])\n",
+        "\n",
+        "# embed a document\n",
+        "test = vo.embed(\"This is a test sentence.\", input_type='document')\n",
+        "print(\"Vector dimensions: \", len(test))\n",
+        "print(test[:10])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Mistral AI\n",
+        "\n",
+        "[Mistral](https://console.mistral.ai/) offers LLM and embedding APIs for you to implement into your product. The `MistralAITextVectorizer` makes it simple to use RedisVL with their embeddings model.\n",
+        "You will need to install `mistralai`.\n",
+        "\n",
+        "```bash\n",
+        "pip install mistralai\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import MistralAITextVectorizer\n",
+        "\n",
+        "mistral = MistralAITextVectorizer()\n",
+        "\n",
+        "# embed a sentence using their asynchronous method\n",
+        "test = await mistral.aembed(\"This is a test sentence.\")\n",
+        "print(\"Vector dimensions: \", len(test))\n",
+        "print(test[:10])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Amazon Bedrock\n",
+        "\n",
+        "Amazon Bedrock provides fully managed foundation models for text embeddings. Install the required dependencies:\n",
+        "\n",
+        "```bash\n",
+        "pip install 'redisvl[bedrock]'  # Installs boto3\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Configure AWS credentials:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import getpass\n",
+        "\n",
+        "if \"AWS_ACCESS_KEY_ID\" not in os.environ:\n",
+        "    os.environ[\"AWS_ACCESS_KEY_ID\"] = getpass.getpass(\"Enter AWS Access Key ID: \")\n",
+        "if \"AWS_SECRET_ACCESS_KEY\" not in os.environ:\n",
+        "    os.environ[\"AWS_SECRET_ACCESS_KEY\"] = getpass.getpass(\"Enter AWS Secret Key: \")\n",
+        "\n",
+        "os.environ[\"AWS_REGION\"] = \"us-east-1\"  # Change as needed"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Create embeddings:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import BedrockVectorizer\n",
+        "\n",
+        "bedrock = BedrockVectorizer(\n",
+        "    model=\"amazon.titan-embed-text-v2:0\"\n",
+        ")\n",
+        "\n",
+        "# Single embedding\n",
+        "text = \"This is a test sentence.\"\n",
+        "embedding = bedrock.embed(text)\n",
+        "print(f\"Vector dimensions: {len(embedding)}\")\n",
+        "\n",
+        "# Multiple embeddings\n",
+        "sentences = [\n",
+        "    \"That is a happy dog\",\n",
+        "    \"That is a happy person\",\n",
+        "    \"Today is a sunny day\"\n",
+        "]\n",
+        "embeddings = bedrock.embed_many(sentences)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Custom Vectorizers\n",
+        "\n",
+        "RedisVL supports the use of other vectorizers and provides a class to enable compatibility with any function that generates a vector or vectors from string data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import CustomVectorizer\n",
+        "\n",
+        "def generate_embeddings(text_input, **kwargs):\n",
+        "    return [0.101] * 768\n",
+        "\n",
+        "custom_vectorizer = CustomVectorizer(generate_embeddings)\n",
+        "\n",
+        "custom_vectorizer.embed(\"This is a test sentence.\")[:10]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This enables the use of custom vectorizers with other RedisVL components"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.extensions.cache.llm import SemanticCache\n",
+        "\n",
+        "cache = SemanticCache(name=\"custom_cache\", vectorizer=custom_vectorizer)\n",
+        "\n",
+        "cache.store(\"this is a test prompt\", \"this is a test response\")\n",
+        "cache.check(\"this is also a test prompt\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Search with Provider Embeddings\n",
+        "\n",
+        "Now that we've created our embeddings, we can use them to search for similar sentences. We will use the same 3 sentences from above and search for similar sentences.\n",
+        "\n",
+        "First, we need to create the schema for our index.\n",
+        "\n",
+        "Here's what the schema for the example looks like in yaml for the HuggingFace vectorizer:\n",
+        "\n",
+        "```yaml\n",
+        "version: '0.1.0'\n",
+        "\n",
+        "index:\n",
+        "    name: vectorizers\n",
+        "    prefix: doc\n",
+        "    storage_type: hash\n",
+        "\n",
+        "fields:\n",
+        "    - name: sentence\n",
+        "      type: text\n",
+        "    - name: embedding\n",
+        "      type: vector\n",
+        "      attrs:\n",
+        "        dims: 768\n",
+        "        algorithm: flat\n",
+        "        distance_metric: cosine\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.index import SearchIndex\n",
+        "\n",
+        "# construct a search index from the schema\n",
+        "index = SearchIndex.from_yaml(\"./schema.yaml\", redis_url=\"redis://localhost:6379\")\n",
+        "\n",
+        "# create the index (no data yet)\n",
+        "index.create(overwrite=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# use the CLI to see the created index\n",
+        "!rvl index listall"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Loading data to RedisVL is easy. It expects a list of dictionaries. The vector is stored as bytes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.redis.utils import array_to_buffer\n",
+        "\n",
+        "embeddings = hf.embed_many(sentences)\n",
+        "\n",
+        "data = [{\"text\": t,\n",
+        "         \"embedding\": array_to_buffer(v, dtype=\"float32\")}\n",
+        "        for t, v in zip(sentences, embeddings)]\n",
+        "\n",
+        "index.load(data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.query import VectorQuery\n",
+        "\n",
+        "# use the HuggingFace vectorizer again to create a query embedding\n",
+        "query_embedding = hf.embed(\"That is a happy cat\")\n",
+        "\n",
+        "query = VectorQuery(\n",
+        "    vector=query_embedding,\n",
+        "    vector_field_name=\"embedding\",\n",
+        "    return_fields=[\"text\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "results = index.query(query)\n",
+        "for doc in results:\n",
+        "    print(doc[\"text\"], doc[\"vector_distance\"])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Selecting your float data type\n",
+        "When embedding text as byte arrays RedisVL supports 4 different floating point data types, `float16`, `float32`, `float64` and `bfloat16`, and 2 integer types, `int8` and `uint8`.\n",
+        "Your dtype set for your vectorizer must match what is defined in your search index. If one is not explicitly set the default is `float32`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "vectorizer = HFTextVectorizer(dtype=\"float16\")\n",
+        "\n",
+        "# subsequent calls to embed('', as_buffer=True) and embed_many('', as_buffer=True) will now encode as float16\n",
+        "float16_bytes = vectorizer.embed('test sentence', as_buffer=True)\n",
+        "\n",
+        "# to generate embeddings with different dtype instantiate a new vectorizer\n",
+        "vectorizer_64 = HFTextVectorizer(dtype='float64')\n",
+        "float64_bytes = vectorizer_64.embed('test sentence', as_buffer=True)\n",
+        "\n",
+        "float16_bytes != float64_bytes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next Steps\n",
+        "\n",
+        "Now that you understand how to create embeddings, explore these related guides:\n",
+        "\n",
+        "- [Getting Started](01_getting_started.ipynb) - Learn the basics of indexes and queries\n",
+        "- [Rerank Results](06_rerankers.ipynb) - Improve search quality with reranking models\n",
+        "- [Cache Embeddings](10_embeddings_cache.ipynb) - Cache embedding vectors for faster repeated computations"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Cleanup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "index.delete()"
+      ]
     }
-   ],
-   "source": [
-    "from redisvl.utils.vectorize import AzureOpenAITextVectorizer\n",
-    "\n",
-    "# create a vectorizer\n",
-    "az_oai = AzureOpenAITextVectorizer(\n",
-    "    model=deployment_name, # Must be your CUSTOM deployment name\n",
-    "    api_config={\n",
-    "        \"api_key\": api_key,\n",
-    "        \"api_version\": api_version,\n",
-    "        \"azure_endpoint\": azure_endpoint\n",
-    "    },\n",
-    ")\n",
-    "\n",
-    "test = az_oai.embed(\"This is a test sentence.\")\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "test[:10]"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.2"
+    },
+    "orig_nbformat": 4
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Just like OpenAI, AzureOpenAI supports batching embeddings and asynchronous requests.\n",
-    "sentences = [\n",
-    "    \"That is a happy dog\",\n",
-    "    \"That is a happy person\",\n",
-    "    \"Today is a sunny day\"\n",
-    "]\n",
-    "\n",
-    "embeddings = await az_oai.aembed_many(sentences)\n",
-    "embeddings[0][:10]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Huggingface\n",
-    "\n",
-    "[Huggingface](https://huggingface.co/models) is a popular NLP platform that has a number of pre-trained models you can use off the shelf. RedisVL supports using Huggingface \"Sentence Transformers\" to create embeddings from text. To use Huggingface, you will need to install the ``sentence-transformers`` library.\n",
-    "\n",
-    "```bash\n",
-    "pip install sentence-transformers\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
-    "from redisvl.utils.vectorize import HFTextVectorizer\n",
-    "\n",
-    "\n",
-    "# create a vectorizer\n",
-    "# choose your model from the huggingface website\n",
-    "hf = HFTextVectorizer(model=\"sentence-transformers/all-mpnet-base-v2\")\n",
-    "\n",
-    "# embed a sentence\n",
-    "test = hf.embed(\"This is a test sentence.\")\n",
-    "test[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# You can also create many embeddings at once\n",
-    "embeddings = hf.embed_many(sentences, as_buffer=True)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### VertexAI\n",
-    "\n",
-    "[VertexAI](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings) is GCP's fully-featured AI platform including a number of pretrained LLMs. RedisVL supports using VertexAI to create embeddings from these models. To use VertexAI, you will first need to install the ``google-cloud-aiplatform`` library.\n",
-    "\n",
-    "```bash\n",
-    "pip install google-cloud-aiplatform>=1.26\n",
-    "```\n",
-    "\n",
-    "1. Then you need to gain access to a [Google Cloud Project](https://cloud.google.com/gcp?hl=en) and provide [access to credentials](https://cloud.google.com/docs/authentication/application-default-credentials). This is accomplished by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing to the path of a JSON key file downloaded from your service account on GCP.\n",
-    "2. Lastly, you need to find your [project ID](https://support.google.com/googleapi/answer/7014113?hl=en) and [geographic region for VertexAI](https://cloud.google.com/vertex-ai/docs/general/locations).\n",
-    "\n",
-    "\n",
-    "**Make sure the following env vars are set:**\n",
-    "\n",
-    "```\n",
-    "GOOGLE_APPLICATION_CREDENTIALS=<path to your gcp JSON creds>\n",
-    "GCP_PROJECT_ID=<your gcp project id>\n",
-    "GCP_LOCATION=<your gcp geo region for vertex ai>\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.utils.vectorize import VertexAIVectorizer\n",
-    "\n",
-    "\n",
-    "# create a vectorizer\n",
-    "vtx = VertexAIVectorizer(api_config={\n",
-    "    \"project_id\": os.environ.get(\"GCP_PROJECT_ID\") or getpass.getpass(\"Enter your GCP Project ID: \"),\n",
-    "    \"location\": os.environ.get(\"GCP_LOCATION\") or getpass.getpass(\"Enter your GCP Location: \"),\n",
-    "    \"google_application_credentials\": os.environ.get(\"GOOGLE_APPLICATION_CREDENTIALS\") or getpass.getpass(\"Enter your Google App Credentials path: \")\n",
-    "})\n",
-    "\n",
-    "# embed a sentence\n",
-    "test = vtx.embed(\"This is a test sentence.\")\n",
-    "test[:10]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Cohere\n",
-    "\n",
-    "[Cohere](https://dashboard.cohere.ai/) allows you to implement language AI into your product. The `CohereTextVectorizer` makes it simple to use RedisVL with the embeddings models at Cohere. For this you will need to install `cohere`.\n",
-    "\n",
-    "```bash\n",
-    "pip install cohere\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import getpass\n",
-    "# setup the API Key\n",
-    "api_key = os.environ.get(\"COHERE_API_KEY\") or getpass.getpass(\"Enter your Cohere API key: \")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Special attention needs to be paid to the `input_type` parameter for each `embed` call. For example, for embedding \n",
-    "queries, you should set `input_type='search_query'`; for embedding documents, set `input_type='search_document'`. See\n",
-    "more information [here](https://docs.cohere.com/reference/embed)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.utils.vectorize import CohereTextVectorizer\n",
-    "\n",
-    "# create a vectorizer\n",
-    "co = CohereTextVectorizer(\n",
-    "    model=\"embed-english-v3.0\",\n",
-    "    api_config={\"api_key\": api_key},\n",
-    ")\n",
-    "\n",
-    "# embed a search query\n",
-    "test = co.embed(\"This is a test sentence.\", input_type='search_query')\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "print(test[:10])\n",
-    "\n",
-    "# embed a document\n",
-    "test = co.embed(\"This is a test sentence.\", input_type='search_document')\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "print(test[:10])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Learn more about using RedisVL and Cohere together through [this dedicated user guide](https://docs.cohere.com/docs/redis-and-cohere)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### VoyageAI\n",
-    "\n",
-    "[VoyageAI](https://dash.voyageai.com/) allows you to implement language AI into your product. The `VoyageAIVectorizer` makes it simple to use RedisVL with the embeddings models at VoyageAI. For this you will need to install `voyageai`.\n",
-    "\n",
-    "```bash\n",
-    "pip install voyageai\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import getpass\n",
-    "# setup the API Key\n",
-    "api_key = os.environ.get(\"VOYAGE_API_KEY\") or getpass.getpass(\"Enter your VoyageAI API key: \")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Special attention needs to be paid to the `input_type` parameter for each `embed` call. For example, for embedding \n",
-    "queries, you should set `input_type='query'`; for embedding documents, set `input_type='document'`. See\n",
-    "more information [here](https://docs.voyageai.com/docs/embeddings)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.utils.vectorize import VoyageAIVectorizer\n",
-    "\n",
-    "# create a vectorizer\n",
-    "vo = VoyageAIVectorizer(\n",
-    "    model=\"voyage-law-2\",  # Please check the available models at https://docs.voyageai.com/docs/embeddings\n",
-    "    api_config={\"api_key\": api_key},\n",
-    ")\n",
-    "\n",
-    "# embed a search query\n",
-    "test = vo.embed(\"This is a test sentence.\", input_type='query')\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "print(test[:10])\n",
-    "\n",
-    "# embed a document\n",
-    "test = vo.embed(\"This is a test sentence.\", input_type='document')\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "print(test[:10])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Mistral AI\n",
-    "\n",
-    "[Mistral](https://console.mistral.ai/) offers LLM and embedding APIs for you to implement into your product. The `MistralAITextVectorizer` makes it simple to use RedisVL with their embeddings model.\n",
-    "You will need to install `mistralai`.\n",
-    "\n",
-    "```bash\n",
-    "pip install mistralai\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.utils.vectorize import MistralAITextVectorizer\n",
-    "\n",
-    "mistral = MistralAITextVectorizer()\n",
-    "\n",
-    "# embed a sentence using their asynchronous method\n",
-    "test = await mistral.aembed(\"This is a test sentence.\")\n",
-    "print(\"Vector dimensions: \", len(test))\n",
-    "print(test[:10])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Amazon Bedrock\n",
-    "\n",
-    "Amazon Bedrock provides fully managed foundation models for text embeddings. Install the required dependencies:\n",
-    "\n",
-    "```bash\n",
-    "pip install 'redisvl[bedrock]'  # Installs boto3\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Configure AWS credentials:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import getpass\n",
-    "\n",
-    "if \"AWS_ACCESS_KEY_ID\" not in os.environ:\n",
-    "    os.environ[\"AWS_ACCESS_KEY_ID\"] = getpass.getpass(\"Enter AWS Access Key ID: \")\n",
-    "if \"AWS_SECRET_ACCESS_KEY\" not in os.environ:\n",
-    "    os.environ[\"AWS_SECRET_ACCESS_KEY\"] = getpass.getpass(\"Enter AWS Secret Key: \")\n",
-    "\n",
-    "os.environ[\"AWS_REGION\"] = \"us-east-1\"  # Change as needed"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Create embeddings:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.utils.vectorize import BedrockVectorizer\n",
-    "\n",
-    "bedrock = BedrockVectorizer(\n",
-    "    model=\"amazon.titan-embed-text-v2:0\"\n",
-    ")\n",
-    "\n",
-    "# Single embedding\n",
-    "text = \"This is a test sentence.\"\n",
-    "embedding = bedrock.embed(text)\n",
-    "print(f\"Vector dimensions: {len(embedding)}\")\n",
-    "\n",
-    "# Multiple embeddings\n",
-    "sentences = [\n",
-    "    \"That is a happy dog\",\n",
-    "    \"That is a happy person\",\n",
-    "    \"Today is a sunny day\"\n",
-    "]\n",
-    "embeddings = bedrock.embed_many(sentences)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Custom Vectorizers\n",
-    "\n",
-    "RedisVL supports the use of other vectorizers and provides a class to enable compatibility with any function that generates a vector or vectors from string data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.utils.vectorize import CustomVectorizer\n",
-    "\n",
-    "def generate_embeddings(text_input, **kwargs):\n",
-    "    return [0.101] * 768\n",
-    "\n",
-    "custom_vectorizer = CustomVectorizer(generate_embeddings)\n",
-    "\n",
-    "custom_vectorizer.embed(\"This is a test sentence.\")[:10]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This enables the use of custom vectorizers with other RedisVL components"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.extensions.cache.llm import SemanticCache\n",
-    "\n",
-    "cache = SemanticCache(name=\"custom_cache\", vectorizer=custom_vectorizer)\n",
-    "\n",
-    "cache.store(\"this is a test prompt\", \"this is a test response\")\n",
-    "cache.check(\"this is also a test prompt\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Search with Provider Embeddings\n",
-    "\n",
-    "Now that we've created our embeddings, we can use them to search for similar sentences. We will use the same 3 sentences from above and search for similar sentences.\n",
-    "\n",
-    "First, we need to create the schema for our index.\n",
-    "\n",
-    "Here's what the schema for the example looks like in yaml for the HuggingFace vectorizer:\n",
-    "\n",
-    "```yaml\n",
-    "version: '0.1.0'\n",
-    "\n",
-    "index:\n",
-    "    name: vectorizers\n",
-    "    prefix: doc\n",
-    "    storage_type: hash\n",
-    "\n",
-    "fields:\n",
-    "    - name: sentence\n",
-    "      type: text\n",
-    "    - name: embedding\n",
-    "      type: vector\n",
-    "      attrs:\n",
-    "        dims: 768\n",
-    "        algorithm: flat\n",
-    "        distance_metric: cosine\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.index import SearchIndex\n",
-    "\n",
-    "# construct a search index from the schema\n",
-    "index = SearchIndex.from_yaml(\"./schema.yaml\", redis_url=\"redis://localhost:6379\")\n",
-    "\n",
-    "# create the index (no data yet)\n",
-    "index.create(overwrite=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# use the CLI to see the created index\n",
-    "!rvl index listall"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Loading data to RedisVL is easy. It expects a list of dictionaries. The vector is stored as bytes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.redis.utils import array_to_buffer\n",
-    "\n",
-    "embeddings = hf.embed_many(sentences)\n",
-    "\n",
-    "data = [{\"text\": t,\n",
-    "         \"embedding\": array_to_buffer(v, dtype=\"float32\")}\n",
-    "        for t, v in zip(sentences, embeddings)]\n",
-    "\n",
-    "index.load(data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from redisvl.query import VectorQuery\n",
-    "\n",
-    "# use the HuggingFace vectorizer again to create a query embedding\n",
-    "query_embedding = hf.embed(\"That is a happy cat\")\n",
-    "\n",
-    "query = VectorQuery(\n",
-    "    vector=query_embedding,\n",
-    "    vector_field_name=\"embedding\",\n",
-    "    return_fields=[\"text\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "results = index.query(query)\n",
-    "for doc in results:\n",
-    "    print(doc[\"text\"], doc[\"vector_distance\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Selecting your float data type\n",
-    "When embedding text as byte arrays RedisVL supports 4 different floating point data types, `float16`, `float32`, `float64` and `bfloat16`, and 2 integer types, `int8` and `uint8`.\n",
-    "Your dtype set for your vectorizer must match what is defined in your search index. If one is not explicitly set the default is `float32`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vectorizer = HFTextVectorizer(dtype=\"float16\")\n",
-    "\n",
-    "# subsequent calls to embed('', as_buffer=True) and embed_many('', as_buffer=True) will now encode as float16\n",
-    "float16_bytes = vectorizer.embed('test sentence', as_buffer=True)\n",
-    "\n",
-    "# to generate embeddings with different dtype instantiate a new vectorizer\n",
-    "vectorizer_64 = HFTextVectorizer(dtype='float64')\n",
-    "float64_bytes = vectorizer_64.embed('test sentence', as_buffer=True)\n",
-    "\n",
-    "float16_bytes != float64_bytes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "Now that you understand how to create embeddings, explore these related guides:\n",
-    "\n",
-    "- [Getting Started](01_getting_started.ipynb) - Learn the basics of indexes and queries\n",
-    "- [Rerank Results](06_rerankers.ipynb) - Improve search quality with reranking models\n",
-    "- [Cache Embeddings](10_embeddings_cache.ipynb) - Cache embedding vectors for faster repeated computations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Cleanup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "index.delete()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.2"
-  },
-  "orig_nbformat": 4
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/docs/user_guide/11_advanced_queries.ipynb
+++ b/docs/user_guide/11_advanced_queries.ipynb
@@ -218,7 +218,8 @@
      "output_type": "stream",
      "text": [
       "Loaded 6 products into the index\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -272,7 +273,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -319,7 +321,8 @@
      "output_type": "stream",
      "text": [
       "Results with BM25 scoring:\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -330,7 +333,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -368,7 +372,8 @@
      "output_type": "stream",
      "text": [
       "Results with TFIDF scoring:\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -379,7 +384,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -431,7 +437,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -475,7 +482,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -527,7 +535,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -576,7 +585,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -618,7 +628,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -660,7 +671,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -764,7 +776,8 @@
      "output_type": "stream",
      "text": [
       "Index created with STOPWORDS 0: <redisvl.index.index.SearchIndex object at 0x130e98410>\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -810,8 +823,9 @@
     {
      "output_type": "stream",
      "text": [
-      "✓ Loaded 5 companies\n"
-     ]
+      "\u2713 Loaded 5 companies\n"
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -827,7 +841,7 @@
     "for i, company in enumerate(companies):\n",
     "    company_index.load([company], keys=[f\"company:{i}\"])\n",
     "\n",
-    "print(f\"✓ Loaded {len(companies)} companies\")"
+    "print(f\"\u2713 Loaded {len(companies)} companies\")"
    ]
   },
   {
@@ -851,7 +865,8 @@
      "text": [
       "Found 1 results for 'Bank of Glasberliner':\n",
       "  - Bank of Glasberliner: Major financial institution\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -878,9 +893,9 @@
     "\n",
     "If we had used the default stopwords (not specifying `stopwords` in the schema), the word \"of\" would be filtered out during indexing. This means:\n",
     "\n",
-    "- ❌ Searching for `\"Bank of Glasberliner\"` might not find exact matches\n",
-    "- ❌ The phrase would be indexed as `\"Bank Berlin\"` (without \"of\")\n",
-    "- ✅ With `STOPWORDS 0`, all words including \"of\" are indexed\n",
+    "- \u274c Searching for `\"Bank of Glasberliner\"` might not find exact matches\n",
+    "- \u274c The phrase would be indexed as `\"Bank Berlin\"` (without \"of\")\n",
+    "- \u2705 With `STOPWORDS 0`, all words including \"of\" are indexed\n",
     "\n",
     "**Custom Stopwords Example:**\n",
     "\n",
@@ -907,7 +922,8 @@
      "output_type": "stream",
      "text": [
       "Custom stopwords: ['inc', 'llc', 'corp']\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -981,14 +997,15 @@
     {
      "output_type": "stream",
      "text": [
-      "✓ Cleaned up company_index\n"
-     ]
+      "\u2713 Cleaned up company_index\n"
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
     "# Cleanup\n",
     "company_index.delete(drop=True)\n",
-    "print(\"✓ Cleaned up company_index\")"
+    "print(\"\u2713 Cleaned up company_index\")"
    ]
   },
   {
@@ -1027,7 +1044,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1087,7 +1105,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1146,7 +1165,8 @@
      "output_type": "stream",
      "text": [
       "Results with alpha=0.1 (vector-heavy):\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -1157,7 +1177,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1204,7 +1225,8 @@
      "output_type": "stream",
      "text": [
       "Results with alpha=0.9 (vector-heavy):\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -1215,7 +1237,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1275,7 +1298,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1334,7 +1358,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1386,7 +1411,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1439,7 +1465,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1491,7 +1518,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1579,7 +1607,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1640,7 +1669,8 @@
      "output_type": "stream",
      "text": [
       "Results with emphasis on image similarity:\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -1651,7 +1681,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1715,7 +1746,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [
@@ -1774,7 +1806,8 @@
      "output_type": "stream",
      "text": [
       "TextQuery Results (keyword-based):\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -1785,13 +1818,15 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     },
     {
      "output_type": "stream",
      "text": [
       "\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -1828,7 +1863,8 @@
      "output_type": "stream",
      "text": [
       "HybridQuery Results (text + vector):\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -1839,13 +1875,15 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     },
     {
      "output_type": "stream",
      "text": [
       "\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
    "source": [
@@ -1904,7 +1942,8 @@
      "output_type": "stream",
      "text": [
       "MultiVectorQuery Results (multiple vectors):\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
      "data": {
@@ -1915,7 +1954,8 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "output_type": "display_data"
+     "output_type": "display_data",
+     "metadata": {}
     }
    ],
    "source": [

--- a/docs/user_guide/11_advanced_queries.ipynb
+++ b/docs/user_guide/11_advanced_queries.ipynb
@@ -1,2088 +1,2037 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Use Advanced Query Types\n",
-        "\n",
-        "This guide covers advanced query types available in RedisVL:\n",
-        "\n",
-        "1. **`TextQuery`**: Full text search with advanced scoring\n",
-        "2. **`AggregateHybridQuery` and `HybridQuery`**: Combines text and vector search for hybrid retrieval\n",
-        "3. **`MultiVectorQuery`**: Search over multiple vector fields simultaneously\n",
-        "\n",
-        "These query types enable sophisticated search applications that go beyond simple vector similarity search.\n",
-        "\n",
-        "## Prerequisites\n",
-        "\n",
-        "Before you begin, ensure you have:\n",
-        "- Installed RedisVL: `pip install redisvl`\n",
-        "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
-        "- For `HybridQuery`: Redis >= 8.4.0 and redis-py >= 7.1.0\n",
-        "\n",
-        "## What You'll Learn\n",
-        "\n",
-        "By the end of this guide, you will be able to:\n",
-        "- Perform full-text search with `TextQuery` and advanced scoring options\n",
-        "- Combine text and vector search using `HybridQuery` and `AggregateHybridQuery`\n",
-        "- Search across multiple vector fields with `MultiVectorQuery`\n",
-        "- Configure custom stopwords for text search"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Setup and Data Preparation\n",
-        "\n",
-        "First, let's create a schema and prepare sample data that includes text fields, numeric fields, and vector fields."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:43.615445Z",
-          "start_time": "2025-12-15T09:27:43.522493Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:07.111759Z",
-          "iopub.status.busy": "2026-02-16T15:17:07.111643Z",
-          "iopub.status.idle": "2026-02-16T15:17:07.193336Z",
-          "shell.execute_reply": "2026-02-16T15:17:07.192860Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "from jupyterutils import result_print\n",
-        "\n",
-        "# Sample data with text descriptions, categories, and vectors\n",
-        "data = [\n",
-        "    {\n",
-        "        'product_id': 'prod_1',\n",
-        "        'brief_description': 'comfortable running shoes for athletes',\n",
-        "        'full_description': 'Engineered with a dual-layer EVA foam midsole and FlexWeave breathable mesh upper, these running shoes deliver responsive cushioning for long-distance runs. The anatomical footbed adapts to your stride while the carbon rubber outsole provides superior traction on varied terrain.',\n",
-        "        'category': 'footwear',\n",
-        "        'price': 89.99,\n",
-        "        'rating': 4.5,\n",
-        "        'text_embedding': np.array([0.1, 0.2, 0.1], dtype=np.float32).tobytes(),\n",
-        "        'image_embedding': np.array([0.8, 0.1], dtype=np.float32).tobytes(),\n",
-        "    },\n",
-        "    {\n",
-        "        'product_id': 'prod_2',\n",
-        "        'brief_description': 'lightweight running jacket with water resistance',\n",
-        "        'full_description': 'Stay protected with this ultralight 2.5-layer DWR-coated shell featuring laser-cut ventilation zones and reflective piping for low-light visibility. Packs into its own chest pocket and weighs just 4.2 oz, making it ideal for unpredictable weather conditions.',\n",
-        "        'category': 'outerwear',\n",
-        "        'price': 129.99,\n",
-        "        'rating': 4.8,\n",
-        "        'text_embedding': np.array([0.2, 0.3, 0.2], dtype=np.float32).tobytes(),\n",
-        "        'image_embedding': np.array([0.7, 0.2], dtype=np.float32).tobytes(),\n",
-        "    },\n",
-        "    {\n",
-        "        'product_id': 'prod_3',\n",
-        "        'brief_description': 'professional tennis racket for competitive players',\n",
-        "        'full_description': 'Competition-grade racket featuring a 98 sq in head size, 16x19 string pattern, and aerospace-grade graphite frame that delivers explosive power with pinpoint control. Tournament-approved specs include 315g weight and 68 RA stiffness rating for advanced baseline play.',\n",
-        "        'category': 'equipment',\n",
-        "        'price': 199.99,\n",
-        "        'rating': 4.9,\n",
-        "        'text_embedding': np.array([0.9, 0.1, 0.05], dtype=np.float32).tobytes(),\n",
-        "        'image_embedding': np.array([0.1, 0.9], dtype=np.float32).tobytes(),\n",
-        "    },\n",
-        "    {\n",
-        "        'product_id': 'prod_4',\n",
-        "        'brief_description': 'yoga mat with extra cushioning for comfort',\n",
-        "        'full_description': 'Premium 8mm thick TPE yoga mat with dual-texture surface - smooth side for hot yoga flow and textured side for maximum grip during balancing poses. Closed-cell technology prevents moisture absorption while alignment markers guide proper positioning in asanas.',\n",
-        "        'category': 'accessories',\n",
-        "        'price': 39.99,\n",
-        "        'rating': 4.3,\n",
-        "        'text_embedding': np.array([0.15, 0.25, 0.15], dtype=np.float32).tobytes(),\n",
-        "        'image_embedding': np.array([0.5, 0.5], dtype=np.float32).tobytes(),\n",
-        "    },\n",
-        "    {\n",
-        "        'product_id': 'prod_5',\n",
-        "        'brief_description': 'basketball shoes with excellent ankle support',\n",
-        "        'full_description': 'High-top basketball sneakers with Zoom Air units in forefoot and heel, reinforced lateral sidewalls for explosive cuts, and herringbone traction pattern optimized for hardwood courts. The internal bootie construction and extended ankle collar provide lockdown support during aggressive drives.',\n",
-        "        'category': 'footwear',\n",
-        "        'price': 139.99,\n",
-        "        'rating': 4.7,\n",
-        "        'text_embedding': np.array([0.12, 0.18, 0.12], dtype=np.float32).tobytes(),\n",
-        "        'image_embedding': np.array([0.75, 0.15], dtype=np.float32).tobytes(),\n",
-        "    },\n",
-        "    {\n",
-        "        'product_id': 'prod_6',\n",
-        "        'brief_description': 'swimming goggles with anti-fog coating',\n",
-        "        'full_description': 'Low-profile competition goggles with curved polycarbonate lenses offering 180-degree peripheral vision and UV protection. Hydrophobic anti-fog coating lasts 10x longer than standard treatments, while the split silicone strap and interchangeable nose bridges ensure a watertight, custom fit.',\n",
-        "        'category': 'accessories',\n",
-        "        'price': 24.99,\n",
-        "        'rating': 4.4,\n",
-        "        'text_embedding': np.array([0.3, 0.1, 0.2], dtype=np.float32).tobytes(),\n",
-        "        'image_embedding': np.array([0.2, 0.8], dtype=np.float32).tobytes(),\n",
-        "    },\n",
-        "]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Define the Schema\n",
-        "\n",
-        "Our schema includes:\n",
-        "- **Tag fields**: `product_id`, `category`\n",
-        "- **Text fields**: `brief_description` and `full_description` for full-text search\n",
-        "- **Numeric fields**: `price`, `rating`\n",
-        "- **Vector fields**: `text_embedding` (3 dimensions) and `image_embedding` (2 dimensions) for semantic search"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:43.620369Z",
-          "start_time": "2025-12-15T09:27:43.615922Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:07.194739Z",
-          "iopub.status.busy": "2026-02-16T15:17:07.194621Z",
-          "iopub.status.idle": "2026-02-16T15:17:07.197015Z",
-          "shell.execute_reply": "2026-02-16T15:17:07.196608Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "schema = {\n",
-        "    \"index\": {\n",
-        "        \"name\": \"advanced_queries\",\n",
-        "        \"prefix\": \"products\",\n",
-        "        \"storage_type\": \"hash\",\n",
-        "    },\n",
-        "    \"fields\": [\n",
-        "        {\"name\": \"product_id\", \"type\": \"tag\"},\n",
-        "        {\"name\": \"category\", \"type\": \"tag\"},\n",
-        "        {\"name\": \"brief_description\", \"type\": \"text\"},\n",
-        "        {\"name\": \"full_description\", \"type\": \"text\"},\n",
-        "        {\"name\": \"price\", \"type\": \"numeric\"},\n",
-        "        {\"name\": \"rating\", \"type\": \"numeric\"},\n",
-        "        {\n",
-        "            \"name\": \"text_embedding\",\n",
-        "            \"type\": \"vector\",\n",
-        "            \"attrs\": {\n",
-        "                \"dims\": 3,\n",
-        "                \"distance_metric\": \"cosine\",\n",
-        "                \"algorithm\": \"flat\",\n",
-        "                \"datatype\": \"float32\"\n",
-        "            }\n",
-        "        },\n",
-        "        {\n",
-        "            \"name\": \"image_embedding\",\n",
-        "            \"type\": \"vector\",\n",
-        "            \"attrs\": {\n",
-        "                \"dims\": 2,\n",
-        "                \"distance_metric\": \"cosine\",\n",
-        "                \"algorithm\": \"flat\",\n",
-        "                \"datatype\": \"float32\"\n",
-        "            }\n",
-        "        }\n",
-        "    ],\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Create Index and Load Data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:43.720506Z",
-          "start_time": "2025-12-15T09:27:43.620716Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:07.198084Z",
-          "iopub.status.busy": "2026-02-16T15:17:07.198011Z",
-          "iopub.status.idle": "2026-02-16T15:17:07.293058Z",
-          "shell.execute_reply": "2026-02-16T15:17:07.292647Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Loaded 6 products into the index\n"
-          ]
-        }
-      ],
-      "source": [
-        "from redisvl.index import SearchIndex\n",
-        "\n",
-        "# Create the search index\n",
-        "index = SearchIndex.from_dict(schema, redis_url=\"redis://localhost:6379\")\n",
-        "\n",
-        "# Create the index and load data\n",
-        "index.create(overwrite=True)\n",
-        "keys = index.load(data)\n",
-        "\n",
-        "print(f\"Loaded {len(keys)} products into the index\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 1. TextQuery: Full Text Search\n",
-        "\n",
-        "The `TextQuery` class enables full text search with advanced scoring algorithms. It's ideal for keyword-based search with relevance ranking.\n",
-        "\n",
-        "### Basic Text Search\n",
-        "\n",
-        "Let's search for products related to \"running shoes\":"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.289286Z",
-          "start_time": "2025-12-15T09:27:43.721057Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:07.310132Z",
-          "iopub.status.busy": "2026-02-16T15:17:07.310020Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.114469Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.113951Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from redisvl.query import TextQuery\n",
-        "\n",
-        "# Create a text query\n",
-        "text_query = TextQuery(\n",
-        "    text=\"running shoes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(text_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Text Search with Different Scoring Algorithms\n",
-        "\n",
-        "RedisVL supports multiple text scoring algorithms. Let's compare `BM25STD` and `TFIDF`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.337057Z",
-          "start_time": "2025-12-15T09:27:44.321956Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.116222Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.116038Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.120972Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.120483Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Results with BM25 scoring:\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>6.031534703977659</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# BM25 standard scoring (default)\n",
-        "bm25_query = TextQuery(\n",
-        "    text=\"comfortable shoes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    text_scorer=\"BM25STD\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "print(\"Results with BM25 scoring:\")\n",
-        "results = index.query(bm25_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.352789Z",
-          "start_time": "2025-12-15T09:27:44.344825Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.122229Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.122120Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.126377Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.125815Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Results with TFIDF scoring:\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>2.3333333333333335</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# TFIDF scoring\n",
-        "tfidf_query = TextQuery(\n",
-        "    text=\"comfortable shoes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    text_scorer=\"TFIDF\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "print(\"Results with TFIDF scoring:\")\n",
-        "results = index.query(tfidf_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Text Search with Filters\n",
-        "\n",
-        "Combine text search with filters to narrow results:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.374828Z",
-          "start_time": "2025-12-15T09:27:44.359984Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.127613Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.127518Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.131534Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.131085Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>3.9314935770863046</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>3.1279733904413027</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from redisvl.query.filter import Tag, Num\n",
-        "\n",
-        "# Search for \"shoes\" only in the footwear category\n",
-        "filtered_text_query = TextQuery(\n",
-        "    text=\"shoes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    filter_expression=Tag(\"category\") == \"footwear\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(filtered_text_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.409910Z",
-          "start_time": "2025-12-15T09:27:44.378041Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.132592Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.132506Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.136099Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.135780Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Search for products under $100\n",
-        "price_filtered_query = TextQuery(\n",
-        "    text=\"comfortable\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    filter_expression=Num(\"price\") < 100,\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(price_filtered_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Text Search with Multiple Fields and Weights\n",
-        "\n",
-        "You can search across multiple text fields with different weights to prioritize certain fields.\n",
-        "Here we'll prioritize the `brief_description` field and make text similarity in that field twice as important as text similarity in `full_description`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.425817Z",
-          "start_time": "2025-12-15T09:27:44.412131Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.137417Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.137337Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.140926Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.140520Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.035440025836444</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "weighted_query = TextQuery(\n",
-        "    text=\"shoes\",\n",
-        "    text_field_name={\"brief_description\": 1.0, \"full_description\": 0.5},\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "results = index.query(weighted_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Text Search with Custom Stopwords\n",
-        "\n",
-        "Stopwords are common words that are filtered out before processing the query. You can specify which language's default stopwords should be filtered out, like `english`, `french`, or `german`. You can also define your own list of stopwords:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.440583Z",
-          "start_time": "2025-12-15T09:27:44.427869Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.142202Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.142056Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.145323Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.144971Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Use English stopwords (default)\n",
-        "query_with_stopwords = TextQuery(\n",
-        "    text=\"the best shoes for running\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    stopwords=\"english\",  # Common words like \"the\", \"for\" will be removed\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "results = index.query(query_with_stopwords)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.461967Z",
-          "start_time": "2025-12-15T09:27:44.447726Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.146274Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.146200Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.149223Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.148867Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>3.0864038416103</td><td>prod_3</td><td>professional tennis racket for competitive players</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Use custom stopwords\n",
-        "custom_stopwords_query = TextQuery(\n",
-        "    text=\"professional equipment for athletes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    stopwords=[\"for\", \"with\"],  # Only these words will be filtered\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "results = index.query(custom_stopwords_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.478620Z",
-          "start_time": "2025-12-15T09:27:44.465051Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.150326Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.150250Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.153330Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.152986Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# No stopwords\n",
-        "no_stopwords_query = TextQuery(\n",
-        "    text=\"the best shoes for running\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    stopwords=None,  # All words will be included\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "results = index.query(no_stopwords_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 2. Hybrid Queries: Combining Text and Vector Search\n",
-        "\n",
-        "Hybrid queries combine text search and vector similarity to provide the best of both worlds:\n",
-        "- **Text search**: Finds exact keyword matches\n",
-        "- **Vector search**: Captures semantic similarity\n",
-        "\n",
-        "As of Redis 8.4.0, Redis natively supports a [`FT.HYBRID`](https://redis.io/docs/latest/commands/ft.hybrid) search command. RedisVL provides a `HybridQuery` class that makes it easy to construct and execute hybrid queries. For earlier versions of Redis, RedisVL provides an `AggregateHybridQuery` class that uses Redis aggregation to achieve similar results."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.494712Z",
-          "start_time": "2025-12-15T09:27:44.481443Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.154372Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.154300Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.157317Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.156892Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "True\n"
-          ]
-        }
-      ],
-      "source": [
-        "import warnings\n",
-        "\n",
-        "# redis-py's hybrid query helpers warn that APIs are experimental; keep notebook output readable\n",
-        "warnings.filterwarnings(\"ignore\", message=r\".*is an experimental.*\", category=UserWarning)\n",
-        "\n",
-        "from packaging.version import Version\n",
-        "\n",
-        "from redis import __version__ as _redis_py_version\n",
-        "\n",
-        "redis_py_version = Version(_redis_py_version)\n",
-        "redis_version = Version(index.client.info()[\"redis_version\"])\n",
-        "\n",
-        "HYBRID_SEARCH_AVAILABLE = redis_version >= Version(\"8.4.0\") and redis_py_version >= Version(\"7.1.0\")\n",
-        "print(HYBRID_SEARCH_AVAILABLE)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Index-Level Stopwords Configuration\n",
-        "\n",
-        "The previous example showed **query-time stopwords** using `TextQuery.stopwords`, which filters words from the query before searching. RedisVL also supports **index-level stopwords** configuration, which determines which words are indexed in the first place.\n",
-        "\n",
-        "**Key Difference:**\n",
-        "- **Query-time stopwords** (`TextQuery.stopwords`): Filters words from your search query (client-side)\n",
-        "- **Index-level stopwords** (`IndexInfo.stopwords`): Controls which words get indexed in Redis (server-side)\n",
-        "\n",
-        "**Three Configuration Modes:**\n",
-        "\n",
-        "1. **`None` (default)**: Use Redis's default stopwords list\n",
-        "2. **`[]` (empty list)**: Disable stopwords completely (`STOPWORDS 0` in FT.CREATE)\n",
-        "3. **`[\"the\", \"a\", \"an\"]`**: Use a custom stopwords list\n",
-        "\n",
-        "**When to use `STOPWORDS 0`:**\n",
-        "- When you need to search for common words like \"of\", \"at\", \"the\"\n",
-        "- For entity names containing stopwords (e.g., \"Bank of Glasberliner\", \"University of Glasberliner\")\n",
-        "- When working with structured data where every word matters"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.512721Z",
-          "start_time": "2025-12-15T09:27:44.497780Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.158421Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.158344Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.164588Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.164184Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Index created with STOPWORDS 0: <redisvl.index.index.SearchIndex object at 0x130e98410>\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Create a schema with index-level stopwords disabled\n",
-        "from redisvl.index import SearchIndex\n",
-        "\n",
-        "stopwords_schema = {\n",
-        "    \"index\": {\n",
-        "        \"name\": \"company_index\",\n",
-        "        \"prefix\": \"company:\",\n",
-        "        \"storage_type\": \"hash\",\n",
-        "        \"stopwords\": []  # STOPWORDS 0 - disable stopwords completely\n",
-        "    },\n",
-        "    \"fields\": [\n",
-        "        {\"name\": \"company_name\", \"type\": \"text\"},\n",
-        "        {\"name\": \"description\", \"type\": \"text\"}\n",
-        "    ]\n",
-        "}\n",
-        "\n",
-        "# Create index using from_dict (handles schema creation internally)\n",
-        "company_index = SearchIndex.from_dict(stopwords_schema, redis_url=\"redis://localhost:6379\")\n",
-        "company_index.create(overwrite=True, drop=True)\n",
-        "\n",
-        "print(f\"Index created with STOPWORDS 0: {company_index}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.528568Z",
-          "start_time": "2025-12-15T09:27:44.513241Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.165547Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.165478Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.169607Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.169224Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "✓ Loaded 5 companies\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Load sample data with company names containing common stopwords\n",
-        "companies = [\n",
-        "    {\"company_name\": \"Bank of Glasberliner\", \"description\": \"Major financial institution\"},\n",
-        "    {\"company_name\": \"University of Glasberliner\", \"description\": \"Public university system\"},\n",
-        "    {\"company_name\": \"Department of Glasberliner Affairs\", \"description\": \"A government agency\"},\n",
-        "    {\"company_name\": \"Glasberliner FC\", \"description\": \"Football Club\"},\n",
-        "    {\"company_name\": \"The Home Market\", \"description\": \"Home improvement retailer\"},\n",
-        "]\n",
-        "\n",
-        "for i, company in enumerate(companies):\n",
-        "    company_index.load([company], keys=[f\"company:{i}\"])\n",
-        "\n",
-        "print(f\"✓ Loaded {len(companies)} companies\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.534288Z",
-          "start_time": "2025-12-15T09:27:44.528999Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.170610Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.170537Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.173265Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.172885Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Found 1 results for 'Bank of Glasberliner':\n",
-            "  - Bank of Glasberliner: Major financial institution\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Search for \"Bank of Glasberliner\" - with STOPWORDS 0, \"of\" is indexed and searchable\n",
-        "from redisvl.query import FilterQuery\n",
-        "\n",
-        "query = FilterQuery(\n",
-        "    filter_expression='@company_name:(Bank of Glasberliner)',\n",
-        "    return_fields=[\"company_name\", \"description\"],\n",
-        ")\n",
-        "\n",
-        "results = company_index.search(query.query, query_params=query.params)\n",
-        "\n",
-        "print(f\"Found {len(results.docs)} results for 'Bank of Glasberliner':\")\n",
-        "for doc in results.docs:\n",
-        "    print(f\"  - {doc.company_name}: {doc.description}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "**Comparison: With vs Without Stopwords**\n",
-        "\n",
-        "If we had used the default stopwords (not specifying `stopwords` in the schema), the word \"of\" would be filtered out during indexing. This means:\n",
-        "\n",
-        "- ❌ Searching for `\"Bank of Glasberliner\"` might not find exact matches\n",
-        "- ❌ The phrase would be indexed as `\"Bank Berlin\"` (without \"of\")\n",
-        "- ✅ With `STOPWORDS 0`, all words including \"of\" are indexed\n",
-        "\n",
-        "**Custom Stopwords Example:**\n",
-        "\n",
-        "You can also provide a custom list of stopwords:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.553398Z",
-          "start_time": "2025-12-15T09:27:44.541083Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.174218Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.174154Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.175974Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.175650Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Custom stopwords: ['inc', 'llc', 'corp']\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Example: Create index with custom stopwords\n",
-        "custom_stopwords_schema = {\n",
-        "    \"index\": {\n",
-        "        \"name\": \"custom_stopwords_index\",\n",
-        "        \"prefix\": \"custom:\",\n",
-        "        \"stopwords\": [\"inc\", \"llc\", \"corp\"]  # Filter out legal entity suffixes\n",
-        "    },\n",
-        "    \"fields\": [\n",
-        "        {\"name\": \"name\", \"type\": \"text\"}\n",
-        "    ]\n",
-        "}\n",
-        "\n",
-        "# This would create an index where \"inc\", \"llc\", \"corp\" are not indexed\n",
-        "print(\"Custom stopwords:\", custom_stopwords_schema[\"index\"][\"stopwords\"])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "**YAML Format:**\n",
-        "\n",
-        "You can also define stopwords in YAML schema files:\n",
-        "\n",
-        "```yaml\n",
-        "version: '0.1.0'\n",
-        "\n",
-        "index:\n",
-        "  name: company_index\n",
-        "  prefix: company:\n",
-        "  storage_type: hash\n",
-        "  stopwords: []  # Disable stopwords (STOPWORDS 0)\n",
-        "\n",
-        "fields:\n",
-        "  - name: company_name\n",
-        "    type: text\n",
-        "  - name: description\n",
-        "    type: text\n",
-        "```\n",
-        "\n",
-        "Or with custom stopwords:\n",
-        "\n",
-        "```yaml\n",
-        "index:\n",
-        "  stopwords:\n",
-        "    - the\n",
-        "    - a\n",
-        "    - an\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.586789Z",
-          "start_time": "2025-12-15T09:27:44.556392Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.176910Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.176846Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.179113Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.178737Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "✓ Cleaned up company_index\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Cleanup\n",
-        "company_index.delete(drop=True)\n",
-        "print(\"✓ Cleaned up company_index\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Basic Hybrid Query\n",
-        "\n",
-        "> NOTE: `HybridQuery` requires Redis >= 8.4.0 and redis-py >= 7.1.0.\n",
-        "\n",
-        "Let's search for \"running\" with both text and semantic search, combining the results' scores using a linear combination:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.599394Z",
-          "start_time": "2025-12-15T09:27:44.589681Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.180129Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.180058Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.184565Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.184291Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>5.95398933304</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>2.48619677905</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>2.04100827745</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>1.30885409823</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0.698640781641</td></tr><tr><td>0</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0.617316907644</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "if HYBRID_SEARCH_AVAILABLE:\n",
-        "    from redisvl.query import HybridQuery\n",
-        "\n",
-        "    # Create a hybrid query\n",
-        "    hybrid_query = HybridQuery(\n",
-        "        text=\"running shoes\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.1, 0.2, 0.1],  # Query vector\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "        num_results=5,\n",
-        "        yield_text_score_as=\"text_score\",\n",
-        "        yield_vsim_score_as=\"vector_similarity\",\n",
-        "        combination_method=\"LINEAR\",\n",
-        "        yield_combined_score_as=\"hybrid_score\",\n",
-        "    )\n",
-        "\n",
-        "    results = index.query(hybrid_query)\n",
-        "    result_print(results)\n",
-        "\n",
-        "else:\n",
-        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "For earlier versions of Redis, you can use `AggregateHybridQuery` instead:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.619601Z",
-          "start_time": "2025-12-15T09:27:44.606514Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.185602Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.185538Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.188771Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.188422Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>5.95398933304</td><td>2.48619677905</td></tr><tr><td>0.00985252857208</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>2.08531559363</td><td>1.32214629309</td></tr><tr><td>0.00985252857208</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>2.04100827745</td><td>1.30885409823</td></tr><tr><td>0.0038834810257</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0</td><td>0.698640781641</td></tr><tr><td>0.236237406731</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0</td><td>0.617316907644</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from redisvl.query import AggregateHybridQuery\n",
-        "\n",
-        "agg_hybrid_query = AggregateHybridQuery(\n",
-        "    text=\"running shoes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    vector=[0.1, 0.2, 0.1],  # Query vector\n",
-        "    vector_field_name=\"text_embedding\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(agg_hybrid_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Adjusting the Alpha Parameter\n",
-        "\n",
-        "Results are scored using a weighted combination:\n",
-        "\n",
-        "```\n",
-        "hybrid_score = (alpha) * text_score + (1 - alpha) * vector_score\n",
-        "```\n",
-        "\n",
-        "Where `alpha` controls the balance between text and vector search (default: 0.3 for `HybridQuery` and 0.7 for `AggregateHybridQuery`). Note that `AggregateHybridQuery` reverses the definition of `alpha` to be the weight of the vector score.\n",
-        "\n",
-        "The `alpha` parameter controls the weight between text and vector search:\n",
-        "- `alpha=1.0`: Pure text search (or pure vector search for `AggregateHybridQuery`)\n",
-        "- `alpha=0.0`: Pure vector search (or pure text search for `AggregateHybridQuery`)\n",
-        "- `alpha=0.3` (default - `HybridQuery`): 30% text, 70% vector"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.636058Z",
-          "start_time": "2025-12-15T09:27:44.621406Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.189764Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.189701Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.193700Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.193353Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Results with alpha=0.1 (vector-heavy):\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>1.21366647389</td></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.05268080238</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.899384003878</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "if HYBRID_SEARCH_AVAILABLE:\n",
-        "    vector_heavy_query = HybridQuery(\n",
-        "        text=\"comfortable\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.15, 0.25, 0.15],\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        combination_method=\"LINEAR\",\n",
-        "\t\tlinear_alpha=0.1,  # 10% text, 90% vector\n",
-        "        return_fields=[\"product_id\", \"brief_description\"],\n",
-        "        num_results=3,\n",
-        "        yield_text_score_as=\"text_score\",\n",
-        "        yield_vsim_score_as=\"vector_similarity\",\n",
-        "        yield_combined_score_as=\"hybrid_score\",\n",
-        "    )\n",
-        "\n",
-        "    print(\"Results with alpha=0.1 (vector-heavy):\")\n",
-        "    results = index.query(vector_heavy_query)\n",
-        "    result_print(results)\n",
-        "\n",
-        "else:\n",
-        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 22,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.651595Z",
-          "start_time": "2025-12-15T09:27:44.643458Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.194553Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.194492Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.198234Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.197931Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Results with alpha=0.9 (vector-heavy):\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.52680748736</td><td>1.05268080238</td></tr><tr><td>0.00136888027191</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr><tr><td>0.00136888027191</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# More emphasis on vector search (alpha=0.9)\n",
-        "vector_heavy_query = AggregateHybridQuery(\n",
-        "    text=\"comfortable\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    vector=[0.15, 0.25, 0.15],\n",
-        "    vector_field_name=\"text_embedding\",\n",
-        "    alpha=0.9,  # 90% vector, 10% text\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "print(\"Results with alpha=0.9 (vector-heavy):\")\n",
-        "results = index.query(vector_heavy_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Reciprocal Rank Fusion (RRF)\n",
-        "\n",
-        "In addition to combining scores using a linear combination, `HybridQuery` also supports reciprocal rank fusion (RRF) for combining scores. This method is useful when you want to combine scores giving more weight to the top results from each query.\n",
-        "\n",
-        "`HybridQuery` allows for the following parameters to be specified for RRF:\n",
-        "- `rrf_window`: The window size to use for the RRF combination method. Limits the fusion scope.\n",
-        "- `rrf_constant`: The constant to use for the RRF combination method. Controls the decay of rank influence.\n",
-        "\n",
-        "`AggregateHybridQuery` does not support RRF, and only supports a linear combination of scores."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.664953Z",
-          "start_time": "2025-12-15T09:27:44.658451Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.199251Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.199188Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.202314Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.201944Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>0.032522474881</td></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>0.032018442623</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.0320020481311</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "if HYBRID_SEARCH_AVAILABLE:\n",
-        "    rrf_query = HybridQuery(\n",
-        "        text=\"comfortable\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.15, 0.25, 0.15],\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        combination_method=\"RRF\",\n",
-        "        return_fields=[\"product_id\", \"brief_description\"],\n",
-        "        num_results=3,\n",
-        "        yield_text_score_as=\"text_score\",\n",
-        "        yield_vsim_score_as=\"vector_similarity\",\n",
-        "        yield_combined_score_as=\"hybrid_score\",\n",
-        "    )\n",
-        "\n",
-        "    results = index.query(rrf_query)\n",
-        "    result_print(results)\n",
-        "\n",
-        "else:\n",
-        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Hybrid Query with Filters\n",
-        "\n",
-        "You can also combine hybrid search with filters:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.686355Z",
-          "start_time": "2025-12-15T09:27:44.672035Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.203197Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.203138Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.206363Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.206077Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.08640384161</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>1.62592119421</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0.555919891596</td></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0.555919891596</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "if HYBRID_SEARCH_AVAILABLE:\n",
-        "    # Hybrid search with a price filter\n",
-        "    filtered_hybrid_query = HybridQuery(\n",
-        "        text=\"professional equipment\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.9, 0.1, 0.05],\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        filter_expression=Num(\"price\") > 100,\n",
-        "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "        num_results=5,\n",
-        "        combination_method=\"LINEAR\",\n",
-        "        yield_text_score_as=\"text_score\",\n",
-        "        yield_vsim_score_as=\"vector_similarity\",\n",
-        "        yield_combined_score_as=\"hybrid_score\",\n",
-        "    )\n",
-        "\n",
-        "    results = index.query(filtered_hybrid_query)\n",
-        "    result_print(results)\n",
-        "\n",
-        "else:\n",
-        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.702984Z",
-          "start_time": "2025-12-15T09:27:44.689201Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.207295Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.207232Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.210438Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.210032Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>3.08640384161</td><td>1.62592119421</td></tr><tr><td>0.411657452583</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr><tr><td>0.411657452583</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Hybrid search with a price filter\n",
-        "filtered_hybrid_query = AggregateHybridQuery(\n",
-        "    text=\"professional equipment\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    vector=[0.9, 0.1, 0.05],\n",
-        "    vector_field_name=\"text_embedding\",\n",
-        "    filter_expression=Num(\"price\") > 100,\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(filtered_hybrid_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Using Different Text Scorers\n",
-        "\n",
-        "Hybrid queries support the same text scoring algorithms as TextQuery:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 26,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.715Z",
-          "start_time": "2025-12-15T09:27:44.706463Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.211324Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.211266Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.214265Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.213897Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.66666666667</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.995073735714</td><td>1.496551615</td></tr><tr><td>1.66666666667</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>1.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0.7</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "if HYBRID_SEARCH_AVAILABLE:\n",
-        "    # Aggregate Hybrid query with TFIDF scorer\n",
-        "    hybrid_tfidf = HybridQuery(\n",
-        "        text=\"shoes support\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.12, 0.18, 0.12],\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        text_scorer=\"TFIDF\",\n",
-        "        return_fields=[\"product_id\", \"brief_description\"],\n",
-        "        num_results=3,\n",
-        "        combination_method=\"LINEAR\",\n",
-        "        yield_text_score_as=\"text_score\",\n",
-        "        yield_vsim_score_as=\"vector_similarity\",\n",
-        "        yield_combined_score_as=\"hybrid_score\",\n",
-        "    )\n",
-        "\n",
-        "    results = index.query(hybrid_tfidf)\n",
-        "    result_print(results)\n",
-        "\n",
-        "else:\n",
-        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 27,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.728396Z",
-          "start_time": "2025-12-15T09:27:44.721838Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.215100Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.215041Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.218819Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.218461Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>5</td><td>2.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0</td><td>0.7</td></tr><tr><td>0.00136888027191</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.999315559864</td><td>0</td><td>0.699520891905</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Aggregate Hybrid query with TFIDF scorer\n",
-        "hybrid_tfidf = AggregateHybridQuery(\n",
-        "    text=\"shoes support\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    vector=[0.12, 0.18, 0.12],\n",
-        "    vector_field_name=\"text_embedding\",\n",
-        "    text_scorer=\"TFIDF\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "results = index.query(hybrid_tfidf)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Runtime Parameters for Vector Search Tuning\n",
-        "\n",
-        "**Important:** `AggregateHybridQuery` uses FT.AGGREGATE commands which do NOT support runtime parameters.\n",
-        "\n",
-        "Runtime parameters (such as `ef_runtime` for HNSW indexes or `search_window_size` for SVS-VAMANA indexes) are only supported with FT.SEARCH (and partially FT.HYBRID) commands.\n",
-        "\n",
-        "**For runtime parameter support, use `HybridQuery`, `VectorQuery`, or `VectorRangeQuery` instead:**\n",
-        "\n",
-        "- `HybridQuery`: Supports `ef_runtime` for HNSW indexes\n",
-        "- `VectorQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
-        "- `VectorRangeQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
-        "- `AggregateHybridQuery`: Does NOT support runtime parameters (uses FT.AGGREGATE)\n",
-        "\n",
-        "See the **Runtime Parameters** section earlier in this notebook for examples of using runtime parameters with `VectorQuery`."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 3. MultiVectorQuery: Multi-Vector Search\n",
-        "\n",
-        "The `MultiVectorQuery` allows you to search over multiple vector fields simultaneously. This is useful when you have different types of embeddings (e.g., text and image embeddings) and want to find results that match across multiple modalities.\n",
-        "\n",
-        "The final score is calculated as a weighted combination:\n",
-        "\n",
-        "```\n",
-        "combined_score = w_1 * score_1 + w_2 * score_2 + w_3 * score_3 + ...\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Basic Multi-Vector Query\n",
-        "\n",
-        "First, we need to import the `Vector` class to define our query vectors:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 28,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.742916Z",
-          "start_time": "2025-12-15T09:27:44.736787Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.219849Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.219790Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.222773Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.222418Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996151670814</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994777700305</td></tr><tr><td>0.0038834810257</td><td>0.210647821426</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.998058259487</td><td>0.894676089287</td><td>0.967043608427</td></tr><tr><td>0.236237406731</td><td>0.639005899429</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.881881296635</td><td>0.680497050285</td><td>0.82146602273</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from redisvl.query import MultiVectorQuery, Vector\n",
-        "\n",
-        "# Define multiple vectors for the query\n",
-        "text_vector = Vector(\n",
-        "    vector=[0.1, 0.2, 0.1],\n",
-        "    field_name=\"text_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.7  # 70% weight for text embedding\n",
-        ")\n",
-        "\n",
-        "image_vector = Vector(\n",
-        "    vector=[0.8, 0.1],\n",
-        "    field_name=\"image_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.3  # 30% weight for image embedding\n",
-        ")\n",
-        "\n",
-        "# Create a multi-vector query\n",
-        "multi_vector_query = MultiVectorQuery(\n",
-        "    vectors=[text_vector, image_vector],\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(multi_vector_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Adjusting Vector Weights\n",
-        "\n",
-        "You can adjust the weights to prioritize different vector fields:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 29,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.764858Z",
-          "start_time": "2025-12-15T09:27:44.749806Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.223637Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.223579Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.226532Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.226206Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Results with emphasis on image similarity:\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>-1.19209289551e-07</td><td>0</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>1.0000000596</td><td>1</td><td>1.00000001192</td></tr><tr><td>0.14539372921</td><td>0.00900757312775</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.927303135395</td><td>0.995496213436</td><td>0.981857597828</td></tr><tr><td>0.436696171761</td><td>0.219131231308</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.78165191412</td><td>0.890434384346</td><td>0.868677890301</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# More emphasis on image similarity\n",
-        "text_vec = Vector(\n",
-        "    vector=[0.9, 0.1, 0.05],\n",
-        "    field_name=\"text_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.2  # 20% weight\n",
-        ")\n",
-        "\n",
-        "image_vec = Vector(\n",
-        "    vector=[0.1, 0.9],\n",
-        "    field_name=\"image_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.8  # 80% weight\n",
-        ")\n",
-        "\n",
-        "image_heavy_query = MultiVectorQuery(\n",
-        "    vectors=[text_vec, image_vec],\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "print(\"Results with emphasis on image similarity:\")\n",
-        "results = index.query(image_heavy_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Multi-Vector Query with Filters\n",
-        "\n",
-        "Combine multi-vector search with filters to narrow results:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 30,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.786971Z",
-          "start_time": "2025-12-15T09:27:44.772064Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.227394Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.227333Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.230297Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.229946Z"
-        }
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996510982513</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Multi-vector search with category filter\n",
-        "text_vec = Vector(\n",
-        "    vector=[0.1, 0.2, 0.1],\n",
-        "    field_name=\"text_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.6\n",
-        ")\n",
-        "\n",
-        "image_vec = Vector(\n",
-        "    vector=[0.8, 0.1],\n",
-        "    field_name=\"image_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.4\n",
-        ")\n",
-        "\n",
-        "filtered_multi_query = MultiVectorQuery(\n",
-        "    vectors=[text_vec, image_vec],\n",
-        "    filter_expression=Tag(\"category\") == \"footwear\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-        "    num_results=5\n",
-        ")\n",
-        "\n",
-        "results = index.query(filtered_multi_query)\n",
-        "result_print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Comparing Query Types\n",
-        "\n",
-        "Let's compare the three query types side by side:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 31,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.804045Z",
-          "start_time": "2025-12-15T09:27:44.788480Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.231190Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.231128Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.234174Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.233900Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "TextQuery Results (keyword-based):\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>2.8773943004779676</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "# TextQuery - keyword-based search\n",
-        "text_q = TextQuery(\n",
-        "    text=\"shoes\",\n",
-        "    text_field_name=\"brief_description\",\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "print(\"TextQuery Results (keyword-based):\")\n",
-        "result_print(index.query(text_q))\n",
-        "print()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 32,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.832484Z",
-          "start_time": "2025-12-15T09:27:44.811853Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.235126Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.235064Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.239216Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.238885Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "HybridQuery Results (text + vector):\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.87739430048</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>1.56321826928</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.998058259487</td><td>0.698640781641</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "if HYBRID_SEARCH_AVAILABLE:\n",
-        "    # HybridQuery - combines text and vector search\n",
-        "    hybrid_q = HybridQuery(\n",
-        "        text=\"shoes\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.1, 0.2, 0.1],\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        return_fields=[\"product_id\", \"brief_description\"],\n",
-        "        num_results=3,\n",
-        "        combination_method=\"LINEAR\",\n",
-        "        yield_text_score_as=\"text_score\",\n",
-        "        yield_vsim_score_as=\"vector_similarity\",\n",
-        "        yield_combined_score_as=\"hybrid_score\",\n",
-        "    )\n",
-        "\n",
-        "    results = index.query(hybrid_q)\n",
-        "\n",
-        "else:\n",
-        "    hybrid_q = AggregateHybridQuery(\n",
-        "        text=\"shoes\",\n",
-        "        text_field_name=\"brief_description\",\n",
-        "        vector=[0.1, 0.2, 0.1],\n",
-        "        vector_field_name=\"text_embedding\",\n",
-        "        return_fields=[\"product_id\", \"brief_description\"],\n",
-        "        num_results=3,\n",
-        "    )\n",
-        "\n",
-        "    results = index.query(hybrid_q)\n",
-        "\n",
-        "\n",
-        "print(f\"{hybrid_q.__class__.__name__} Results (text + vector):\")\n",
-        "result_print(results)\n",
-        "print()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 33,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.853040Z",
-          "start_time": "2025-12-15T09:27:44.833266Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.240109Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.240048Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.244083Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.243804Z"
-        }
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "MultiVectorQuery Results (multiple vectors):\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996870294213</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994580343366</td></tr></table>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# MultiVectorQuery - searches multiple vector fields\n",
-        "mv_text = Vector(\n",
-        "    vector=[0.1, 0.2, 0.1],\n",
-        "    field_name=\"text_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.5\n",
-        ")\n",
-        "\n",
-        "mv_image = Vector(\n",
-        "    vector=[0.8, 0.1],\n",
-        "    field_name=\"image_embedding\",\n",
-        "    dtype=\"float32\",\n",
-        "    weight=0.5\n",
-        ")\n",
-        "\n",
-        "multi_q = MultiVectorQuery(\n",
-        "    vectors=[mv_text, mv_image],\n",
-        "    return_fields=[\"product_id\", \"brief_description\"],\n",
-        "    num_results=3\n",
-        ")\n",
-        "\n",
-        "print(\"MultiVectorQuery Results (multiple vectors):\")\n",
-        "result_print(index.query(multi_q))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Best Practices\n",
-        "\n",
-        "### When to Use Each Query Type:\n",
-        "\n",
-        "1. **`TextQuery`**:\n",
-        "   - When you need precise keyword matching\n",
-        "   - For traditional search engine functionality\n",
-        "   - When text relevance scoring is important\n",
-        "   - Example: Product search, document retrieval\n",
-        "\n",
-        "2. **`HybridQuery`**:\n",
-        "   - When you want to combine keyword and semantic search\n",
-        "   - For improved search quality over pure text or vector search\n",
-        "   - When you have both text and vector representations of your data\n",
-        "   - Example: E-commerce search, content recommendation\n",
-        "\n",
-        "3. **`MultiVectorQuery`**:\n",
-        "   - When you have multiple types of embeddings (text, image, audio, etc.)\n",
-        "   - For multi-modal search applications\n",
-        "   - When you want to balance multiple semantic signals\n",
-        "   - Example: Image-text search, cross-modal retrieval"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Next Steps\n",
-        "\n",
-        "Now that you understand advanced query types, explore these related guides:\n",
-        "\n",
-        "- [Query and Filter Data](02_complex_filtering.ipynb) - Apply filters to narrow down search results\n",
-        "- [Write SQL Queries for Redis](12_sql_to_redis_queries.ipynb) - Use SQL-like syntax for Redis queries\n",
-        "- [Improve Search Quality with Rerankers](06_rerankers.ipynb) - Rerank results for better relevance"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Cleanup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 34,
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2025-12-15T09:27:44.865832Z",
-          "start_time": "2025-12-15T09:27:44.861322Z"
-        },
-        "execution": {
-          "iopub.execute_input": "2026-02-16T15:17:31.245159Z",
-          "iopub.status.busy": "2026-02-16T15:17:31.245099Z",
-          "iopub.status.idle": "2026-02-16T15:17:31.247976Z",
-          "shell.execute_reply": "2026-02-16T15:17:31.247577Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "# Cleanup\n",
-        "index.delete()"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.13.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use Advanced Query Types\n",
+    "\n",
+    "This guide covers advanced query types available in RedisVL:\n",
+    "\n",
+    "1. **`TextQuery`**: Full text search with advanced scoring\n",
+    "2. **`AggregateHybridQuery` and `HybridQuery`**: Combines text and vector search for hybrid retrieval\n",
+    "3. **`MultiVectorQuery`**: Search over multiple vector fields simultaneously\n",
+    "\n",
+    "These query types enable sophisticated search applications that go beyond simple vector similarity search.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "Before you begin, ensure you have:\n",
+    "- Installed RedisVL: `pip install redisvl`\n",
+    "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
+    "- For `HybridQuery`: Redis >= 8.4.0 and redis-py >= 7.1.0\n",
+    "\n",
+    "## What You'll Learn\n",
+    "\n",
+    "By the end of this guide, you will be able to:\n",
+    "- Perform full-text search with `TextQuery` and advanced scoring options\n",
+    "- Combine text and vector search using `HybridQuery` and `AggregateHybridQuery`\n",
+    "- Search across multiple vector fields with `MultiVectorQuery`\n",
+    "- Configure custom stopwords for text search"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup and Data Preparation\n",
+    "\n",
+    "First, let's create a schema and prepare sample data that includes text fields, numeric fields, and vector fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:43.615445Z",
+     "start_time": "2025-12-15T09:27:43.522493Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:07.111759Z",
+     "iopub.status.busy": "2026-02-16T15:17:07.111643Z",
+     "iopub.status.idle": "2026-02-16T15:17:07.193336Z",
+     "shell.execute_reply": "2026-02-16T15:17:07.192860Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from jupyterutils import result_print\n",
+    "\n",
+    "# Sample data with text descriptions, categories, and vectors\n",
+    "data = [\n",
+    "    {\n",
+    "        'product_id': 'prod_1',\n",
+    "        'brief_description': 'comfortable running shoes for athletes',\n",
+    "        'full_description': 'Engineered with a dual-layer EVA foam midsole and FlexWeave breathable mesh upper, these running shoes deliver responsive cushioning for long-distance runs. The anatomical footbed adapts to your stride while the carbon rubber outsole provides superior traction on varied terrain.',\n",
+    "        'category': 'footwear',\n",
+    "        'price': 89.99,\n",
+    "        'rating': 4.5,\n",
+    "        'text_embedding': np.array([0.1, 0.2, 0.1], dtype=np.float32).tobytes(),\n",
+    "        'image_embedding': np.array([0.8, 0.1], dtype=np.float32).tobytes(),\n",
+    "    },\n",
+    "    {\n",
+    "        'product_id': 'prod_2',\n",
+    "        'brief_description': 'lightweight running jacket with water resistance',\n",
+    "        'full_description': 'Stay protected with this ultralight 2.5-layer DWR-coated shell featuring laser-cut ventilation zones and reflective piping for low-light visibility. Packs into its own chest pocket and weighs just 4.2 oz, making it ideal for unpredictable weather conditions.',\n",
+    "        'category': 'outerwear',\n",
+    "        'price': 129.99,\n",
+    "        'rating': 4.8,\n",
+    "        'text_embedding': np.array([0.2, 0.3, 0.2], dtype=np.float32).tobytes(),\n",
+    "        'image_embedding': np.array([0.7, 0.2], dtype=np.float32).tobytes(),\n",
+    "    },\n",
+    "    {\n",
+    "        'product_id': 'prod_3',\n",
+    "        'brief_description': 'professional tennis racket for competitive players',\n",
+    "        'full_description': 'Competition-grade racket featuring a 98 sq in head size, 16x19 string pattern, and aerospace-grade graphite frame that delivers explosive power with pinpoint control. Tournament-approved specs include 315g weight and 68 RA stiffness rating for advanced baseline play.',\n",
+    "        'category': 'equipment',\n",
+    "        'price': 199.99,\n",
+    "        'rating': 4.9,\n",
+    "        'text_embedding': np.array([0.9, 0.1, 0.05], dtype=np.float32).tobytes(),\n",
+    "        'image_embedding': np.array([0.1, 0.9], dtype=np.float32).tobytes(),\n",
+    "    },\n",
+    "    {\n",
+    "        'product_id': 'prod_4',\n",
+    "        'brief_description': 'yoga mat with extra cushioning for comfort',\n",
+    "        'full_description': 'Premium 8mm thick TPE yoga mat with dual-texture surface - smooth side for hot yoga flow and textured side for maximum grip during balancing poses. Closed-cell technology prevents moisture absorption while alignment markers guide proper positioning in asanas.',\n",
+    "        'category': 'accessories',\n",
+    "        'price': 39.99,\n",
+    "        'rating': 4.3,\n",
+    "        'text_embedding': np.array([0.15, 0.25, 0.15], dtype=np.float32).tobytes(),\n",
+    "        'image_embedding': np.array([0.5, 0.5], dtype=np.float32).tobytes(),\n",
+    "    },\n",
+    "    {\n",
+    "        'product_id': 'prod_5',\n",
+    "        'brief_description': 'basketball shoes with excellent ankle support',\n",
+    "        'full_description': 'High-top basketball sneakers with Zoom Air units in forefoot and heel, reinforced lateral sidewalls for explosive cuts, and herringbone traction pattern optimized for hardwood courts. The internal bootie construction and extended ankle collar provide lockdown support during aggressive drives.',\n",
+    "        'category': 'footwear',\n",
+    "        'price': 139.99,\n",
+    "        'rating': 4.7,\n",
+    "        'text_embedding': np.array([0.12, 0.18, 0.12], dtype=np.float32).tobytes(),\n",
+    "        'image_embedding': np.array([0.75, 0.15], dtype=np.float32).tobytes(),\n",
+    "    },\n",
+    "    {\n",
+    "        'product_id': 'prod_6',\n",
+    "        'brief_description': 'swimming goggles with anti-fog coating',\n",
+    "        'full_description': 'Low-profile competition goggles with curved polycarbonate lenses offering 180-degree peripheral vision and UV protection. Hydrophobic anti-fog coating lasts 10x longer than standard treatments, while the split silicone strap and interchangeable nose bridges ensure a watertight, custom fit.',\n",
+    "        'category': 'accessories',\n",
+    "        'price': 24.99,\n",
+    "        'rating': 4.4,\n",
+    "        'text_embedding': np.array([0.3, 0.1, 0.2], dtype=np.float32).tobytes(),\n",
+    "        'image_embedding': np.array([0.2, 0.8], dtype=np.float32).tobytes(),\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the Schema\n",
+    "\n",
+    "Our schema includes:\n",
+    "- **Tag fields**: `product_id`, `category`\n",
+    "- **Text fields**: `brief_description` and `full_description` for full-text search\n",
+    "- **Numeric fields**: `price`, `rating`\n",
+    "- **Vector fields**: `text_embedding` (3 dimensions) and `image_embedding` (2 dimensions) for semantic search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:43.620369Z",
+     "start_time": "2025-12-15T09:27:43.615922Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:07.194739Z",
+     "iopub.status.busy": "2026-02-16T15:17:07.194621Z",
+     "iopub.status.idle": "2026-02-16T15:17:07.197015Z",
+     "shell.execute_reply": "2026-02-16T15:17:07.196608Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "schema = {\n",
+    "    \"index\": {\n",
+    "        \"name\": \"advanced_queries\",\n",
+    "        \"prefix\": \"products\",\n",
+    "        \"storage_type\": \"hash\",\n",
+    "    },\n",
+    "    \"fields\": [\n",
+    "        {\"name\": \"product_id\", \"type\": \"tag\"},\n",
+    "        {\"name\": \"category\", \"type\": \"tag\"},\n",
+    "        {\"name\": \"brief_description\", \"type\": \"text\"},\n",
+    "        {\"name\": \"full_description\", \"type\": \"text\"},\n",
+    "        {\"name\": \"price\", \"type\": \"numeric\"},\n",
+    "        {\"name\": \"rating\", \"type\": \"numeric\"},\n",
+    "        {\n",
+    "            \"name\": \"text_embedding\",\n",
+    "            \"type\": \"vector\",\n",
+    "            \"attrs\": {\n",
+    "                \"dims\": 3,\n",
+    "                \"distance_metric\": \"cosine\",\n",
+    "                \"algorithm\": \"flat\",\n",
+    "                \"datatype\": \"float32\"\n",
+    "            }\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"image_embedding\",\n",
+    "            \"type\": \"vector\",\n",
+    "            \"attrs\": {\n",
+    "                \"dims\": 2,\n",
+    "                \"distance_metric\": \"cosine\",\n",
+    "                \"algorithm\": \"flat\",\n",
+    "                \"datatype\": \"float32\"\n",
+    "            }\n",
+    "        }\n",
+    "    ],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Index and Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:43.720506Z",
+     "start_time": "2025-12-15T09:27:43.620716Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:07.198084Z",
+     "iopub.status.busy": "2026-02-16T15:17:07.198011Z",
+     "iopub.status.idle": "2026-02-16T15:17:07.293058Z",
+     "shell.execute_reply": "2026-02-16T15:17:07.292647Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Loaded 6 products into the index\n"
+     ]
+    }
+   ],
+   "source": [
+    "from redisvl.index import SearchIndex\n",
+    "\n",
+    "# Create the search index\n",
+    "index = SearchIndex.from_dict(schema, redis_url=\"redis://localhost:6379\")\n",
+    "\n",
+    "# Create the index and load data\n",
+    "index.create(overwrite=True)\n",
+    "keys = index.load(data)\n",
+    "\n",
+    "print(f\"Loaded {len(keys)} products into the index\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. TextQuery: Full Text Search\n",
+    "\n",
+    "The `TextQuery` class enables full text search with advanced scoring algorithms. It's ideal for keyword-based search with relevance ranking.\n",
+    "\n",
+    "### Basic Text Search\n",
+    "\n",
+    "Let's search for products related to \"running shoes\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.289286Z",
+     "start_time": "2025-12-15T09:27:43.721057Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:07.310132Z",
+     "iopub.status.busy": "2026-02-16T15:17:07.310020Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.114469Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.113951Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from redisvl.query import TextQuery\n",
+    "\n",
+    "# Create a text query\n",
+    "text_query = TextQuery(\n",
+    "    text=\"running shoes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(text_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Text Search with Different Scoring Algorithms\n",
+    "\n",
+    "RedisVL supports multiple text scoring algorithms. Let's compare `BM25STD` and `TFIDF`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.337057Z",
+     "start_time": "2025-12-15T09:27:44.321956Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.116222Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.116038Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.120972Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.120483Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Results with BM25 scoring:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>6.031534703977659</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# BM25 standard scoring (default)\n",
+    "bm25_query = TextQuery(\n",
+    "    text=\"comfortable shoes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    text_scorer=\"BM25STD\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "print(\"Results with BM25 scoring:\")\n",
+    "results = index.query(bm25_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.352789Z",
+     "start_time": "2025-12-15T09:27:44.344825Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.122229Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.122120Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.126377Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.125815Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Results with TFIDF scoring:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>2.3333333333333335</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# TFIDF scoring\n",
+    "tfidf_query = TextQuery(\n",
+    "    text=\"comfortable shoes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    text_scorer=\"TFIDF\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "print(\"Results with TFIDF scoring:\")\n",
+    "results = index.query(tfidf_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Text Search with Filters\n",
+    "\n",
+    "Combine text search with filters to narrow results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.374828Z",
+     "start_time": "2025-12-15T09:27:44.359984Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.127613Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.127518Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.131534Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.131085Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>3.9314935770863046</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>3.1279733904413027</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from redisvl.query.filter import Tag, Num\n",
+    "\n",
+    "# Search for \"shoes\" only in the footwear category\n",
+    "filtered_text_query = TextQuery(\n",
+    "    text=\"shoes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    filter_expression=Tag(\"category\") == \"footwear\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(filtered_text_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.409910Z",
+     "start_time": "2025-12-15T09:27:44.378041Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.132592Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.132506Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.136099Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.135780Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Search for products under $100\n",
+    "price_filtered_query = TextQuery(\n",
+    "    text=\"comfortable\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    filter_expression=Num(\"price\") < 100,\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(price_filtered_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Text Search with Multiple Fields and Weights\n",
+    "\n",
+    "You can search across multiple text fields with different weights to prioritize certain fields.\n",
+    "Here we'll prioritize the `brief_description` field and make text similarity in that field twice as important as text similarity in `full_description`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.425817Z",
+     "start_time": "2025-12-15T09:27:44.412131Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.137417Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.137337Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.140926Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.140520Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.035440025836444</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "weighted_query = TextQuery(\n",
+    "    text=\"shoes\",\n",
+    "    text_field_name={\"brief_description\": 1.0, \"full_description\": 0.5},\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "results = index.query(weighted_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Text Search with Custom Stopwords\n",
+    "\n",
+    "Stopwords are common words that are filtered out before processing the query. You can specify which language's default stopwords should be filtered out, like `english`, `french`, or `german`. You can also define your own list of stopwords:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.440583Z",
+     "start_time": "2025-12-15T09:27:44.427869Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.142202Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.142056Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.145323Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.144971Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Use English stopwords (default)\n",
+    "query_with_stopwords = TextQuery(\n",
+    "    text=\"the best shoes for running\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    stopwords=\"english\",  # Common words like \"the\", \"for\" will be removed\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "results = index.query(query_with_stopwords)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.461967Z",
+     "start_time": "2025-12-15T09:27:44.447726Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.146274Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.146200Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.149223Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.148867Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>3.0864038416103</td><td>prod_3</td><td>professional tennis racket for competitive players</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Use custom stopwords\n",
+    "custom_stopwords_query = TextQuery(\n",
+    "    text=\"professional equipment for athletes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    stopwords=[\"for\", \"with\"],  # Only these words will be filtered\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "results = index.query(custom_stopwords_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.478620Z",
+     "start_time": "2025-12-15T09:27:44.465051Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.150326Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.150250Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.153330Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.152986Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# No stopwords\n",
+    "no_stopwords_query = TextQuery(\n",
+    "    text=\"the best shoes for running\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    stopwords=None,  # All words will be included\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "results = index.query(no_stopwords_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Hybrid Queries: Combining Text and Vector Search\n",
+    "\n",
+    "Hybrid queries combine text search and vector similarity to provide the best of both worlds:\n",
+    "- **Text search**: Finds exact keyword matches\n",
+    "- **Vector search**: Captures semantic similarity\n",
+    "\n",
+    "As of Redis 8.4.0, Redis natively supports a [`FT.HYBRID`](https://redis.io/docs/latest/commands/ft.hybrid) search command. RedisVL provides a `HybridQuery` class that makes it easy to construct and execute hybrid queries. For earlier versions of Redis, RedisVL provides an `AggregateHybridQuery` class that uses Redis aggregation to achieve similar results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "# redis-py's hybrid query helpers warn that APIs are experimental; keep notebook output readable\n",
+    "warnings.filterwarnings(\"ignore\", message=r\".*is an experimental.*\", category=UserWarning)\n",
+    "\n",
+    "from packaging.version import Version\n",
+    "\n",
+    "from redis import __version__ as _redis_py_version\n",
+    "\n",
+    "redis_py_version = Version(_redis_py_version)\n",
+    "redis_version = Version(index.client.info()[\"redis_version\"])\n",
+    "\n",
+    "HYBRID_SEARCH_AVAILABLE = redis_version >= Version(\"8.4.0\") and redis_py_version >= Version(\"7.1.0\")\n",
+    "print(HYBRID_SEARCH_AVAILABLE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Index-Level Stopwords Configuration\n",
+    "\n",
+    "The previous example showed **query-time stopwords** using `TextQuery.stopwords`, which filters words from the query before searching. RedisVL also supports **index-level stopwords** configuration, which determines which words are indexed in the first place.\n",
+    "\n",
+    "**Key Difference:**\n",
+    "- **Query-time stopwords** (`TextQuery.stopwords`): Filters words from your search query (client-side)\n",
+    "- **Index-level stopwords** (`IndexInfo.stopwords`): Controls which words get indexed in Redis (server-side)\n",
+    "\n",
+    "**Three Configuration Modes:**\n",
+    "\n",
+    "1. **`None` (default)**: Use Redis's default stopwords list\n",
+    "2. **`[]` (empty list)**: Disable stopwords completely (`STOPWORDS 0` in FT.CREATE)\n",
+    "3. **`[\"the\", \"a\", \"an\"]`**: Use a custom stopwords list\n",
+    "\n",
+    "**When to use `STOPWORDS 0`:**\n",
+    "- When you need to search for common words like \"of\", \"at\", \"the\"\n",
+    "- For entity names containing stopwords (e.g., \"Bank of Glasberliner\", \"University of Glasberliner\")\n",
+    "- When working with structured data where every word matters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.512721Z",
+     "start_time": "2025-12-15T09:27:44.497780Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.158421Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.158344Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.164588Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.164184Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Index created with STOPWORDS 0: <redisvl.index.index.SearchIndex object at 0x130e98410>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a schema with index-level stopwords disabled\n",
+    "from redisvl.index import SearchIndex\n",
+    "\n",
+    "stopwords_schema = {\n",
+    "    \"index\": {\n",
+    "        \"name\": \"company_index\",\n",
+    "        \"prefix\": \"company:\",\n",
+    "        \"storage_type\": \"hash\",\n",
+    "        \"stopwords\": []  # STOPWORDS 0 - disable stopwords completely\n",
+    "    },\n",
+    "    \"fields\": [\n",
+    "        {\"name\": \"company_name\", \"type\": \"text\"},\n",
+    "        {\"name\": \"description\", \"type\": \"text\"}\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "# Create index using from_dict (handles schema creation internally)\n",
+    "company_index = SearchIndex.from_dict(stopwords_schema, redis_url=\"redis://localhost:6379\")\n",
+    "company_index.create(overwrite=True, drop=True)\n",
+    "\n",
+    "print(f\"Index created with STOPWORDS 0: {company_index}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.528568Z",
+     "start_time": "2025-12-15T09:27:44.513241Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.165547Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.165478Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.169607Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.169224Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "✓ Loaded 5 companies\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load sample data with company names containing common stopwords\n",
+    "companies = [\n",
+    "    {\"company_name\": \"Bank of Glasberliner\", \"description\": \"Major financial institution\"},\n",
+    "    {\"company_name\": \"University of Glasberliner\", \"description\": \"Public university system\"},\n",
+    "    {\"company_name\": \"Department of Glasberliner Affairs\", \"description\": \"A government agency\"},\n",
+    "    {\"company_name\": \"Glasberliner FC\", \"description\": \"Football Club\"},\n",
+    "    {\"company_name\": \"The Home Market\", \"description\": \"Home improvement retailer\"},\n",
+    "]\n",
+    "\n",
+    "for i, company in enumerate(companies):\n",
+    "    company_index.load([company], keys=[f\"company:{i}\"])\n",
+    "\n",
+    "print(f\"✓ Loaded {len(companies)} companies\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.534288Z",
+     "start_time": "2025-12-15T09:27:44.528999Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.170610Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.170537Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.173265Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.172885Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Found 1 results for 'Bank of Glasberliner':\n",
+      "  - Bank of Glasberliner: Major financial institution\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Search for \"Bank of Glasberliner\" - with STOPWORDS 0, \"of\" is indexed and searchable\n",
+    "from redisvl.query import FilterQuery\n",
+    "\n",
+    "query = FilterQuery(\n",
+    "    filter_expression='@company_name:(Bank of Glasberliner)',\n",
+    "    return_fields=[\"company_name\", \"description\"],\n",
+    ")\n",
+    "\n",
+    "results = company_index.search(query.query, query_params=query.params)\n",
+    "\n",
+    "print(f\"Found {len(results.docs)} results for 'Bank of Glasberliner':\")\n",
+    "for doc in results.docs:\n",
+    "    print(f\"  - {doc.company_name}: {doc.description}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Comparison: With vs Without Stopwords**\n",
+    "\n",
+    "If we had used the default stopwords (not specifying `stopwords` in the schema), the word \"of\" would be filtered out during indexing. This means:\n",
+    "\n",
+    "- ❌ Searching for `\"Bank of Glasberliner\"` might not find exact matches\n",
+    "- ❌ The phrase would be indexed as `\"Bank Berlin\"` (without \"of\")\n",
+    "- ✅ With `STOPWORDS 0`, all words including \"of\" are indexed\n",
+    "\n",
+    "**Custom Stopwords Example:**\n",
+    "\n",
+    "You can also provide a custom list of stopwords:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.553398Z",
+     "start_time": "2025-12-15T09:27:44.541083Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.174218Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.174154Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.175974Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.175650Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Custom stopwords: ['inc', 'llc', 'corp']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example: Create index with custom stopwords\n",
+    "custom_stopwords_schema = {\n",
+    "    \"index\": {\n",
+    "        \"name\": \"custom_stopwords_index\",\n",
+    "        \"prefix\": \"custom:\",\n",
+    "        \"stopwords\": [\"inc\", \"llc\", \"corp\"]  # Filter out legal entity suffixes\n",
+    "    },\n",
+    "    \"fields\": [\n",
+    "        {\"name\": \"name\", \"type\": \"text\"}\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "# This would create an index where \"inc\", \"llc\", \"corp\" are not indexed\n",
+    "print(\"Custom stopwords:\", custom_stopwords_schema[\"index\"][\"stopwords\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**YAML Format:**\n",
+    "\n",
+    "You can also define stopwords in YAML schema files:\n",
+    "\n",
+    "```yaml\n",
+    "version: '0.1.0'\n",
+    "\n",
+    "index:\n",
+    "  name: company_index\n",
+    "  prefix: company:\n",
+    "  storage_type: hash\n",
+    "  stopwords: []  # Disable stopwords (STOPWORDS 0)\n",
+    "\n",
+    "fields:\n",
+    "  - name: company_name\n",
+    "    type: text\n",
+    "  - name: description\n",
+    "    type: text\n",
+    "```\n",
+    "\n",
+    "Or with custom stopwords:\n",
+    "\n",
+    "```yaml\n",
+    "index:\n",
+    "  stopwords:\n",
+    "    - the\n",
+    "    - a\n",
+    "    - an\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.586789Z",
+     "start_time": "2025-12-15T09:27:44.556392Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.176910Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.176846Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.179113Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.178737Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "✓ Cleaned up company_index\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cleanup\n",
+    "company_index.delete(drop=True)\n",
+    "print(\"✓ Cleaned up company_index\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Hybrid Query\n",
+    "\n",
+    "> NOTE: `HybridQuery` requires Redis >= 8.4.0 and redis-py >= 7.1.0.\n",
+    "\n",
+    "Let's search for \"running\" with both text and semantic search, combining the results' scores using a linear combination:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.599394Z",
+     "start_time": "2025-12-15T09:27:44.589681Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.180129Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.180058Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.184565Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.184291Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>5.95398933304</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>2.48619677905</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>2.04100827745</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>1.30885409823</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0.698640781641</td></tr><tr><td>0</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0.617316907644</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if HYBRID_SEARCH_AVAILABLE:\n",
+    "    from redisvl.query import HybridQuery\n",
+    "\n",
+    "    # Create a hybrid query\n",
+    "    hybrid_query = HybridQuery(\n",
+    "        text=\"running shoes\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.1, 0.2, 0.1],  # Query vector\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "        num_results=5,\n",
+    "        yield_text_score_as=\"text_score\",\n",
+    "        yield_vsim_score_as=\"vector_similarity\",\n",
+    "        combination_method=\"LINEAR\",\n",
+    "        yield_combined_score_as=\"hybrid_score\",\n",
+    "    )\n",
+    "\n",
+    "    results = index.query(hybrid_query)\n",
+    "    result_print(results)\n",
+    "\n",
+    "else:\n",
+    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For earlier versions of Redis, you can use `AggregateHybridQuery` instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.619601Z",
+     "start_time": "2025-12-15T09:27:44.606514Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.185602Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.185538Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.188771Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.188422Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>5.95398933304</td><td>2.48619677905</td></tr><tr><td>0.00985252857208</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>2.08531559363</td><td>1.32214629309</td></tr><tr><td>0.00985252857208</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>2.04100827745</td><td>1.30885409823</td></tr><tr><td>0.0038834810257</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0</td><td>0.698640781641</td></tr><tr><td>0.236237406731</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0</td><td>0.617316907644</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from redisvl.query import AggregateHybridQuery\n",
+    "\n",
+    "agg_hybrid_query = AggregateHybridQuery(\n",
+    "    text=\"running shoes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    vector=[0.1, 0.2, 0.1],  # Query vector\n",
+    "    vector_field_name=\"text_embedding\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(agg_hybrid_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adjusting the Alpha Parameter\n",
+    "\n",
+    "Results are scored using a weighted combination:\n",
+    "\n",
+    "```\n",
+    "hybrid_score = (alpha) * text_score + (1 - alpha) * vector_score\n",
+    "```\n",
+    "\n",
+    "Where `alpha` controls the balance between text and vector search (default: 0.3 for `HybridQuery` and 0.7 for `AggregateHybridQuery`). Note that `AggregateHybridQuery` reverses the definition of `alpha` to be the weight of the vector score.\n",
+    "\n",
+    "The `alpha` parameter controls the weight between text and vector search:\n",
+    "- `alpha=1.0`: Pure text search (or pure vector search for `AggregateHybridQuery`)\n",
+    "- `alpha=0.0`: Pure vector search (or pure text search for `AggregateHybridQuery`)\n",
+    "- `alpha=0.3` (default - `HybridQuery`): 30% text, 70% vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.636058Z",
+     "start_time": "2025-12-15T09:27:44.621406Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.189764Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.189701Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.193700Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.193353Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Results with alpha=0.1 (vector-heavy):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>1.21366647389</td></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.05268080238</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.899384003878</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if HYBRID_SEARCH_AVAILABLE:\n",
+    "    vector_heavy_query = HybridQuery(\n",
+    "        text=\"comfortable\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.15, 0.25, 0.15],\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        combination_method=\"LINEAR\",\n",
+    "\t\tlinear_alpha=0.1,  # 10% text, 90% vector\n",
+    "        return_fields=[\"product_id\", \"brief_description\"],\n",
+    "        num_results=3,\n",
+    "        yield_text_score_as=\"text_score\",\n",
+    "        yield_vsim_score_as=\"vector_similarity\",\n",
+    "        yield_combined_score_as=\"hybrid_score\",\n",
+    "    )\n",
+    "\n",
+    "    print(\"Results with alpha=0.1 (vector-heavy):\")\n",
+    "    results = index.query(vector_heavy_query)\n",
+    "    result_print(results)\n",
+    "\n",
+    "else:\n",
+    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.651595Z",
+     "start_time": "2025-12-15T09:27:44.643458Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.194553Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.194492Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.198234Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.197931Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Results with alpha=0.9 (vector-heavy):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.52680748736</td><td>1.05268080238</td></tr><tr><td>0.00136888027191</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr><tr><td>0.00136888027191</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# More emphasis on vector search (alpha=0.9)\n",
+    "vector_heavy_query = AggregateHybridQuery(\n",
+    "    text=\"comfortable\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    vector=[0.15, 0.25, 0.15],\n",
+    "    vector_field_name=\"text_embedding\",\n",
+    "    alpha=0.9,  # 90% vector, 10% text\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "print(\"Results with alpha=0.9 (vector-heavy):\")\n",
+    "results = index.query(vector_heavy_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reciprocal Rank Fusion (RRF)\n",
+    "\n",
+    "In addition to combining scores using a linear combination, `HybridQuery` also supports reciprocal rank fusion (RRF) for combining scores. This method is useful when you want to combine scores giving more weight to the top results from each query.\n",
+    "\n",
+    "`HybridQuery` allows for the following parameters to be specified for RRF:\n",
+    "- `rrf_window`: The window size to use for the RRF combination method. Limits the fusion scope.\n",
+    "- `rrf_constant`: The constant to use for the RRF combination method. Controls the decay of rank influence.\n",
+    "\n",
+    "`AggregateHybridQuery` does not support RRF, and only supports a linear combination of scores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.664953Z",
+     "start_time": "2025-12-15T09:27:44.658451Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.199251Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.199188Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.202314Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.201944Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>0.032522474881</td></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>0.032018442623</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.0320020481311</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if HYBRID_SEARCH_AVAILABLE:\n",
+    "    rrf_query = HybridQuery(\n",
+    "        text=\"comfortable\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.15, 0.25, 0.15],\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        combination_method=\"RRF\",\n",
+    "        return_fields=[\"product_id\", \"brief_description\"],\n",
+    "        num_results=3,\n",
+    "        yield_text_score_as=\"text_score\",\n",
+    "        yield_vsim_score_as=\"vector_similarity\",\n",
+    "        yield_combined_score_as=\"hybrid_score\",\n",
+    "    )\n",
+    "\n",
+    "    results = index.query(rrf_query)\n",
+    "    result_print(results)\n",
+    "\n",
+    "else:\n",
+    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hybrid Query with Filters\n",
+    "\n",
+    "You can also combine hybrid search with filters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.686355Z",
+     "start_time": "2025-12-15T09:27:44.672035Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.203197Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.203138Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.206363Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.206077Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.08640384161</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>1.62592119421</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0.555919891596</td></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0.555919891596</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if HYBRID_SEARCH_AVAILABLE:\n",
+    "    # Hybrid search with a price filter\n",
+    "    filtered_hybrid_query = HybridQuery(\n",
+    "        text=\"professional equipment\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.9, 0.1, 0.05],\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        filter_expression=Num(\"price\") > 100,\n",
+    "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "        num_results=5,\n",
+    "        combination_method=\"LINEAR\",\n",
+    "        yield_text_score_as=\"text_score\",\n",
+    "        yield_vsim_score_as=\"vector_similarity\",\n",
+    "        yield_combined_score_as=\"hybrid_score\",\n",
+    "    )\n",
+    "\n",
+    "    results = index.query(filtered_hybrid_query)\n",
+    "    result_print(results)\n",
+    "\n",
+    "else:\n",
+    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.702984Z",
+     "start_time": "2025-12-15T09:27:44.689201Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.207295Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.207232Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.210438Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.210032Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>3.08640384161</td><td>1.62592119421</td></tr><tr><td>0.411657452583</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr><tr><td>0.411657452583</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Hybrid search with a price filter\n",
+    "filtered_hybrid_query = AggregateHybridQuery(\n",
+    "    text=\"professional equipment\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    vector=[0.9, 0.1, 0.05],\n",
+    "    vector_field_name=\"text_embedding\",\n",
+    "    filter_expression=Num(\"price\") > 100,\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(filtered_hybrid_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using Different Text Scorers\n",
+    "\n",
+    "Hybrid queries support the same text scoring algorithms as TextQuery:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.715Z",
+     "start_time": "2025-12-15T09:27:44.706463Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.211324Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.211266Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.214265Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.213897Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.66666666667</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.995073735714</td><td>1.496551615</td></tr><tr><td>1.66666666667</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>1.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0.7</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if HYBRID_SEARCH_AVAILABLE:\n",
+    "    # Aggregate Hybrid query with TFIDF scorer\n",
+    "    hybrid_tfidf = HybridQuery(\n",
+    "        text=\"shoes support\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.12, 0.18, 0.12],\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        text_scorer=\"TFIDF\",\n",
+    "        return_fields=[\"product_id\", \"brief_description\"],\n",
+    "        num_results=3,\n",
+    "        combination_method=\"LINEAR\",\n",
+    "        yield_text_score_as=\"text_score\",\n",
+    "        yield_vsim_score_as=\"vector_similarity\",\n",
+    "        yield_combined_score_as=\"hybrid_score\",\n",
+    "    )\n",
+    "\n",
+    "    results = index.query(hybrid_tfidf)\n",
+    "    result_print(results)\n",
+    "\n",
+    "else:\n",
+    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.728396Z",
+     "start_time": "2025-12-15T09:27:44.721838Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.215100Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.215041Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.218819Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.218461Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>5</td><td>2.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0</td><td>0.7</td></tr><tr><td>0.00136888027191</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.999315559864</td><td>0</td><td>0.699520891905</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Aggregate Hybrid query with TFIDF scorer\n",
+    "hybrid_tfidf = AggregateHybridQuery(\n",
+    "    text=\"shoes support\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    vector=[0.12, 0.18, 0.12],\n",
+    "    vector_field_name=\"text_embedding\",\n",
+    "    text_scorer=\"TFIDF\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "results = index.query(hybrid_tfidf)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Runtime Parameters for Vector Search Tuning\n",
+    "\n",
+    "**Important:** `AggregateHybridQuery` uses FT.AGGREGATE commands which do NOT support runtime parameters.\n",
+    "\n",
+    "Runtime parameters (such as `ef_runtime` for HNSW indexes or `search_window_size` for SVS-VAMANA indexes) are only supported with FT.SEARCH (and partially FT.HYBRID) commands.\n",
+    "\n",
+    "**For runtime parameter support, use `HybridQuery`, `VectorQuery`, or `VectorRangeQuery` instead:**\n",
+    "\n",
+    "- `HybridQuery`: Supports `ef_runtime` for HNSW indexes\n",
+    "- `VectorQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
+    "- `VectorRangeQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
+    "- `AggregateHybridQuery`: Does NOT support runtime parameters (uses FT.AGGREGATE)\n",
+    "\n",
+    "See the **Runtime Parameters** section earlier in this notebook for examples of using runtime parameters with `VectorQuery`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. MultiVectorQuery: Multi-Vector Search\n",
+    "\n",
+    "The `MultiVectorQuery` allows you to search over multiple vector fields simultaneously. This is useful when you have different types of embeddings (e.g., text and image embeddings) and want to find results that match across multiple modalities.\n",
+    "\n",
+    "The final score is calculated as a weighted combination:\n",
+    "\n",
+    "```\n",
+    "combined_score = w_1 * score_1 + w_2 * score_2 + w_3 * score_3 + ...\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Multi-Vector Query\n",
+    "\n",
+    "First, we need to import the `Vector` class to define our query vectors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.742916Z",
+     "start_time": "2025-12-15T09:27:44.736787Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.219849Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.219790Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.222773Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.222418Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996151670814</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994777700305</td></tr><tr><td>0.0038834810257</td><td>0.210647821426</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.998058259487</td><td>0.894676089287</td><td>0.967043608427</td></tr><tr><td>0.236237406731</td><td>0.639005899429</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.881881296635</td><td>0.680497050285</td><td>0.82146602273</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from redisvl.query import MultiVectorQuery, Vector\n",
+    "\n",
+    "# Define multiple vectors for the query\n",
+    "text_vector = Vector(\n",
+    "    vector=[0.1, 0.2, 0.1],\n",
+    "    field_name=\"text_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.7  # 70% weight for text embedding\n",
+    ")\n",
+    "\n",
+    "image_vector = Vector(\n",
+    "    vector=[0.8, 0.1],\n",
+    "    field_name=\"image_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.3  # 30% weight for image embedding\n",
+    ")\n",
+    "\n",
+    "# Create a multi-vector query\n",
+    "multi_vector_query = MultiVectorQuery(\n",
+    "    vectors=[text_vector, image_vector],\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(multi_vector_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adjusting Vector Weights\n",
+    "\n",
+    "You can adjust the weights to prioritize different vector fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.764858Z",
+     "start_time": "2025-12-15T09:27:44.749806Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.223637Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.223579Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.226532Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.226206Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Results with emphasis on image similarity:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>-1.19209289551e-07</td><td>0</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>1.0000000596</td><td>1</td><td>1.00000001192</td></tr><tr><td>0.14539372921</td><td>0.00900757312775</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.927303135395</td><td>0.995496213436</td><td>0.981857597828</td></tr><tr><td>0.436696171761</td><td>0.219131231308</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.78165191412</td><td>0.890434384346</td><td>0.868677890301</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# More emphasis on image similarity\n",
+    "text_vec = Vector(\n",
+    "    vector=[0.9, 0.1, 0.05],\n",
+    "    field_name=\"text_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.2  # 20% weight\n",
+    ")\n",
+    "\n",
+    "image_vec = Vector(\n",
+    "    vector=[0.1, 0.9],\n",
+    "    field_name=\"image_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.8  # 80% weight\n",
+    ")\n",
+    "\n",
+    "image_heavy_query = MultiVectorQuery(\n",
+    "    vectors=[text_vec, image_vec],\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "print(\"Results with emphasis on image similarity:\")\n",
+    "results = index.query(image_heavy_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multi-Vector Query with Filters\n",
+    "\n",
+    "Combine multi-vector search with filters to narrow results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.786971Z",
+     "start_time": "2025-12-15T09:27:44.772064Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.227394Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.227333Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.230297Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.229946Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996510982513</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Multi-vector search with category filter\n",
+    "text_vec = Vector(\n",
+    "    vector=[0.1, 0.2, 0.1],\n",
+    "    field_name=\"text_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.6\n",
+    ")\n",
+    "\n",
+    "image_vec = Vector(\n",
+    "    vector=[0.8, 0.1],\n",
+    "    field_name=\"image_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.4\n",
+    ")\n",
+    "\n",
+    "filtered_multi_query = MultiVectorQuery(\n",
+    "    vectors=[text_vec, image_vec],\n",
+    "    filter_expression=Tag(\"category\") == \"footwear\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+    "    num_results=5\n",
+    ")\n",
+    "\n",
+    "results = index.query(filtered_multi_query)\n",
+    "result_print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing Query Types\n",
+    "\n",
+    "Let's compare the three query types side by side:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.804045Z",
+     "start_time": "2025-12-15T09:27:44.788480Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.231190Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.231128Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.234174Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.233900Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "TextQuery Results (keyword-based):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>2.8773943004779676</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TextQuery - keyword-based search\n",
+    "text_q = TextQuery(\n",
+    "    text=\"shoes\",\n",
+    "    text_field_name=\"brief_description\",\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "print(\"TextQuery Results (keyword-based):\")\n",
+    "result_print(index.query(text_q))\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.832484Z",
+     "start_time": "2025-12-15T09:27:44.811853Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.235126Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.235064Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.239216Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.238885Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "HybridQuery Results (text + vector):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.87739430048</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>1.56321826928</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.998058259487</td><td>0.698640781641</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "if HYBRID_SEARCH_AVAILABLE:\n",
+    "    # HybridQuery - combines text and vector search\n",
+    "    hybrid_q = HybridQuery(\n",
+    "        text=\"shoes\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.1, 0.2, 0.1],\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        return_fields=[\"product_id\", \"brief_description\"],\n",
+    "        num_results=3,\n",
+    "        combination_method=\"LINEAR\",\n",
+    "        yield_text_score_as=\"text_score\",\n",
+    "        yield_vsim_score_as=\"vector_similarity\",\n",
+    "        yield_combined_score_as=\"hybrid_score\",\n",
+    "    )\n",
+    "\n",
+    "    results = index.query(hybrid_q)\n",
+    "\n",
+    "else:\n",
+    "    hybrid_q = AggregateHybridQuery(\n",
+    "        text=\"shoes\",\n",
+    "        text_field_name=\"brief_description\",\n",
+    "        vector=[0.1, 0.2, 0.1],\n",
+    "        vector_field_name=\"text_embedding\",\n",
+    "        return_fields=[\"product_id\", \"brief_description\"],\n",
+    "        num_results=3,\n",
+    "    )\n",
+    "\n",
+    "    results = index.query(hybrid_q)\n",
+    "\n",
+    "\n",
+    "print(f\"{hybrid_q.__class__.__name__} Results (text + vector):\")\n",
+    "result_print(results)\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.853040Z",
+     "start_time": "2025-12-15T09:27:44.833266Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.240109Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.240048Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.244083Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.243804Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "MultiVectorQuery Results (multiple vectors):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996870294213</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994580343366</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# MultiVectorQuery - searches multiple vector fields\n",
+    "mv_text = Vector(\n",
+    "    vector=[0.1, 0.2, 0.1],\n",
+    "    field_name=\"text_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.5\n",
+    ")\n",
+    "\n",
+    "mv_image = Vector(\n",
+    "    vector=[0.8, 0.1],\n",
+    "    field_name=\"image_embedding\",\n",
+    "    dtype=\"float32\",\n",
+    "    weight=0.5\n",
+    ")\n",
+    "\n",
+    "multi_q = MultiVectorQuery(\n",
+    "    vectors=[mv_text, mv_image],\n",
+    "    return_fields=[\"product_id\", \"brief_description\"],\n",
+    "    num_results=3\n",
+    ")\n",
+    "\n",
+    "print(\"MultiVectorQuery Results (multiple vectors):\")\n",
+    "result_print(index.query(multi_q))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Best Practices\n",
+    "\n",
+    "### When to Use Each Query Type:\n",
+    "\n",
+    "1. **`TextQuery`**:\n",
+    "   - When you need precise keyword matching\n",
+    "   - For traditional search engine functionality\n",
+    "   - When text relevance scoring is important\n",
+    "   - Example: Product search, document retrieval\n",
+    "\n",
+    "2. **`HybridQuery`**:\n",
+    "   - When you want to combine keyword and semantic search\n",
+    "   - For improved search quality over pure text or vector search\n",
+    "   - When you have both text and vector representations of your data\n",
+    "   - Example: E-commerce search, content recommendation\n",
+    "\n",
+    "3. **`MultiVectorQuery`**:\n",
+    "   - When you have multiple types of embeddings (text, image, audio, etc.)\n",
+    "   - For multi-modal search applications\n",
+    "   - When you want to balance multiple semantic signals\n",
+    "   - Example: Image-text search, cross-modal retrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "Now that you understand advanced query types, explore these related guides:\n",
+    "\n",
+    "- [Query and Filter Data](02_complex_filtering.ipynb) - Apply filters to narrow down search results\n",
+    "- [Write SQL Queries for Redis](12_sql_to_redis_queries.ipynb) - Use SQL-like syntax for Redis queries\n",
+    "- [Improve Search Quality with Rerankers](06_rerankers.ipynb) - Rerank results for better relevance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-15T09:27:44.865832Z",
+     "start_time": "2025-12-15T09:27:44.861322Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-02-16T15:17:31.245159Z",
+     "iopub.status.busy": "2026-02-16T15:17:31.245099Z",
+     "iopub.status.idle": "2026-02-16T15:17:31.247976Z",
+     "shell.execute_reply": "2026-02-16T15:17:31.247577Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Cleanup\n",
+    "index.delete()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/user_guide/11_advanced_queries.ipynb
+++ b/docs/user_guide/11_advanced_queries.ipynb
@@ -1,2097 +1,2088 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Use Advanced Query Types\n",
-    "\n",
-    "This guide covers advanced query types available in RedisVL:\n",
-    "\n",
-    "1. **`TextQuery`**: Full text search with advanced scoring\n",
-    "2. **`AggregateHybridQuery` and `HybridQuery`**: Combines text and vector search for hybrid retrieval\n",
-    "3. **`MultiVectorQuery`**: Search over multiple vector fields simultaneously\n",
-    "\n",
-    "These query types enable sophisticated search applications that go beyond simple vector similarity search.\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "Before you begin, ensure you have:\n",
-    "- Installed RedisVL: `pip install redisvl`\n",
-    "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
-    "- For `HybridQuery`: Redis >= 8.4.0 and redis-py >= 7.1.0\n",
-    "\n",
-    "## What You'll Learn\n",
-    "\n",
-    "By the end of this guide, you will be able to:\n",
-    "- Perform full-text search with `TextQuery` and advanced scoring options\n",
-    "- Combine text and vector search using `HybridQuery` and `AggregateHybridQuery`\n",
-    "- Search across multiple vector fields with `MultiVectorQuery`\n",
-    "- Configure custom stopwords for text search"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup and Data Preparation\n",
-    "\n",
-    "First, let's create a schema and prepare sample data that includes text fields, numeric fields, and vector fields."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:43.615445Z",
-     "start_time": "2025-12-15T09:27:43.522493Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:07.111759Z",
-     "iopub.status.busy": "2026-02-16T15:17:07.111643Z",
-     "iopub.status.idle": "2026-02-16T15:17:07.193336Z",
-     "shell.execute_reply": "2026-02-16T15:17:07.192860Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "from jupyterutils import result_print\n",
-    "\n",
-    "# Sample data with text descriptions, categories, and vectors\n",
-    "data = [\n",
-    "    {\n",
-    "        'product_id': 'prod_1',\n",
-    "        'brief_description': 'comfortable running shoes for athletes',\n",
-    "        'full_description': 'Engineered with a dual-layer EVA foam midsole and FlexWeave breathable mesh upper, these running shoes deliver responsive cushioning for long-distance runs. The anatomical footbed adapts to your stride while the carbon rubber outsole provides superior traction on varied terrain.',\n",
-    "        'category': 'footwear',\n",
-    "        'price': 89.99,\n",
-    "        'rating': 4.5,\n",
-    "        'text_embedding': np.array([0.1, 0.2, 0.1], dtype=np.float32).tobytes(),\n",
-    "        'image_embedding': np.array([0.8, 0.1], dtype=np.float32).tobytes(),\n",
-    "    },\n",
-    "    {\n",
-    "        'product_id': 'prod_2',\n",
-    "        'brief_description': 'lightweight running jacket with water resistance',\n",
-    "        'full_description': 'Stay protected with this ultralight 2.5-layer DWR-coated shell featuring laser-cut ventilation zones and reflective piping for low-light visibility. Packs into its own chest pocket and weighs just 4.2 oz, making it ideal for unpredictable weather conditions.',\n",
-    "        'category': 'outerwear',\n",
-    "        'price': 129.99,\n",
-    "        'rating': 4.8,\n",
-    "        'text_embedding': np.array([0.2, 0.3, 0.2], dtype=np.float32).tobytes(),\n",
-    "        'image_embedding': np.array([0.7, 0.2], dtype=np.float32).tobytes(),\n",
-    "    },\n",
-    "    {\n",
-    "        'product_id': 'prod_3',\n",
-    "        'brief_description': 'professional tennis racket for competitive players',\n",
-    "        'full_description': 'Competition-grade racket featuring a 98 sq in head size, 16x19 string pattern, and aerospace-grade graphite frame that delivers explosive power with pinpoint control. Tournament-approved specs include 315g weight and 68 RA stiffness rating for advanced baseline play.',\n",
-    "        'category': 'equipment',\n",
-    "        'price': 199.99,\n",
-    "        'rating': 4.9,\n",
-    "        'text_embedding': np.array([0.9, 0.1, 0.05], dtype=np.float32).tobytes(),\n",
-    "        'image_embedding': np.array([0.1, 0.9], dtype=np.float32).tobytes(),\n",
-    "    },\n",
-    "    {\n",
-    "        'product_id': 'prod_4',\n",
-    "        'brief_description': 'yoga mat with extra cushioning for comfort',\n",
-    "        'full_description': 'Premium 8mm thick TPE yoga mat with dual-texture surface - smooth side for hot yoga flow and textured side for maximum grip during balancing poses. Closed-cell technology prevents moisture absorption while alignment markers guide proper positioning in asanas.',\n",
-    "        'category': 'accessories',\n",
-    "        'price': 39.99,\n",
-    "        'rating': 4.3,\n",
-    "        'text_embedding': np.array([0.15, 0.25, 0.15], dtype=np.float32).tobytes(),\n",
-    "        'image_embedding': np.array([0.5, 0.5], dtype=np.float32).tobytes(),\n",
-    "    },\n",
-    "    {\n",
-    "        'product_id': 'prod_5',\n",
-    "        'brief_description': 'basketball shoes with excellent ankle support',\n",
-    "        'full_description': 'High-top basketball sneakers with Zoom Air units in forefoot and heel, reinforced lateral sidewalls for explosive cuts, and herringbone traction pattern optimized for hardwood courts. The internal bootie construction and extended ankle collar provide lockdown support during aggressive drives.',\n",
-    "        'category': 'footwear',\n",
-    "        'price': 139.99,\n",
-    "        'rating': 4.7,\n",
-    "        'text_embedding': np.array([0.12, 0.18, 0.12], dtype=np.float32).tobytes(),\n",
-    "        'image_embedding': np.array([0.75, 0.15], dtype=np.float32).tobytes(),\n",
-    "    },\n",
-    "    {\n",
-    "        'product_id': 'prod_6',\n",
-    "        'brief_description': 'swimming goggles with anti-fog coating',\n",
-    "        'full_description': 'Low-profile competition goggles with curved polycarbonate lenses offering 180-degree peripheral vision and UV protection. Hydrophobic anti-fog coating lasts 10x longer than standard treatments, while the split silicone strap and interchangeable nose bridges ensure a watertight, custom fit.',\n",
-    "        'category': 'accessories',\n",
-    "        'price': 24.99,\n",
-    "        'rating': 4.4,\n",
-    "        'text_embedding': np.array([0.3, 0.1, 0.2], dtype=np.float32).tobytes(),\n",
-    "        'image_embedding': np.array([0.2, 0.8], dtype=np.float32).tobytes(),\n",
-    "    },\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Define the Schema\n",
-    "\n",
-    "Our schema includes:\n",
-    "- **Tag fields**: `product_id`, `category`\n",
-    "- **Text fields**: `brief_description` and `full_description` for full-text search\n",
-    "- **Numeric fields**: `price`, `rating`\n",
-    "- **Vector fields**: `text_embedding` (3 dimensions) and `image_embedding` (2 dimensions) for semantic search"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:43.620369Z",
-     "start_time": "2025-12-15T09:27:43.615922Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:07.194739Z",
-     "iopub.status.busy": "2026-02-16T15:17:07.194621Z",
-     "iopub.status.idle": "2026-02-16T15:17:07.197015Z",
-     "shell.execute_reply": "2026-02-16T15:17:07.196608Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "schema = {\n",
-    "    \"index\": {\n",
-    "        \"name\": \"advanced_queries\",\n",
-    "        \"prefix\": \"products\",\n",
-    "        \"storage_type\": \"hash\",\n",
-    "    },\n",
-    "    \"fields\": [\n",
-    "        {\"name\": \"product_id\", \"type\": \"tag\"},\n",
-    "        {\"name\": \"category\", \"type\": \"tag\"},\n",
-    "        {\"name\": \"brief_description\", \"type\": \"text\"},\n",
-    "        {\"name\": \"full_description\", \"type\": \"text\"},\n",
-    "        {\"name\": \"price\", \"type\": \"numeric\"},\n",
-    "        {\"name\": \"rating\", \"type\": \"numeric\"},\n",
-    "        {\n",
-    "            \"name\": \"text_embedding\",\n",
-    "            \"type\": \"vector\",\n",
-    "            \"attrs\": {\n",
-    "                \"dims\": 3,\n",
-    "                \"distance_metric\": \"cosine\",\n",
-    "                \"algorithm\": \"flat\",\n",
-    "                \"datatype\": \"float32\"\n",
-    "            }\n",
-    "        },\n",
-    "        {\n",
-    "            \"name\": \"image_embedding\",\n",
-    "            \"type\": \"vector\",\n",
-    "            \"attrs\": {\n",
-    "                \"dims\": 2,\n",
-    "                \"distance_metric\": \"cosine\",\n",
-    "                \"algorithm\": \"flat\",\n",
-    "                \"datatype\": \"float32\"\n",
-    "            }\n",
-    "        }\n",
-    "    ],\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create Index and Load Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:43.720506Z",
-     "start_time": "2025-12-15T09:27:43.620716Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:07.198084Z",
-     "iopub.status.busy": "2026-02-16T15:17:07.198011Z",
-     "iopub.status.idle": "2026-02-16T15:17:07.293058Z",
-     "shell.execute_reply": "2026-02-16T15:17:07.292647Z"
-    }
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded 6 products into the index\n"
-     ]
-    }
-   ],
-   "source": [
-    "from redisvl.index import SearchIndex\n",
-    "\n",
-    "# Create the search index\n",
-    "index = SearchIndex.from_dict(schema, redis_url=\"redis://localhost:6379\")\n",
-    "\n",
-    "# Create the index and load data\n",
-    "index.create(overwrite=True)\n",
-    "keys = index.load(data)\n",
-    "\n",
-    "print(f\"Loaded {len(keys)} products into the index\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 1. TextQuery: Full Text Search\n",
-    "\n",
-    "The `TextQuery` class enables full text search with advanced scoring algorithms. It's ideal for keyword-based search with relevance ranking.\n",
-    "\n",
-    "### Basic Text Search\n",
-    "\n",
-    "Let's search for products related to \"running shoes\":"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.289286Z",
-     "start_time": "2025-12-15T09:27:43.721057Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:07.310132Z",
-     "iopub.status.busy": "2026-02-16T15:17:07.310020Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.114469Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.113951Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Use Advanced Query Types\n",
+        "\n",
+        "This guide covers advanced query types available in RedisVL:\n",
+        "\n",
+        "1. **`TextQuery`**: Full text search with advanced scoring\n",
+        "2. **`AggregateHybridQuery` and `HybridQuery`**: Combines text and vector search for hybrid retrieval\n",
+        "3. **`MultiVectorQuery`**: Search over multiple vector fields simultaneously\n",
+        "\n",
+        "These query types enable sophisticated search applications that go beyond simple vector similarity search.\n",
+        "\n",
+        "## Prerequisites\n",
+        "\n",
+        "Before you begin, ensure you have:\n",
+        "- Installed RedisVL: `pip install redisvl`\n",
+        "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
+        "- For `HybridQuery`: Redis >= 8.4.0 and redis-py >= 7.1.0\n",
+        "\n",
+        "## What You'll Learn\n",
+        "\n",
+        "By the end of this guide, you will be able to:\n",
+        "- Perform full-text search with `TextQuery` and advanced scoring options\n",
+        "- Combine text and vector search using `HybridQuery` and `AggregateHybridQuery`\n",
+        "- Search across multiple vector fields with `MultiVectorQuery`\n",
+        "- Configure custom stopwords for text search"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from redisvl.query import TextQuery\n",
-    "\n",
-    "# Create a text query\n",
-    "text_query = TextQuery(\n",
-    "    text=\"running shoes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(text_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Text Search with Different Scoring Algorithms\n",
-    "\n",
-    "RedisVL supports multiple text scoring algorithms. Let's compare `BM25STD` and `TFIDF`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.337057Z",
-     "start_time": "2025-12-15T09:27:44.321956Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.116222Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.116038Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.120972Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.120483Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results with BM25 scoring:\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>6.031534703977659</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup and Data Preparation\n",
+        "\n",
+        "First, let's create a schema and prepare sample data that includes text fields, numeric fields, and vector fields."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# BM25 standard scoring (default)\n",
-    "bm25_query = TextQuery(\n",
-    "    text=\"comfortable shoes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    text_scorer=\"BM25STD\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "print(\"Results with BM25 scoring:\")\n",
-    "results = index.query(bm25_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.352789Z",
-     "start_time": "2025-12-15T09:27:44.344825Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.122229Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.122120Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.126377Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.125815Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results with TFIDF scoring:\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>2.3333333333333335</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:43.615445Z",
+          "start_time": "2025-12-15T09:27:43.522493Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:07.111759Z",
+          "iopub.status.busy": "2026-02-16T15:17:07.111643Z",
+          "iopub.status.idle": "2026-02-16T15:17:07.193336Z",
+          "shell.execute_reply": "2026-02-16T15:17:07.192860Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "from jupyterutils import result_print\n",
+        "\n",
+        "# Sample data with text descriptions, categories, and vectors\n",
+        "data = [\n",
+        "    {\n",
+        "        'product_id': 'prod_1',\n",
+        "        'brief_description': 'comfortable running shoes for athletes',\n",
+        "        'full_description': 'Engineered with a dual-layer EVA foam midsole and FlexWeave breathable mesh upper, these running shoes deliver responsive cushioning for long-distance runs. The anatomical footbed adapts to your stride while the carbon rubber outsole provides superior traction on varied terrain.',\n",
+        "        'category': 'footwear',\n",
+        "        'price': 89.99,\n",
+        "        'rating': 4.5,\n",
+        "        'text_embedding': np.array([0.1, 0.2, 0.1], dtype=np.float32).tobytes(),\n",
+        "        'image_embedding': np.array([0.8, 0.1], dtype=np.float32).tobytes(),\n",
+        "    },\n",
+        "    {\n",
+        "        'product_id': 'prod_2',\n",
+        "        'brief_description': 'lightweight running jacket with water resistance',\n",
+        "        'full_description': 'Stay protected with this ultralight 2.5-layer DWR-coated shell featuring laser-cut ventilation zones and reflective piping for low-light visibility. Packs into its own chest pocket and weighs just 4.2 oz, making it ideal for unpredictable weather conditions.',\n",
+        "        'category': 'outerwear',\n",
+        "        'price': 129.99,\n",
+        "        'rating': 4.8,\n",
+        "        'text_embedding': np.array([0.2, 0.3, 0.2], dtype=np.float32).tobytes(),\n",
+        "        'image_embedding': np.array([0.7, 0.2], dtype=np.float32).tobytes(),\n",
+        "    },\n",
+        "    {\n",
+        "        'product_id': 'prod_3',\n",
+        "        'brief_description': 'professional tennis racket for competitive players',\n",
+        "        'full_description': 'Competition-grade racket featuring a 98 sq in head size, 16x19 string pattern, and aerospace-grade graphite frame that delivers explosive power with pinpoint control. Tournament-approved specs include 315g weight and 68 RA stiffness rating for advanced baseline play.',\n",
+        "        'category': 'equipment',\n",
+        "        'price': 199.99,\n",
+        "        'rating': 4.9,\n",
+        "        'text_embedding': np.array([0.9, 0.1, 0.05], dtype=np.float32).tobytes(),\n",
+        "        'image_embedding': np.array([0.1, 0.9], dtype=np.float32).tobytes(),\n",
+        "    },\n",
+        "    {\n",
+        "        'product_id': 'prod_4',\n",
+        "        'brief_description': 'yoga mat with extra cushioning for comfort',\n",
+        "        'full_description': 'Premium 8mm thick TPE yoga mat with dual-texture surface - smooth side for hot yoga flow and textured side for maximum grip during balancing poses. Closed-cell technology prevents moisture absorption while alignment markers guide proper positioning in asanas.',\n",
+        "        'category': 'accessories',\n",
+        "        'price': 39.99,\n",
+        "        'rating': 4.3,\n",
+        "        'text_embedding': np.array([0.15, 0.25, 0.15], dtype=np.float32).tobytes(),\n",
+        "        'image_embedding': np.array([0.5, 0.5], dtype=np.float32).tobytes(),\n",
+        "    },\n",
+        "    {\n",
+        "        'product_id': 'prod_5',\n",
+        "        'brief_description': 'basketball shoes with excellent ankle support',\n",
+        "        'full_description': 'High-top basketball sneakers with Zoom Air units in forefoot and heel, reinforced lateral sidewalls for explosive cuts, and herringbone traction pattern optimized for hardwood courts. The internal bootie construction and extended ankle collar provide lockdown support during aggressive drives.',\n",
+        "        'category': 'footwear',\n",
+        "        'price': 139.99,\n",
+        "        'rating': 4.7,\n",
+        "        'text_embedding': np.array([0.12, 0.18, 0.12], dtype=np.float32).tobytes(),\n",
+        "        'image_embedding': np.array([0.75, 0.15], dtype=np.float32).tobytes(),\n",
+        "    },\n",
+        "    {\n",
+        "        'product_id': 'prod_6',\n",
+        "        'brief_description': 'swimming goggles with anti-fog coating',\n",
+        "        'full_description': 'Low-profile competition goggles with curved polycarbonate lenses offering 180-degree peripheral vision and UV protection. Hydrophobic anti-fog coating lasts 10x longer than standard treatments, while the split silicone strap and interchangeable nose bridges ensure a watertight, custom fit.',\n",
+        "        'category': 'accessories',\n",
+        "        'price': 24.99,\n",
+        "        'rating': 4.4,\n",
+        "        'text_embedding': np.array([0.3, 0.1, 0.2], dtype=np.float32).tobytes(),\n",
+        "        'image_embedding': np.array([0.2, 0.8], dtype=np.float32).tobytes(),\n",
+        "    },\n",
+        "]"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# TFIDF scoring\n",
-    "tfidf_query = TextQuery(\n",
-    "    text=\"comfortable shoes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    text_scorer=\"TFIDF\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "print(\"Results with TFIDF scoring:\")\n",
-    "results = index.query(tfidf_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Text Search with Filters\n",
-    "\n",
-    "Combine text search with filters to narrow results:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.374828Z",
-     "start_time": "2025-12-15T09:27:44.359984Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.127613Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.127518Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.131534Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.131085Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>3.9314935770863046</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>3.1279733904413027</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Define the Schema\n",
+        "\n",
+        "Our schema includes:\n",
+        "- **Tag fields**: `product_id`, `category`\n",
+        "- **Text fields**: `brief_description` and `full_description` for full-text search\n",
+        "- **Numeric fields**: `price`, `rating`\n",
+        "- **Vector fields**: `text_embedding` (3 dimensions) and `image_embedding` (2 dimensions) for semantic search"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from redisvl.query.filter import Tag, Num\n",
-    "\n",
-    "# Search for \"shoes\" only in the footwear category\n",
-    "filtered_text_query = TextQuery(\n",
-    "    text=\"shoes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    filter_expression=Tag(\"category\") == \"footwear\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(filtered_text_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.409910Z",
-     "start_time": "2025-12-15T09:27:44.378041Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.132592Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.132506Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.136099Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.135780Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:43.620369Z",
+          "start_time": "2025-12-15T09:27:43.615922Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:07.194739Z",
+          "iopub.status.busy": "2026-02-16T15:17:07.194621Z",
+          "iopub.status.idle": "2026-02-16T15:17:07.197015Z",
+          "shell.execute_reply": "2026-02-16T15:17:07.196608Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "schema = {\n",
+        "    \"index\": {\n",
+        "        \"name\": \"advanced_queries\",\n",
+        "        \"prefix\": \"products\",\n",
+        "        \"storage_type\": \"hash\",\n",
+        "    },\n",
+        "    \"fields\": [\n",
+        "        {\"name\": \"product_id\", \"type\": \"tag\"},\n",
+        "        {\"name\": \"category\", \"type\": \"tag\"},\n",
+        "        {\"name\": \"brief_description\", \"type\": \"text\"},\n",
+        "        {\"name\": \"full_description\", \"type\": \"text\"},\n",
+        "        {\"name\": \"price\", \"type\": \"numeric\"},\n",
+        "        {\"name\": \"rating\", \"type\": \"numeric\"},\n",
+        "        {\n",
+        "            \"name\": \"text_embedding\",\n",
+        "            \"type\": \"vector\",\n",
+        "            \"attrs\": {\n",
+        "                \"dims\": 3,\n",
+        "                \"distance_metric\": \"cosine\",\n",
+        "                \"algorithm\": \"flat\",\n",
+        "                \"datatype\": \"float32\"\n",
+        "            }\n",
+        "        },\n",
+        "        {\n",
+        "            \"name\": \"image_embedding\",\n",
+        "            \"type\": \"vector\",\n",
+        "            \"attrs\": {\n",
+        "                \"dims\": 2,\n",
+        "                \"distance_metric\": \"cosine\",\n",
+        "                \"algorithm\": \"flat\",\n",
+        "                \"datatype\": \"float32\"\n",
+        "            }\n",
+        "        }\n",
+        "    ],\n",
+        "}"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Search for products under $100\n",
-    "price_filtered_query = TextQuery(\n",
-    "    text=\"comfortable\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    filter_expression=Num(\"price\") < 100,\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(price_filtered_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Text Search with Multiple Fields and Weights\n",
-    "\n",
-    "You can search across multiple text fields with different weights to prioritize certain fields.\n",
-    "Here we'll prioritize the `brief_description` field and make text similarity in that field twice as important as text similarity in `full_description`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.425817Z",
-     "start_time": "2025-12-15T09:27:44.412131Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.137417Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.137337Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.140926Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.140520Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.035440025836444</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Create Index and Load Data"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "weighted_query = TextQuery(\n",
-    "    text=\"shoes\",\n",
-    "    text_field_name={\"brief_description\": 1.0, \"full_description\": 0.5},\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "results = index.query(weighted_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Text Search with Custom Stopwords\n",
-    "\n",
-    "Stopwords are common words that are filtered out before processing the query. You can specify which language's default stopwords should be filtered out, like `english`, `french`, or `german`. You can also define your own list of stopwords:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.440583Z",
-     "start_time": "2025-12-15T09:27:44.427869Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.142202Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.142056Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.145323Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.144971Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:43.720506Z",
+          "start_time": "2025-12-15T09:27:43.620716Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:07.198084Z",
+          "iopub.status.busy": "2026-02-16T15:17:07.198011Z",
+          "iopub.status.idle": "2026-02-16T15:17:07.293058Z",
+          "shell.execute_reply": "2026-02-16T15:17:07.292647Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Loaded 6 products into the index\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "from redisvl.index import SearchIndex\n",
+        "\n",
+        "# Create the search index\n",
+        "index = SearchIndex.from_dict(schema, redis_url=\"redis://localhost:6379\")\n",
+        "\n",
+        "# Create the index and load data\n",
+        "index.create(overwrite=True)\n",
+        "keys = index.load(data)\n",
+        "\n",
+        "print(f\"Loaded {len(keys)} products into the index\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Use English stopwords (default)\n",
-    "query_with_stopwords = TextQuery(\n",
-    "    text=\"the best shoes for running\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    stopwords=\"english\",  # Common words like \"the\", \"for\" will be removed\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "results = index.query(query_with_stopwords)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.461967Z",
-     "start_time": "2025-12-15T09:27:44.447726Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.146274Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.146200Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.149223Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.148867Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>3.0864038416103</td><td>prod_3</td><td>professional tennis racket for competitive players</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. TextQuery: Full Text Search\n",
+        "\n",
+        "The `TextQuery` class enables full text search with advanced scoring algorithms. It's ideal for keyword-based search with relevance ranking.\n",
+        "\n",
+        "### Basic Text Search\n",
+        "\n",
+        "Let's search for products related to \"running shoes\":"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.289286Z",
+          "start_time": "2025-12-15T09:27:43.721057Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:07.310132Z",
+          "iopub.status.busy": "2026-02-16T15:17:07.310020Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.114469Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.113951Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "from redisvl.query import TextQuery\n",
+        "\n",
+        "# Create a text query\n",
+        "text_query = TextQuery(\n",
+        "    text=\"running shoes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(text_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Use custom stopwords\n",
-    "custom_stopwords_query = TextQuery(\n",
-    "    text=\"professional equipment for athletes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    stopwords=[\"for\", \"with\"],  # Only these words will be filtered\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "results = index.query(custom_stopwords_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.478620Z",
-     "start_time": "2025-12-15T09:27:44.465051Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.150326Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.150250Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.153330Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.152986Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Text Search with Different Scoring Algorithms\n",
+        "\n",
+        "RedisVL supports multiple text scoring algorithms. Let's compare `BM25STD` and `TFIDF`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.337057Z",
+          "start_time": "2025-12-15T09:27:44.321956Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.116222Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.116038Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.120972Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.120483Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Results with BM25 scoring:\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>6.031534703977659</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# BM25 standard scoring (default)\n",
+        "bm25_query = TextQuery(\n",
+        "    text=\"comfortable shoes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    text_scorer=\"BM25STD\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "print(\"Results with BM25 scoring:\")\n",
+        "results = index.query(bm25_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# No stopwords\n",
-    "no_stopwords_query = TextQuery(\n",
-    "    text=\"the best shoes for running\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    stopwords=None,  # All words will be included\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "results = index.query(no_stopwords_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2. Hybrid Queries: Combining Text and Vector Search\n",
-    "\n",
-    "Hybrid queries combine text search and vector similarity to provide the best of both worlds:\n",
-    "- **Text search**: Finds exact keyword matches\n",
-    "- **Vector search**: Captures semantic similarity\n",
-    "\n",
-    "As of Redis 8.4.0, Redis natively supports a [`FT.HYBRID`](https://redis.io/docs/latest/commands/ft.hybrid) search command. RedisVL provides a `HybridQuery` class that makes it easy to construct and execute hybrid queries. For earlier versions of Redis, RedisVL provides an `AggregateHybridQuery` class that uses Redis aggregation to achieve similar results."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.494712Z",
-     "start_time": "2025-12-15T09:27:44.481443Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.154372Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.154300Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.157317Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.156892Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "True\n"
-     ]
-    }
-   ],
-   "source": [
-    "from packaging.version import Version\n",
-    "\n",
-    "from redis import __version__ as _redis_py_version\n",
-    "\n",
-    "redis_py_version = Version(_redis_py_version)\n",
-    "redis_version = Version(index.client.info()[\"redis_version\"])\n",
-    "\n",
-    "HYBRID_SEARCH_AVAILABLE = redis_version >= Version(\"8.4.0\") and redis_py_version >= Version(\"7.1.0\")\n",
-    "print(HYBRID_SEARCH_AVAILABLE)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Index-Level Stopwords Configuration\n",
-    "\n",
-    "The previous example showed **query-time stopwords** using `TextQuery.stopwords`, which filters words from the query before searching. RedisVL also supports **index-level stopwords** configuration, which determines which words are indexed in the first place.\n",
-    "\n",
-    "**Key Difference:**\n",
-    "- **Query-time stopwords** (`TextQuery.stopwords`): Filters words from your search query (client-side)\n",
-    "- **Index-level stopwords** (`IndexInfo.stopwords`): Controls which words get indexed in Redis (server-side)\n",
-    "\n",
-    "**Three Configuration Modes:**\n",
-    "\n",
-    "1. **`None` (default)**: Use Redis's default stopwords list\n",
-    "2. **`[]` (empty list)**: Disable stopwords completely (`STOPWORDS 0` in FT.CREATE)\n",
-    "3. **`[\"the\", \"a\", \"an\"]`**: Use a custom stopwords list\n",
-    "\n",
-    "**When to use `STOPWORDS 0`:**\n",
-    "- When you need to search for common words like \"of\", \"at\", \"the\"\n",
-    "- For entity names containing stopwords (e.g., \"Bank of Glasberliner\", \"University of Glasberliner\")\n",
-    "- When working with structured data where every word matters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.512721Z",
-     "start_time": "2025-12-15T09:27:44.497780Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.158421Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.158344Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.164588Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.164184Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Index created with STOPWORDS 0: <redisvl.index.index.SearchIndex object at 0x130e98410>\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create a schema with index-level stopwords disabled\n",
-    "from redisvl.index import SearchIndex\n",
-    "\n",
-    "stopwords_schema = {\n",
-    "    \"index\": {\n",
-    "        \"name\": \"company_index\",\n",
-    "        \"prefix\": \"company:\",\n",
-    "        \"storage_type\": \"hash\",\n",
-    "        \"stopwords\": []  # STOPWORDS 0 - disable stopwords completely\n",
-    "    },\n",
-    "    \"fields\": [\n",
-    "        {\"name\": \"company_name\", \"type\": \"text\"},\n",
-    "        {\"name\": \"description\", \"type\": \"text\"}\n",
-    "    ]\n",
-    "}\n",
-    "\n",
-    "# Create index using from_dict (handles schema creation internally)\n",
-    "company_index = SearchIndex.from_dict(stopwords_schema, redis_url=\"redis://localhost:6379\")\n",
-    "company_index.create(overwrite=True, drop=True)\n",
-    "\n",
-    "print(f\"Index created with STOPWORDS 0: {company_index}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.528568Z",
-     "start_time": "2025-12-15T09:27:44.513241Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.165547Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.165478Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.169607Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.169224Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ Loaded 5 companies\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Load sample data with company names containing common stopwords\n",
-    "companies = [\n",
-    "    {\"company_name\": \"Bank of Glasberliner\", \"description\": \"Major financial institution\"},\n",
-    "    {\"company_name\": \"University of Glasberliner\", \"description\": \"Public university system\"},\n",
-    "    {\"company_name\": \"Department of Glasberliner Affairs\", \"description\": \"A government agency\"},\n",
-    "    {\"company_name\": \"Glasberliner FC\", \"description\": \"Football Club\"},\n",
-    "    {\"company_name\": \"The Home Market\", \"description\": \"Home improvement retailer\"},\n",
-    "]\n",
-    "\n",
-    "for i, company in enumerate(companies):\n",
-    "    company_index.load([company], keys=[f\"company:{i}\"])\n",
-    "\n",
-    "print(f\"✓ Loaded {len(companies)} companies\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.534288Z",
-     "start_time": "2025-12-15T09:27:44.528999Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.170610Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.170537Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.173265Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.172885Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 1 results for 'Bank of Glasberliner':\n",
-      "  - Bank of Glasberliner: Major financial institution\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Search for \"Bank of Glasberliner\" - with STOPWORDS 0, \"of\" is indexed and searchable\n",
-    "from redisvl.query import FilterQuery\n",
-    "\n",
-    "query = FilterQuery(\n",
-    "    filter_expression='@company_name:(Bank of Glasberliner)',\n",
-    "    return_fields=[\"company_name\", \"description\"],\n",
-    ")\n",
-    "\n",
-    "results = company_index.search(query.query, query_params=query.params)\n",
-    "\n",
-    "print(f\"Found {len(results.docs)} results for 'Bank of Glasberliner':\")\n",
-    "for doc in results.docs:\n",
-    "    print(f\"  - {doc.company_name}: {doc.description}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Comparison: With vs Without Stopwords**\n",
-    "\n",
-    "If we had used the default stopwords (not specifying `stopwords` in the schema), the word \"of\" would be filtered out during indexing. This means:\n",
-    "\n",
-    "- ❌ Searching for `\"Bank of Glasberliner\"` might not find exact matches\n",
-    "- ❌ The phrase would be indexed as `\"Bank Berlin\"` (without \"of\")\n",
-    "- ✅ With `STOPWORDS 0`, all words including \"of\" are indexed\n",
-    "\n",
-    "**Custom Stopwords Example:**\n",
-    "\n",
-    "You can also provide a custom list of stopwords:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.553398Z",
-     "start_time": "2025-12-15T09:27:44.541083Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.174218Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.174154Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.175974Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.175650Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Custom stopwords: ['inc', 'llc', 'corp']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Example: Create index with custom stopwords\n",
-    "custom_stopwords_schema = {\n",
-    "    \"index\": {\n",
-    "        \"name\": \"custom_stopwords_index\",\n",
-    "        \"prefix\": \"custom:\",\n",
-    "        \"stopwords\": [\"inc\", \"llc\", \"corp\"]  # Filter out legal entity suffixes\n",
-    "    },\n",
-    "    \"fields\": [\n",
-    "        {\"name\": \"name\", \"type\": \"text\"}\n",
-    "    ]\n",
-    "}\n",
-    "\n",
-    "# This would create an index where \"inc\", \"llc\", \"corp\" are not indexed\n",
-    "print(\"Custom stopwords:\", custom_stopwords_schema[\"index\"][\"stopwords\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**YAML Format:**\n",
-    "\n",
-    "You can also define stopwords in YAML schema files:\n",
-    "\n",
-    "```yaml\n",
-    "version: '0.1.0'\n",
-    "\n",
-    "index:\n",
-    "  name: company_index\n",
-    "  prefix: company:\n",
-    "  storage_type: hash\n",
-    "  stopwords: []  # Disable stopwords (STOPWORDS 0)\n",
-    "\n",
-    "fields:\n",
-    "  - name: company_name\n",
-    "    type: text\n",
-    "  - name: description\n",
-    "    type: text\n",
-    "```\n",
-    "\n",
-    "Or with custom stopwords:\n",
-    "\n",
-    "```yaml\n",
-    "index:\n",
-    "  stopwords:\n",
-    "    - the\n",
-    "    - a\n",
-    "    - an\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.586789Z",
-     "start_time": "2025-12-15T09:27:44.556392Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.176910Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.176846Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.179113Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.178737Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ Cleaned up company_index\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Cleanup\n",
-    "company_index.delete(drop=True)\n",
-    "print(\"✓ Cleaned up company_index\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Basic Hybrid Query\n",
-    "\n",
-    "> NOTE: `HybridQuery` requires Redis >= 8.4.0 and redis-py >= 7.1.0.\n",
-    "\n",
-    "Let's search for \"running\" with both text and semantic search, combining the results' scores using a linear combination:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.599394Z",
-     "start_time": "2025-12-15T09:27:44.589681Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.180129Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.180058Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.184565Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.184291Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/tyler.hutcherson/Documents/AppliedAI/redis-vl-python/redisvl/query/hybrid.py:136: UserWarning: HybridPostProcessingConfig is an experimental and may change or be removed in future versions.\n",
-      "  self.postprocessing_config = HybridPostProcessingConfig()\n",
-      "/Users/tyler.hutcherson/Documents/AppliedAI/redis-vl-python/redisvl/query/hybrid.py:247: UserWarning: HybridSearchQuery is an experimental and may change or be removed in future versions.\n",
-      "  search_query = HybridSearchQuery(\n",
-      "/Users/tyler.hutcherson/Documents/AppliedAI/redis-vl-python/redisvl/query/hybrid.py:288: UserWarning: HybridVsimQuery is an experimental and may change or be removed in future versions.\n",
-      "  vsim_query = HybridVsimQuery(\n",
-      "/Users/tyler.hutcherson/Documents/AppliedAI/redis-vl-python/redisvl/query/hybrid.py:363: UserWarning: CombineResultsMethod is an experimental and may change or be removed in future versions.\n",
-      "  return CombineResultsMethod(\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>5.95398933304</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>2.48619677905</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>2.04100827745</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>1.30885409823</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0.698640781641</td></tr><tr><td>0</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0.617316907644</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.352789Z",
+          "start_time": "2025-12-15T09:27:44.344825Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.122229Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.122120Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.126377Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.125815Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Results with TFIDF scoring:\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>2.3333333333333335</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>2.0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>139.99</td></tr><tr><td>1.0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# TFIDF scoring\n",
+        "tfidf_query = TextQuery(\n",
+        "    text=\"comfortable shoes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    text_scorer=\"TFIDF\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "print(\"Results with TFIDF scoring:\")\n",
+        "results = index.query(tfidf_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if HYBRID_SEARCH_AVAILABLE:\n",
-    "    from redisvl.query import HybridQuery\n",
-    "\n",
-    "    # Create a hybrid query\n",
-    "    hybrid_query = HybridQuery(\n",
-    "        text=\"running shoes\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.1, 0.2, 0.1],  # Query vector\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "        num_results=5,\n",
-    "        yield_text_score_as=\"text_score\",\n",
-    "        yield_vsim_score_as=\"vector_similarity\",\n",
-    "        combination_method=\"LINEAR\",\n",
-    "        yield_combined_score_as=\"hybrid_score\",\n",
-    "    )\n",
-    "\n",
-    "    results = index.query(hybrid_query)\n",
-    "    result_print(results)\n",
-    "\n",
-    "else:\n",
-    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For earlier versions of Redis, you can use `AggregateHybridQuery` instead:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.619601Z",
-     "start_time": "2025-12-15T09:27:44.606514Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.185602Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.185538Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.188771Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.188422Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>5.95398933304</td><td>2.48619677905</td></tr><tr><td>0.00985252857208</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>2.08531559363</td><td>1.32214629309</td></tr><tr><td>0.00985252857208</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>2.04100827745</td><td>1.30885409823</td></tr><tr><td>0.0038834810257</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0</td><td>0.698640781641</td></tr><tr><td>0.236237406731</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0</td><td>0.617316907644</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Text Search with Filters\n",
+        "\n",
+        "Combine text search with filters to narrow results:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.374828Z",
+          "start_time": "2025-12-15T09:27:44.359984Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.127613Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.127518Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.131534Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.131085Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th></tr><tr><td>3.9314935770863046</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td></tr><tr><td>3.1279733904413027</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "from redisvl.query.filter import Tag, Num\n",
+        "\n",
+        "# Search for \"shoes\" only in the footwear category\n",
+        "filtered_text_query = TextQuery(\n",
+        "    text=\"shoes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    filter_expression=Tag(\"category\") == \"footwear\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(filtered_text_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from redisvl.query import AggregateHybridQuery\n",
-    "\n",
-    "agg_hybrid_query = AggregateHybridQuery(\n",
-    "    text=\"running shoes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    vector=[0.1, 0.2, 0.1],  # Query vector\n",
-    "    vector_field_name=\"text_embedding\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(agg_hybrid_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Adjusting the Alpha Parameter\n",
-    "\n",
-    "Results are scored using a weighted combination:\n",
-    "\n",
-    "```\n",
-    "hybrid_score = (alpha) * text_score + (1 - alpha) * vector_score\n",
-    "```\n",
-    "\n",
-    "Where `alpha` controls the balance between text and vector search (default: 0.3 for `HybridQuery` and 0.7 for `AggregateHybridQuery`). Note that `AggregateHybridQuery` reverses the definition of `alpha` to be the weight of the vector score.\n",
-    "\n",
-    "The `alpha` parameter controls the weight between text and vector search:\n",
-    "- `alpha=1.0`: Pure text search (or pure vector search for `AggregateHybridQuery`)\n",
-    "- `alpha=0.0`: Pure vector search (or pure text search for `AggregateHybridQuery`)\n",
-    "- `alpha=0.3` (default - `HybridQuery`): 30% text, 70% vector"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.636058Z",
-     "start_time": "2025-12-15T09:27:44.621406Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.189764Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.189701Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.193700Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.193353Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results with alpha=0.1 (vector-heavy):\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>1.21366647389</td></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.05268080238</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.899384003878</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.409910Z",
+          "start_time": "2025-12-15T09:27:44.378041Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.132592Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.132506Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.136099Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.135780Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th><th>price</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>89.99</td></tr><tr><td>1.5268074873573214</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>39.99</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Search for products under $100\n",
+        "price_filtered_query = TextQuery(\n",
+        "    text=\"comfortable\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    filter_expression=Num(\"price\") < 100,\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"price\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(price_filtered_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if HYBRID_SEARCH_AVAILABLE:\n",
-    "    vector_heavy_query = HybridQuery(\n",
-    "        text=\"comfortable\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.15, 0.25, 0.15],\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        combination_method=\"LINEAR\",\n",
-    "\t\tlinear_alpha=0.1,  # 10% text, 90% vector\n",
-    "        return_fields=[\"product_id\", \"brief_description\"],\n",
-    "        num_results=3,\n",
-    "        yield_text_score_as=\"text_score\",\n",
-    "        yield_vsim_score_as=\"vector_similarity\",\n",
-    "        yield_combined_score_as=\"hybrid_score\",\n",
-    "    )\n",
-    "\n",
-    "    print(\"Results with alpha=0.1 (vector-heavy):\")\n",
-    "    results = index.query(vector_heavy_query)\n",
-    "    result_print(results)\n",
-    "\n",
-    "else:\n",
-    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.651595Z",
-     "start_time": "2025-12-15T09:27:44.643458Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.194553Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.194492Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.198234Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.197931Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results with alpha=0.9 (vector-heavy):\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.52680748736</td><td>1.05268080238</td></tr><tr><td>0.00136888027191</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr><tr><td>0.00136888027191</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Text Search with Multiple Fields and Weights\n",
+        "\n",
+        "You can search across multiple text fields with different weights to prioritize certain fields.\n",
+        "Here we'll prioritize the `brief_description` field and make text similarity in that field twice as important as text similarity in `full_description`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.425817Z",
+          "start_time": "2025-12-15T09:27:44.412131Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.137417Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.137337Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.140926Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.140520Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.035440025836444</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "weighted_query = TextQuery(\n",
+        "    text=\"shoes\",\n",
+        "    text_field_name={\"brief_description\": 1.0, \"full_description\": 0.5},\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "results = index.query(weighted_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# More emphasis on vector search (alpha=0.9)\n",
-    "vector_heavy_query = AggregateHybridQuery(\n",
-    "    text=\"comfortable\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    vector=[0.15, 0.25, 0.15],\n",
-    "    vector_field_name=\"text_embedding\",\n",
-    "    alpha=0.9,  # 90% vector, 10% text\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "print(\"Results with alpha=0.9 (vector-heavy):\")\n",
-    "results = index.query(vector_heavy_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Reciprocal Rank Fusion (RRF)\n",
-    "\n",
-    "In addition to combining scores using a linear combination, `HybridQuery` also supports reciprocal rank fusion (RRF) for combining scores. This method is useful when you want to combine scores giving more weight to the top results from each query.\n",
-    "\n",
-    "`HybridQuery` allows for the following parameters to be specified for RRF:\n",
-    "- `rrf_window`: The window size to use for the RRF combination method. Limits the fusion scope.\n",
-    "- `rrf_constant`: The constant to use for the RRF combination method. Controls the decay of rank influence.\n",
-    "\n",
-    "`AggregateHybridQuery` does not support RRF, and only supports a linear combination of scores."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.664953Z",
-     "start_time": "2025-12-15T09:27:44.658451Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.199251Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.199188Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.202314Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.201944Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>0.032522474881</td></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>0.032018442623</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.0320020481311</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Text Search with Custom Stopwords\n",
+        "\n",
+        "Stopwords are common words that are filtered out before processing the query. You can specify which language's default stopwords should be filtered out, like `english`, `french`, or `german`. You can also define your own list of stopwords:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.440583Z",
+          "start_time": "2025-12-15T09:27:44.427869Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.142202Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.142056Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.145323Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.144971Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Use English stopwords (default)\n",
+        "query_with_stopwords = TextQuery(\n",
+        "    text=\"the best shoes for running\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    stopwords=\"english\",  # Common words like \"the\", \"for\" will be removed\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "results = index.query(query_with_stopwords)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if HYBRID_SEARCH_AVAILABLE:\n",
-    "    rrf_query = HybridQuery(\n",
-    "        text=\"comfortable\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.15, 0.25, 0.15],\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        combination_method=\"RRF\",\n",
-    "        return_fields=[\"product_id\", \"brief_description\"],\n",
-    "        num_results=3,\n",
-    "        yield_text_score_as=\"text_score\",\n",
-    "        yield_vsim_score_as=\"vector_similarity\",\n",
-    "        yield_combined_score_as=\"hybrid_score\",\n",
-    "    )\n",
-    "\n",
-    "    results = index.query(rrf_query)\n",
-    "    result_print(results)\n",
-    "\n",
-    "else:\n",
-    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Hybrid Query with Filters\n",
-    "\n",
-    "You can also combine hybrid search with filters:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.686355Z",
-     "start_time": "2025-12-15T09:27:44.672035Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.203197Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.203138Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.206363Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.206077Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.08640384161</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>1.62592119421</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0.555919891596</td></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0.555919891596</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.461967Z",
+          "start_time": "2025-12-15T09:27:44.447726Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.146274Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.146200Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.149223Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.148867Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>3.1541404034996914</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>3.0864038416103</td><td>prod_3</td><td>professional tennis racket for competitive players</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Use custom stopwords\n",
+        "custom_stopwords_query = TextQuery(\n",
+        "    text=\"professional equipment for athletes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    stopwords=[\"for\", \"with\"],  # Only these words will be filtered\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "results = index.query(custom_stopwords_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if HYBRID_SEARCH_AVAILABLE:\n",
-    "    # Hybrid search with a price filter\n",
-    "    filtered_hybrid_query = HybridQuery(\n",
-    "        text=\"professional equipment\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.9, 0.1, 0.05],\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        filter_expression=Num(\"price\") > 100,\n",
-    "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "        num_results=5,\n",
-    "        combination_method=\"LINEAR\",\n",
-    "        yield_text_score_as=\"text_score\",\n",
-    "        yield_vsim_score_as=\"vector_similarity\",\n",
-    "        yield_combined_score_as=\"hybrid_score\",\n",
-    "    )\n",
-    "\n",
-    "    results = index.query(filtered_hybrid_query)\n",
-    "    result_print(results)\n",
-    "\n",
-    "else:\n",
-    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.702984Z",
-     "start_time": "2025-12-15T09:27:44.689201Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.207295Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.207232Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.210438Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.210032Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>3.08640384161</td><td>1.62592119421</td></tr><tr><td>0.411657452583</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr><tr><td>0.411657452583</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.478620Z",
+          "start_time": "2025-12-15T09:27:44.465051Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.150326Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.150250Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.153330Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.152986Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>5.953989333038773</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr><tr><td>2.0410082774474088</td><td>prod_2</td><td>lightweight running jacket with water resistance</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# No stopwords\n",
+        "no_stopwords_query = TextQuery(\n",
+        "    text=\"the best shoes for running\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    stopwords=None,  # All words will be included\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "results = index.query(no_stopwords_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Hybrid search with a price filter\n",
-    "filtered_hybrid_query = AggregateHybridQuery(\n",
-    "    text=\"professional equipment\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    vector=[0.9, 0.1, 0.05],\n",
-    "    vector_field_name=\"text_embedding\",\n",
-    "    filter_expression=Num(\"price\") > 100,\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(filtered_hybrid_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Using Different Text Scorers\n",
-    "\n",
-    "Hybrid queries support the same text scoring algorithms as TextQuery:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.715Z",
-     "start_time": "2025-12-15T09:27:44.706463Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.211324Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.211266Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.214265Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.213897Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.66666666667</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.995073735714</td><td>1.496551615</td></tr><tr><td>1.66666666667</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>1.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0.7</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Hybrid Queries: Combining Text and Vector Search\n",
+        "\n",
+        "Hybrid queries combine text search and vector similarity to provide the best of both worlds:\n",
+        "- **Text search**: Finds exact keyword matches\n",
+        "- **Vector search**: Captures semantic similarity\n",
+        "\n",
+        "As of Redis 8.4.0, Redis natively supports a [`FT.HYBRID`](https://redis.io/docs/latest/commands/ft.hybrid) search command. RedisVL provides a `HybridQuery` class that makes it easy to construct and execute hybrid queries. For earlier versions of Redis, RedisVL provides an `AggregateHybridQuery` class that uses Redis aggregation to achieve similar results."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.494712Z",
+          "start_time": "2025-12-15T09:27:44.481443Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.154372Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.154300Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.157317Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.156892Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "True\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "import warnings\n",
+        "\n",
+        "# redis-py's hybrid query helpers warn that APIs are experimental; keep notebook output readable\n",
+        "warnings.filterwarnings(\"ignore\", message=r\".*is an experimental.*\", category=UserWarning)\n",
+        "\n",
+        "from packaging.version import Version\n",
+        "\n",
+        "from redis import __version__ as _redis_py_version\n",
+        "\n",
+        "redis_py_version = Version(_redis_py_version)\n",
+        "redis_version = Version(index.client.info()[\"redis_version\"])\n",
+        "\n",
+        "HYBRID_SEARCH_AVAILABLE = redis_version >= Version(\"8.4.0\") and redis_py_version >= Version(\"7.1.0\")\n",
+        "print(HYBRID_SEARCH_AVAILABLE)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if HYBRID_SEARCH_AVAILABLE:\n",
-    "    # Aggregate Hybrid query with TFIDF scorer\n",
-    "    hybrid_tfidf = HybridQuery(\n",
-    "        text=\"shoes support\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.12, 0.18, 0.12],\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        text_scorer=\"TFIDF\",\n",
-    "        return_fields=[\"product_id\", \"brief_description\"],\n",
-    "        num_results=3,\n",
-    "        combination_method=\"LINEAR\",\n",
-    "        yield_text_score_as=\"text_score\",\n",
-    "        yield_vsim_score_as=\"vector_similarity\",\n",
-    "        yield_combined_score_as=\"hybrid_score\",\n",
-    "    )\n",
-    "\n",
-    "    results = index.query(hybrid_tfidf)\n",
-    "    result_print(results)\n",
-    "\n",
-    "else:\n",
-    "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.728396Z",
-     "start_time": "2025-12-15T09:27:44.721838Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.215100Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.215041Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.218819Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.218461Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>5</td><td>2.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0</td><td>0.7</td></tr><tr><td>0.00136888027191</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.999315559864</td><td>0</td><td>0.699520891905</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Index-Level Stopwords Configuration\n",
+        "\n",
+        "The previous example showed **query-time stopwords** using `TextQuery.stopwords`, which filters words from the query before searching. RedisVL also supports **index-level stopwords** configuration, which determines which words are indexed in the first place.\n",
+        "\n",
+        "**Key Difference:**\n",
+        "- **Query-time stopwords** (`TextQuery.stopwords`): Filters words from your search query (client-side)\n",
+        "- **Index-level stopwords** (`IndexInfo.stopwords`): Controls which words get indexed in Redis (server-side)\n",
+        "\n",
+        "**Three Configuration Modes:**\n",
+        "\n",
+        "1. **`None` (default)**: Use Redis's default stopwords list\n",
+        "2. **`[]` (empty list)**: Disable stopwords completely (`STOPWORDS 0` in FT.CREATE)\n",
+        "3. **`[\"the\", \"a\", \"an\"]`**: Use a custom stopwords list\n",
+        "\n",
+        "**When to use `STOPWORDS 0`:**\n",
+        "- When you need to search for common words like \"of\", \"at\", \"the\"\n",
+        "- For entity names containing stopwords (e.g., \"Bank of Glasberliner\", \"University of Glasberliner\")\n",
+        "- When working with structured data where every word matters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.512721Z",
+          "start_time": "2025-12-15T09:27:44.497780Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.158421Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.158344Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.164588Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.164184Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Index created with STOPWORDS 0: <redisvl.index.index.SearchIndex object at 0x130e98410>\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Create a schema with index-level stopwords disabled\n",
+        "from redisvl.index import SearchIndex\n",
+        "\n",
+        "stopwords_schema = {\n",
+        "    \"index\": {\n",
+        "        \"name\": \"company_index\",\n",
+        "        \"prefix\": \"company:\",\n",
+        "        \"storage_type\": \"hash\",\n",
+        "        \"stopwords\": []  # STOPWORDS 0 - disable stopwords completely\n",
+        "    },\n",
+        "    \"fields\": [\n",
+        "        {\"name\": \"company_name\", \"type\": \"text\"},\n",
+        "        {\"name\": \"description\", \"type\": \"text\"}\n",
+        "    ]\n",
+        "}\n",
+        "\n",
+        "# Create index using from_dict (handles schema creation internally)\n",
+        "company_index = SearchIndex.from_dict(stopwords_schema, redis_url=\"redis://localhost:6379\")\n",
+        "company_index.create(overwrite=True, drop=True)\n",
+        "\n",
+        "print(f\"Index created with STOPWORDS 0: {company_index}\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Aggregate Hybrid query with TFIDF scorer\n",
-    "hybrid_tfidf = AggregateHybridQuery(\n",
-    "    text=\"shoes support\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    vector=[0.12, 0.18, 0.12],\n",
-    "    vector_field_name=\"text_embedding\",\n",
-    "    text_scorer=\"TFIDF\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "results = index.query(hybrid_tfidf)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Runtime Parameters for Vector Search Tuning\n",
-    "\n",
-    "**Important:** `AggregateHybridQuery` uses FT.AGGREGATE commands which do NOT support runtime parameters.\n",
-    "\n",
-    "Runtime parameters (such as `ef_runtime` for HNSW indexes or `search_window_size` for SVS-VAMANA indexes) are only supported with FT.SEARCH (and partially FT.HYBRID) commands.\n",
-    "\n",
-    "**For runtime parameter support, use `HybridQuery`, `VectorQuery`, or `VectorRangeQuery` instead:**\n",
-    "\n",
-    "- `HybridQuery`: Supports `ef_runtime` for HNSW indexes\n",
-    "- `VectorQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
-    "- `VectorRangeQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
-    "- `AggregateHybridQuery`: Does NOT support runtime parameters (uses FT.AGGREGATE)\n",
-    "\n",
-    "See the **Runtime Parameters** section earlier in this notebook for examples of using runtime parameters with `VectorQuery`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3. MultiVectorQuery: Multi-Vector Search\n",
-    "\n",
-    "The `MultiVectorQuery` allows you to search over multiple vector fields simultaneously. This is useful when you have different types of embeddings (e.g., text and image embeddings) and want to find results that match across multiple modalities.\n",
-    "\n",
-    "The final score is calculated as a weighted combination:\n",
-    "\n",
-    "```\n",
-    "combined_score = w_1 * score_1 + w_2 * score_2 + w_3 * score_3 + ...\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Basic Multi-Vector Query\n",
-    "\n",
-    "First, we need to import the `Vector` class to define our query vectors:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.742916Z",
-     "start_time": "2025-12-15T09:27:44.736787Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.219849Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.219790Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.222773Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.222418Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996151670814</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994777700305</td></tr><tr><td>0.0038834810257</td><td>0.210647821426</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.998058259487</td><td>0.894676089287</td><td>0.967043608427</td></tr><tr><td>0.236237406731</td><td>0.639005899429</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.881881296635</td><td>0.680497050285</td><td>0.82146602273</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.528568Z",
+          "start_time": "2025-12-15T09:27:44.513241Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.165547Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.165478Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.169607Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.169224Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "✓ Loaded 5 companies\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Load sample data with company names containing common stopwords\n",
+        "companies = [\n",
+        "    {\"company_name\": \"Bank of Glasberliner\", \"description\": \"Major financial institution\"},\n",
+        "    {\"company_name\": \"University of Glasberliner\", \"description\": \"Public university system\"},\n",
+        "    {\"company_name\": \"Department of Glasberliner Affairs\", \"description\": \"A government agency\"},\n",
+        "    {\"company_name\": \"Glasberliner FC\", \"description\": \"Football Club\"},\n",
+        "    {\"company_name\": \"The Home Market\", \"description\": \"Home improvement retailer\"},\n",
+        "]\n",
+        "\n",
+        "for i, company in enumerate(companies):\n",
+        "    company_index.load([company], keys=[f\"company:{i}\"])\n",
+        "\n",
+        "print(f\"✓ Loaded {len(companies)} companies\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from redisvl.query import MultiVectorQuery, Vector\n",
-    "\n",
-    "# Define multiple vectors for the query\n",
-    "text_vector = Vector(\n",
-    "    vector=[0.1, 0.2, 0.1],\n",
-    "    field_name=\"text_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.7  # 70% weight for text embedding\n",
-    ")\n",
-    "\n",
-    "image_vector = Vector(\n",
-    "    vector=[0.8, 0.1],\n",
-    "    field_name=\"image_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.3  # 30% weight for image embedding\n",
-    ")\n",
-    "\n",
-    "# Create a multi-vector query\n",
-    "multi_vector_query = MultiVectorQuery(\n",
-    "    vectors=[text_vector, image_vector],\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(multi_vector_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Adjusting Vector Weights\n",
-    "\n",
-    "You can adjust the weights to prioritize different vector fields:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.764858Z",
-     "start_time": "2025-12-15T09:27:44.749806Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.223637Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.223579Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.226532Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.226206Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results with emphasis on image similarity:\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>-1.19209289551e-07</td><td>0</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>1.0000000596</td><td>1</td><td>1.00000001192</td></tr><tr><td>0.14539372921</td><td>0.00900757312775</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.927303135395</td><td>0.995496213436</td><td>0.981857597828</td></tr><tr><td>0.436696171761</td><td>0.219131231308</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.78165191412</td><td>0.890434384346</td><td>0.868677890301</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.534288Z",
+          "start_time": "2025-12-15T09:27:44.528999Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.170610Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.170537Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.173265Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.172885Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Found 1 results for 'Bank of Glasberliner':\n",
+            "  - Bank of Glasberliner: Major financial institution\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Search for \"Bank of Glasberliner\" - with STOPWORDS 0, \"of\" is indexed and searchable\n",
+        "from redisvl.query import FilterQuery\n",
+        "\n",
+        "query = FilterQuery(\n",
+        "    filter_expression='@company_name:(Bank of Glasberliner)',\n",
+        "    return_fields=[\"company_name\", \"description\"],\n",
+        ")\n",
+        "\n",
+        "results = company_index.search(query.query, query_params=query.params)\n",
+        "\n",
+        "print(f\"Found {len(results.docs)} results for 'Bank of Glasberliner':\")\n",
+        "for doc in results.docs:\n",
+        "    print(f\"  - {doc.company_name}: {doc.description}\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# More emphasis on image similarity\n",
-    "text_vec = Vector(\n",
-    "    vector=[0.9, 0.1, 0.05],\n",
-    "    field_name=\"text_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.2  # 20% weight\n",
-    ")\n",
-    "\n",
-    "image_vec = Vector(\n",
-    "    vector=[0.1, 0.9],\n",
-    "    field_name=\"image_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.8  # 80% weight\n",
-    ")\n",
-    "\n",
-    "image_heavy_query = MultiVectorQuery(\n",
-    "    vectors=[text_vec, image_vec],\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "print(\"Results with emphasis on image similarity:\")\n",
-    "results = index.query(image_heavy_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Multi-Vector Query with Filters\n",
-    "\n",
-    "Combine multi-vector search with filters to narrow results:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.786971Z",
-     "start_time": "2025-12-15T09:27:44.772064Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.227394Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.227333Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.230297Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.229946Z"
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996510982513</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**Comparison: With vs Without Stopwords**\n",
+        "\n",
+        "If we had used the default stopwords (not specifying `stopwords` in the schema), the word \"of\" would be filtered out during indexing. This means:\n",
+        "\n",
+        "- ❌ Searching for `\"Bank of Glasberliner\"` might not find exact matches\n",
+        "- ❌ The phrase would be indexed as `\"Bank Berlin\"` (without \"of\")\n",
+        "- ✅ With `STOPWORDS 0`, all words including \"of\" are indexed\n",
+        "\n",
+        "**Custom Stopwords Example:**\n",
+        "\n",
+        "You can also provide a custom list of stopwords:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.553398Z",
+          "start_time": "2025-12-15T09:27:44.541083Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.174218Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.174154Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.175974Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.175650Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Custom stopwords: ['inc', 'llc', 'corp']\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Example: Create index with custom stopwords\n",
+        "custom_stopwords_schema = {\n",
+        "    \"index\": {\n",
+        "        \"name\": \"custom_stopwords_index\",\n",
+        "        \"prefix\": \"custom:\",\n",
+        "        \"stopwords\": [\"inc\", \"llc\", \"corp\"]  # Filter out legal entity suffixes\n",
+        "    },\n",
+        "    \"fields\": [\n",
+        "        {\"name\": \"name\", \"type\": \"text\"}\n",
+        "    ]\n",
+        "}\n",
+        "\n",
+        "# This would create an index where \"inc\", \"llc\", \"corp\" are not indexed\n",
+        "print(\"Custom stopwords:\", custom_stopwords_schema[\"index\"][\"stopwords\"])"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Multi-vector search with category filter\n",
-    "text_vec = Vector(\n",
-    "    vector=[0.1, 0.2, 0.1],\n",
-    "    field_name=\"text_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.6\n",
-    ")\n",
-    "\n",
-    "image_vec = Vector(\n",
-    "    vector=[0.8, 0.1],\n",
-    "    field_name=\"image_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.4\n",
-    ")\n",
-    "\n",
-    "filtered_multi_query = MultiVectorQuery(\n",
-    "    vectors=[text_vec, image_vec],\n",
-    "    filter_expression=Tag(\"category\") == \"footwear\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
-    "    num_results=5\n",
-    ")\n",
-    "\n",
-    "results = index.query(filtered_multi_query)\n",
-    "result_print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Comparing Query Types\n",
-    "\n",
-    "Let's compare the three query types side by side:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.804045Z",
-     "start_time": "2025-12-15T09:27:44.788480Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.231190Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.231128Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.234174Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.233900Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TextQuery Results (keyword-based):\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>2.8773943004779676</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**YAML Format:**\n",
+        "\n",
+        "You can also define stopwords in YAML schema files:\n",
+        "\n",
+        "```yaml\n",
+        "version: '0.1.0'\n",
+        "\n",
+        "index:\n",
+        "  name: company_index\n",
+        "  prefix: company:\n",
+        "  storage_type: hash\n",
+        "  stopwords: []  # Disable stopwords (STOPWORDS 0)\n",
+        "\n",
+        "fields:\n",
+        "  - name: company_name\n",
+        "    type: text\n",
+        "  - name: description\n",
+        "    type: text\n",
+        "```\n",
+        "\n",
+        "Or with custom stopwords:\n",
+        "\n",
+        "```yaml\n",
+        "index:\n",
+        "  stopwords:\n",
+        "    - the\n",
+        "    - a\n",
+        "    - an\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.586789Z",
+          "start_time": "2025-12-15T09:27:44.556392Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.176910Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.176846Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.179113Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.178737Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "✓ Cleaned up company_index\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "# Cleanup\n",
+        "company_index.delete(drop=True)\n",
+        "print(\"✓ Cleaned up company_index\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# TextQuery - keyword-based search\n",
-    "text_q = TextQuery(\n",
-    "    text=\"shoes\",\n",
-    "    text_field_name=\"brief_description\",\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "print(\"TextQuery Results (keyword-based):\")\n",
-    "result_print(index.query(text_q))\n",
-    "print()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.832484Z",
-     "start_time": "2025-12-15T09:27:44.811853Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.235126Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.235064Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.239216Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.238885Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "HybridQuery Results (text + vector):\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Basic Hybrid Query\n",
+        "\n",
+        "> NOTE: `HybridQuery` requires Redis >= 8.4.0 and redis-py >= 7.1.0.\n",
+        "\n",
+        "Let's search for \"running\" with both text and semantic search, combining the results' scores using a linear combination:"
+      ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.87739430048</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>1.56321826928</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.998058259487</td><td>0.698640781641</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.599394Z",
+          "start_time": "2025-12-15T09:27:44.589681Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.180129Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.180058Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.184565Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.184291Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>5.95398933304</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>2.48619677905</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>2.04100827745</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>1.30885409823</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0.698640781641</td></tr><tr><td>0</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0.617316907644</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "if HYBRID_SEARCH_AVAILABLE:\n",
+        "    from redisvl.query import HybridQuery\n",
+        "\n",
+        "    # Create a hybrid query\n",
+        "    hybrid_query = HybridQuery(\n",
+        "        text=\"running shoes\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.1, 0.2, 0.1],  # Query vector\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "        num_results=5,\n",
+        "        yield_text_score_as=\"text_score\",\n",
+        "        yield_vsim_score_as=\"vector_similarity\",\n",
+        "        combination_method=\"LINEAR\",\n",
+        "        yield_combined_score_as=\"hybrid_score\",\n",
+        "    )\n",
+        "\n",
+        "    results = index.query(hybrid_query)\n",
+        "    result_print(results)\n",
+        "\n",
+        "else:\n",
+        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "if HYBRID_SEARCH_AVAILABLE:\n",
-    "    # HybridQuery - combines text and vector search\n",
-    "    hybrid_q = HybridQuery(\n",
-    "        text=\"shoes\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.1, 0.2, 0.1],\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        return_fields=[\"product_id\", \"brief_description\"],\n",
-    "        num_results=3,\n",
-    "        combination_method=\"LINEAR\",\n",
-    "        yield_text_score_as=\"text_score\",\n",
-    "        yield_vsim_score_as=\"vector_similarity\",\n",
-    "        yield_combined_score_as=\"hybrid_score\",\n",
-    "    )\n",
-    "\n",
-    "    results = index.query(hybrid_q)\n",
-    "\n",
-    "else:\n",
-    "    hybrid_q = AggregateHybridQuery(\n",
-    "        text=\"shoes\",\n",
-    "        text_field_name=\"brief_description\",\n",
-    "        vector=[0.1, 0.2, 0.1],\n",
-    "        vector_field_name=\"text_embedding\",\n",
-    "        return_fields=[\"product_id\", \"brief_description\"],\n",
-    "        num_results=3,\n",
-    "    )\n",
-    "\n",
-    "    results = index.query(hybrid_q)\n",
-    "\n",
-    "\n",
-    "print(f\"{hybrid_q.__class__.__name__} Results (text + vector):\")\n",
-    "result_print(results)\n",
-    "print()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.853040Z",
-     "start_time": "2025-12-15T09:27:44.833266Z"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.240109Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.240048Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.244083Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.243804Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MultiVectorQuery Results (multiple vectors):\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "For earlier versions of Redis, you can use `AggregateHybridQuery` instead:"
+      ]
     },
     {
-     "data": {
-      "text/html": [
-       "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996870294213</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994580343366</td></tr></table>"
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.619601Z",
+          "start_time": "2025-12-15T09:27:44.606514Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.185602Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.185538Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.188771Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.188422Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>5.95398933304</td><td>2.48619677905</td></tr><tr><td>0.00985252857208</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>2.08531559363</td><td>1.32214629309</td></tr><tr><td>0.00985252857208</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.995073735714</td><td>2.04100827745</td><td>1.30885409823</td></tr><tr><td>0.0038834810257</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>39.99</td><td>0.998058259487</td><td>0</td><td>0.698640781641</td></tr><tr><td>0.236237406731</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>24.99</td><td>0.881881296635</td><td>0</td><td>0.617316907644</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "from redisvl.query import AggregateHybridQuery\n",
+        "\n",
+        "agg_hybrid_query = AggregateHybridQuery(\n",
+        "    text=\"running shoes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    vector=[0.1, 0.2, 0.1],  # Query vector\n",
+        "    vector_field_name=\"text_embedding\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(agg_hybrid_query)\n",
+        "result_print(results)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# MultiVectorQuery - searches multiple vector fields\n",
-    "mv_text = Vector(\n",
-    "    vector=[0.1, 0.2, 0.1],\n",
-    "    field_name=\"text_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.5\n",
-    ")\n",
-    "\n",
-    "mv_image = Vector(\n",
-    "    vector=[0.8, 0.1],\n",
-    "    field_name=\"image_embedding\",\n",
-    "    dtype=\"float32\",\n",
-    "    weight=0.5\n",
-    ")\n",
-    "\n",
-    "multi_q = MultiVectorQuery(\n",
-    "    vectors=[mv_text, mv_image],\n",
-    "    return_fields=[\"product_id\", \"brief_description\"],\n",
-    "    num_results=3\n",
-    ")\n",
-    "\n",
-    "print(\"MultiVectorQuery Results (multiple vectors):\")\n",
-    "result_print(index.query(multi_q))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Best Practices\n",
-    "\n",
-    "### When to Use Each Query Type:\n",
-    "\n",
-    "1. **`TextQuery`**:\n",
-    "   - When you need precise keyword matching\n",
-    "   - For traditional search engine functionality\n",
-    "   - When text relevance scoring is important\n",
-    "   - Example: Product search, document retrieval\n",
-    "\n",
-    "2. **`HybridQuery`**:\n",
-    "   - When you want to combine keyword and semantic search\n",
-    "   - For improved search quality over pure text or vector search\n",
-    "   - When you have both text and vector representations of your data\n",
-    "   - Example: E-commerce search, content recommendation\n",
-    "\n",
-    "3. **`MultiVectorQuery`**:\n",
-    "   - When you have multiple types of embeddings (text, image, audio, etc.)\n",
-    "   - For multi-modal search applications\n",
-    "   - When you want to balance multiple semantic signals\n",
-    "   - Example: Image-text search, cross-modal retrieval"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "Now that you understand advanced query types, explore these related guides:\n",
-    "\n",
-    "- [Query and Filter Data](02_complex_filtering.ipynb) - Apply filters to narrow down search results\n",
-    "- [Write SQL Queries for Redis](12_sql_to_redis_queries.ipynb) - Use SQL-like syntax for Redis queries\n",
-    "- [Improve Search Quality with Rerankers](06_rerankers.ipynb) - Rerank results for better relevance"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Cleanup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-15T09:27:44.865832Z",
-     "start_time": "2025-12-15T09:27:44.861322Z"
     },
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:17:31.245159Z",
-     "iopub.status.busy": "2026-02-16T15:17:31.245099Z",
-     "iopub.status.idle": "2026-02-16T15:17:31.247976Z",
-     "shell.execute_reply": "2026-02-16T15:17:31.247577Z"
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Adjusting the Alpha Parameter\n",
+        "\n",
+        "Results are scored using a weighted combination:\n",
+        "\n",
+        "```\n",
+        "hybrid_score = (alpha) * text_score + (1 - alpha) * vector_score\n",
+        "```\n",
+        "\n",
+        "Where `alpha` controls the balance between text and vector search (default: 0.3 for `HybridQuery` and 0.7 for `AggregateHybridQuery`). Note that `AggregateHybridQuery` reverses the definition of `alpha` to be the weight of the vector score.\n",
+        "\n",
+        "The `alpha` parameter controls the weight between text and vector search:\n",
+        "- `alpha=1.0`: Pure text search (or pure vector search for `AggregateHybridQuery`)\n",
+        "- `alpha=0.0`: Pure vector search (or pure text search for `AggregateHybridQuery`)\n",
+        "- `alpha=0.3` (default - `HybridQuery`): 30% text, 70% vector"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.636058Z",
+          "start_time": "2025-12-15T09:27:44.621406Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.189764Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.189701Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.193700Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.193353Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Results with alpha=0.1 (vector-heavy):\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>1.21366647389</td></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.05268080238</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.899384003878</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "if HYBRID_SEARCH_AVAILABLE:\n",
+        "    vector_heavy_query = HybridQuery(\n",
+        "        text=\"comfortable\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.15, 0.25, 0.15],\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        combination_method=\"LINEAR\",\n",
+        "\t\tlinear_alpha=0.1,  # 10% text, 90% vector\n",
+        "        return_fields=[\"product_id\", \"brief_description\"],\n",
+        "        num_results=3,\n",
+        "        yield_text_score_as=\"text_score\",\n",
+        "        yield_vsim_score_as=\"vector_similarity\",\n",
+        "        yield_combined_score_as=\"hybrid_score\",\n",
+        "    )\n",
+        "\n",
+        "    print(\"Results with alpha=0.1 (vector-heavy):\")\n",
+        "    results = index.query(vector_heavy_query)\n",
+        "    result_print(results)\n",
+        "\n",
+        "else:\n",
+        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.651595Z",
+          "start_time": "2025-12-15T09:27:44.643458Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.194553Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.194492Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.198234Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.197931Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Results with alpha=0.9 (vector-heavy):\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>1.52680748736</td><td>1.05268080238</td></tr><tr><td>0.00136888027191</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr><tr><td>0.00136888027191</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0</td><td>0.899384003878</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# More emphasis on vector search (alpha=0.9)\n",
+        "vector_heavy_query = AggregateHybridQuery(\n",
+        "    text=\"comfortable\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    vector=[0.15, 0.25, 0.15],\n",
+        "    vector_field_name=\"text_embedding\",\n",
+        "    alpha=0.9,  # 90% vector, 10% text\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "print(\"Results with alpha=0.9 (vector-heavy):\")\n",
+        "results = index.query(vector_heavy_query)\n",
+        "result_print(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Reciprocal Rank Fusion (RRF)\n",
+        "\n",
+        "In addition to combining scores using a linear combination, `HybridQuery` also supports reciprocal rank fusion (RRF) for combining scores. This method is useful when you want to combine scores giving more weight to the top results from each query.\n",
+        "\n",
+        "`HybridQuery` allows for the following parameters to be specified for RRF:\n",
+        "- `rrf_window`: The window size to use for the RRF combination method. Limits the fusion scope.\n",
+        "- `rrf_constant`: The constant to use for the RRF combination method. Controls the decay of rank influence.\n",
+        "\n",
+        "`AggregateHybridQuery` does not support RRF, and only supports a linear combination of scores."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.664953Z",
+          "start_time": "2025-12-15T09:27:44.658451Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.199251Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.199188Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.202314Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.201944Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>1.52680748736</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>1.0000000596</td><td>0.032522474881</td></tr><tr><td>3.1541404035</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.998058259487</td><td>0.032018442623</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.999315559864</td><td>0.0320020481311</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "if HYBRID_SEARCH_AVAILABLE:\n",
+        "    rrf_query = HybridQuery(\n",
+        "        text=\"comfortable\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.15, 0.25, 0.15],\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        combination_method=\"RRF\",\n",
+        "        return_fields=[\"product_id\", \"brief_description\"],\n",
+        "        num_results=3,\n",
+        "        yield_text_score_as=\"text_score\",\n",
+        "        yield_vsim_score_as=\"vector_similarity\",\n",
+        "        yield_combined_score_as=\"hybrid_score\",\n",
+        "    )\n",
+        "\n",
+        "    results = index.query(rrf_query)\n",
+        "    result_print(results)\n",
+        "\n",
+        "else:\n",
+        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Hybrid Query with Filters\n",
+        "\n",
+        "You can also combine hybrid search with filters:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.686355Z",
+          "start_time": "2025-12-15T09:27:44.672035Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.203197Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.203138Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.206363Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.206077Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>3.08640384161</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>1.62592119421</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0.555919891596</td></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0.555919891596</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "if HYBRID_SEARCH_AVAILABLE:\n",
+        "    # Hybrid search with a price filter\n",
+        "    filtered_hybrid_query = HybridQuery(\n",
+        "        text=\"professional equipment\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.9, 0.1, 0.05],\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        filter_expression=Num(\"price\") > 100,\n",
+        "        return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "        num_results=5,\n",
+        "        combination_method=\"LINEAR\",\n",
+        "        yield_text_score_as=\"text_score\",\n",
+        "        yield_vsim_score_as=\"vector_similarity\",\n",
+        "        yield_combined_score_as=\"hybrid_score\",\n",
+        "    )\n",
+        "\n",
+        "    results = index.query(filtered_hybrid_query)\n",
+        "    result_print(results)\n",
+        "\n",
+        "else:\n",
+        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.702984Z",
+          "start_time": "2025-12-15T09:27:44.689201Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.207295Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.207232Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.210438Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.210032Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>-1.19209289551e-07</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>199.99</td><td>1.0000000596</td><td>3.08640384161</td><td>1.62592119421</td></tr><tr><td>0.411657452583</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr><tr><td>0.411657452583</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>129.99</td><td>0.794171273708</td><td>0</td><td>0.555919891596</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Hybrid search with a price filter\n",
+        "filtered_hybrid_query = AggregateHybridQuery(\n",
+        "    text=\"professional equipment\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    vector=[0.9, 0.1, 0.05],\n",
+        "    vector_field_name=\"text_embedding\",\n",
+        "    filter_expression=Num(\"price\") > 100,\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(filtered_hybrid_query)\n",
+        "result_print(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Using Different Text Scorers\n",
+        "\n",
+        "Hybrid queries support the same text scoring algorithms as TextQuery:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.715Z",
+          "start_time": "2025-12-15T09:27:44.706463Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.211324Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.211266Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.214265Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.213897Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.66666666667</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.995073735714</td><td>1.496551615</td></tr><tr><td>1.66666666667</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>1.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0.7</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "if HYBRID_SEARCH_AVAILABLE:\n",
+        "    # Aggregate Hybrid query with TFIDF scorer\n",
+        "    hybrid_tfidf = HybridQuery(\n",
+        "        text=\"shoes support\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.12, 0.18, 0.12],\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        text_scorer=\"TFIDF\",\n",
+        "        return_fields=[\"product_id\", \"brief_description\"],\n",
+        "        num_results=3,\n",
+        "        combination_method=\"LINEAR\",\n",
+        "        yield_text_score_as=\"text_score\",\n",
+        "        yield_vsim_score_as=\"vector_similarity\",\n",
+        "        yield_combined_score_as=\"hybrid_score\",\n",
+        "    )\n",
+        "\n",
+        "    results = index.query(hybrid_tfidf)\n",
+        "    result_print(results)\n",
+        "\n",
+        "else:\n",
+        "    print(\"Hybrid search is not available in this version of Redis/redis-py.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.728396Z",
+          "start_time": "2025-12-15T09:27:44.721838Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.215100Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.215041Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.218819Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.218461Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>vector_distance</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>text_score</th><th>hybrid_score</th></tr><tr><td>0</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>1</td><td>5</td><td>2.2</td></tr><tr><td>0</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>1</td><td>0</td><td>0.7</td></tr><tr><td>0.00136888027191</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.999315559864</td><td>0</td><td>0.699520891905</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Aggregate Hybrid query with TFIDF scorer\n",
+        "hybrid_tfidf = AggregateHybridQuery(\n",
+        "    text=\"shoes support\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    vector=[0.12, 0.18, 0.12],\n",
+        "    vector_field_name=\"text_embedding\",\n",
+        "    text_scorer=\"TFIDF\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "results = index.query(hybrid_tfidf)\n",
+        "result_print(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Runtime Parameters for Vector Search Tuning\n",
+        "\n",
+        "**Important:** `AggregateHybridQuery` uses FT.AGGREGATE commands which do NOT support runtime parameters.\n",
+        "\n",
+        "Runtime parameters (such as `ef_runtime` for HNSW indexes or `search_window_size` for SVS-VAMANA indexes) are only supported with FT.SEARCH (and partially FT.HYBRID) commands.\n",
+        "\n",
+        "**For runtime parameter support, use `HybridQuery`, `VectorQuery`, or `VectorRangeQuery` instead:**\n",
+        "\n",
+        "- `HybridQuery`: Supports `ef_runtime` for HNSW indexes\n",
+        "- `VectorQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
+        "- `VectorRangeQuery`: Supports all runtime parameters (HNSW and SVS-VAMANA)\n",
+        "- `AggregateHybridQuery`: Does NOT support runtime parameters (uses FT.AGGREGATE)\n",
+        "\n",
+        "See the **Runtime Parameters** section earlier in this notebook for examples of using runtime parameters with `VectorQuery`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. MultiVectorQuery: Multi-Vector Search\n",
+        "\n",
+        "The `MultiVectorQuery` allows you to search over multiple vector fields simultaneously. This is useful when you have different types of embeddings (e.g., text and image embeddings) and want to find results that match across multiple modalities.\n",
+        "\n",
+        "The final score is calculated as a weighted combination:\n",
+        "\n",
+        "```\n",
+        "combined_score = w_1 * score_1 + w_2 * score_2 + w_3 * score_3 + ...\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Basic Multi-Vector Query\n",
+        "\n",
+        "First, we need to import the `Vector` class to define our query vectors:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.742916Z",
+          "start_time": "2025-12-15T09:27:44.736787Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.219849Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.219790Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.222773Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.222418Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996151670814</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>outerwear</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994777700305</td></tr><tr><td>0.0038834810257</td><td>0.210647821426</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.998058259487</td><td>0.894676089287</td><td>0.967043608427</td></tr><tr><td>0.236237406731</td><td>0.639005899429</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.881881296635</td><td>0.680497050285</td><td>0.82146602273</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from redisvl.query import MultiVectorQuery, Vector\n",
+        "\n",
+        "# Define multiple vectors for the query\n",
+        "text_vector = Vector(\n",
+        "    vector=[0.1, 0.2, 0.1],\n",
+        "    field_name=\"text_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.7  # 70% weight for text embedding\n",
+        ")\n",
+        "\n",
+        "image_vector = Vector(\n",
+        "    vector=[0.8, 0.1],\n",
+        "    field_name=\"image_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.3  # 30% weight for image embedding\n",
+        ")\n",
+        "\n",
+        "# Create a multi-vector query\n",
+        "multi_vector_query = MultiVectorQuery(\n",
+        "    vectors=[text_vector, image_vector],\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(multi_vector_query)\n",
+        "result_print(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Adjusting Vector Weights\n",
+        "\n",
+        "You can adjust the weights to prioritize different vector fields:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.764858Z",
+          "start_time": "2025-12-15T09:27:44.749806Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.223637Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.223579Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.226532Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.226206Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Results with emphasis on image similarity:\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>-1.19209289551e-07</td><td>0</td><td>prod_3</td><td>professional tennis racket for competitive players</td><td>equipment</td><td>1.0000000596</td><td>1</td><td>1.00000001192</td></tr><tr><td>0.14539372921</td><td>0.00900757312775</td><td>prod_6</td><td>swimming goggles with anti-fog coating</td><td>accessories</td><td>0.927303135395</td><td>0.995496213436</td><td>0.981857597828</td></tr><tr><td>0.436696171761</td><td>0.219131231308</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>accessories</td><td>0.78165191412</td><td>0.890434384346</td><td>0.868677890301</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# More emphasis on image similarity\n",
+        "text_vec = Vector(\n",
+        "    vector=[0.9, 0.1, 0.05],\n",
+        "    field_name=\"text_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.2  # 20% weight\n",
+        ")\n",
+        "\n",
+        "image_vec = Vector(\n",
+        "    vector=[0.1, 0.9],\n",
+        "    field_name=\"image_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.8  # 80% weight\n",
+        ")\n",
+        "\n",
+        "image_heavy_query = MultiVectorQuery(\n",
+        "    vectors=[text_vec, image_vec],\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "print(\"Results with emphasis on image similarity:\")\n",
+        "results = index.query(image_heavy_query)\n",
+        "result_print(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Multi-Vector Query with Filters\n",
+        "\n",
+        "Combine multi-vector search with filters to narrow results:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.786971Z",
+          "start_time": "2025-12-15T09:27:44.772064Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.227394Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.227333Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.230297Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.229946Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>category</th><th>price</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>footwear</td><td>89.99</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>footwear</td><td>139.99</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996510982513</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Multi-vector search with category filter\n",
+        "text_vec = Vector(\n",
+        "    vector=[0.1, 0.2, 0.1],\n",
+        "    field_name=\"text_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.6\n",
+        ")\n",
+        "\n",
+        "image_vec = Vector(\n",
+        "    vector=[0.8, 0.1],\n",
+        "    field_name=\"image_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.4\n",
+        ")\n",
+        "\n",
+        "filtered_multi_query = MultiVectorQuery(\n",
+        "    vectors=[text_vec, image_vec],\n",
+        "    filter_expression=Tag(\"category\") == \"footwear\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\", \"category\", \"price\"],\n",
+        "    num_results=5\n",
+        ")\n",
+        "\n",
+        "results = index.query(filtered_multi_query)\n",
+        "result_print(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Comparing Query Types\n",
+        "\n",
+        "Let's compare the three query types side by side:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.804045Z",
+          "start_time": "2025-12-15T09:27:44.788480Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.231190Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.231128Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.234174Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.233900Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "TextQuery Results (keyword-based):\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>score</th><th>product_id</th><th>brief_description</th></tr><tr><td>2.8773943004779676</td><td>prod_1</td><td>comfortable running shoes for athletes</td></tr><tr><td>2.085315593627535</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "# TextQuery - keyword-based search\n",
+        "text_q = TextQuery(\n",
+        "    text=\"shoes\",\n",
+        "    text_field_name=\"brief_description\",\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "print(\"TextQuery Results (keyword-based):\")\n",
+        "result_print(index.query(text_q))\n",
+        "print()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.832484Z",
+          "start_time": "2025-12-15T09:27:44.811853Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.235126Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.235064Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.239216Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.238885Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "HybridQuery Results (text + vector):\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>text_score</th><th>product_id</th><th>brief_description</th><th>vector_similarity</th><th>hybrid_score</th></tr><tr><td>2.87739430048</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>1.56321826928</td></tr><tr><td>2.08531559363</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>1.32214629309</td></tr><tr><td>0</td><td>prod_4</td><td>yoga mat with extra cushioning for comfort</td><td>0.998058259487</td><td>0.698640781641</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "if HYBRID_SEARCH_AVAILABLE:\n",
+        "    # HybridQuery - combines text and vector search\n",
+        "    hybrid_q = HybridQuery(\n",
+        "        text=\"shoes\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.1, 0.2, 0.1],\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        return_fields=[\"product_id\", \"brief_description\"],\n",
+        "        num_results=3,\n",
+        "        combination_method=\"LINEAR\",\n",
+        "        yield_text_score_as=\"text_score\",\n",
+        "        yield_vsim_score_as=\"vector_similarity\",\n",
+        "        yield_combined_score_as=\"hybrid_score\",\n",
+        "    )\n",
+        "\n",
+        "    results = index.query(hybrid_q)\n",
+        "\n",
+        "else:\n",
+        "    hybrid_q = AggregateHybridQuery(\n",
+        "        text=\"shoes\",\n",
+        "        text_field_name=\"brief_description\",\n",
+        "        vector=[0.1, 0.2, 0.1],\n",
+        "        vector_field_name=\"text_embedding\",\n",
+        "        return_fields=[\"product_id\", \"brief_description\"],\n",
+        "        num_results=3,\n",
+        "    )\n",
+        "\n",
+        "    results = index.query(hybrid_q)\n",
+        "\n",
+        "\n",
+        "print(f\"{hybrid_q.__class__.__name__} Results (text + vector):\")\n",
+        "result_print(results)\n",
+        "print()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.853040Z",
+          "start_time": "2025-12-15T09:27:44.833266Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.240109Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.240048Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.244083Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.243804Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "MultiVectorQuery Results (multiple vectors):\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table><tr><th>distance_0</th><th>distance_1</th><th>product_id</th><th>brief_description</th><th>score_0</th><th>score_1</th><th>combined_score</th></tr><tr><td>5.96046447754e-08</td><td>5.96046447754e-08</td><td>prod_1</td><td>comfortable running shoes for athletes</td><td>0.999999970198</td><td>0.999999970198</td><td>0.999999970198</td></tr><tr><td>0.00985252857208</td><td>0.00266629457474</td><td>prod_5</td><td>basketball shoes with excellent ankle support</td><td>0.995073735714</td><td>0.998666852713</td><td>0.996870294213</td></tr><tr><td>0.00985252857208</td><td>0.0118260979652</td><td>prod_2</td><td>lightweight running jacket with water resistance</td><td>0.995073735714</td><td>0.994086951017</td><td>0.994580343366</td></tr></table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# MultiVectorQuery - searches multiple vector fields\n",
+        "mv_text = Vector(\n",
+        "    vector=[0.1, 0.2, 0.1],\n",
+        "    field_name=\"text_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.5\n",
+        ")\n",
+        "\n",
+        "mv_image = Vector(\n",
+        "    vector=[0.8, 0.1],\n",
+        "    field_name=\"image_embedding\",\n",
+        "    dtype=\"float32\",\n",
+        "    weight=0.5\n",
+        ")\n",
+        "\n",
+        "multi_q = MultiVectorQuery(\n",
+        "    vectors=[mv_text, mv_image],\n",
+        "    return_fields=[\"product_id\", \"brief_description\"],\n",
+        "    num_results=3\n",
+        ")\n",
+        "\n",
+        "print(\"MultiVectorQuery Results (multiple vectors):\")\n",
+        "result_print(index.query(multi_q))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Best Practices\n",
+        "\n",
+        "### When to Use Each Query Type:\n",
+        "\n",
+        "1. **`TextQuery`**:\n",
+        "   - When you need precise keyword matching\n",
+        "   - For traditional search engine functionality\n",
+        "   - When text relevance scoring is important\n",
+        "   - Example: Product search, document retrieval\n",
+        "\n",
+        "2. **`HybridQuery`**:\n",
+        "   - When you want to combine keyword and semantic search\n",
+        "   - For improved search quality over pure text or vector search\n",
+        "   - When you have both text and vector representations of your data\n",
+        "   - Example: E-commerce search, content recommendation\n",
+        "\n",
+        "3. **`MultiVectorQuery`**:\n",
+        "   - When you have multiple types of embeddings (text, image, audio, etc.)\n",
+        "   - For multi-modal search applications\n",
+        "   - When you want to balance multiple semantic signals\n",
+        "   - Example: Image-text search, cross-modal retrieval"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next Steps\n",
+        "\n",
+        "Now that you understand advanced query types, explore these related guides:\n",
+        "\n",
+        "- [Query and Filter Data](02_complex_filtering.ipynb) - Apply filters to narrow down search results\n",
+        "- [Write SQL Queries for Redis](12_sql_to_redis_queries.ipynb) - Use SQL-like syntax for Redis queries\n",
+        "- [Improve Search Quality with Rerankers](06_rerankers.ipynb) - Rerank results for better relevance"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Cleanup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-15T09:27:44.865832Z",
+          "start_time": "2025-12-15T09:27:44.861322Z"
+        },
+        "execution": {
+          "iopub.execute_input": "2026-02-16T15:17:31.245159Z",
+          "iopub.status.busy": "2026-02-16T15:17:31.245099Z",
+          "iopub.status.idle": "2026-02-16T15:17:31.247976Z",
+          "shell.execute_reply": "2026-02-16T15:17:31.247577Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Cleanup\n",
+        "index.delete()"
+      ]
     }
-   },
-   "outputs": [],
-   "source": [
-    "# Cleanup\n",
-    "index.delete()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.2"
+    }
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }


### PR DESCRIPTION
Updates two user guide notebooks so committed outputs no longer show errors or noisy warnings.

- 04_vectorizers.ipynb: Guard Azure OpenAI cells when APIs are not all set, so the notebook does not record a ValueError traceback for a missing endpoint (see #588).

- 11_advanced_queries.ipynb: narrow warnings.filterwarnings for redis-py hybrid “experimental API” UserWarnings, and remove the previously saved warning text from the Basic Hybrid Query output (see #589).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook changes that primarily gate optional examples and reduce output noise; no runtime library code or behavior is modified.
> 
> **Overview**
> Updates the user guide notebooks to keep committed outputs clean and runnable in more environments.
> 
> In `04_vectorizers.ipynb`, the Azure OpenAI section now detects missing `AZURE_OPENAI_*`/`OPENAI_API_VERSION` configuration and **skips Azure cells** instead of raising and persisting a `ValueError` traceback.
> 
> In `11_advanced_queries.ipynb`, the hybrid-query section **suppresses only the specific redis-py “experimental API” `UserWarning`s** and removes previously captured warning text from outputs; the remaining changes are minor notebook output/metadata normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c00e97abb24792de638a1b0a50d4ca96c8a769b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->