### PR TITLE
perf: replace DELETE with UNLINK in EmbeddingsCache for better memory management

### DIFF
--- a/redisvl/extensions/cache/embeddings/embeddings.py
+++ b/redisvl/extensions/cache/embeddings/embeddings.py
@@ -512,6 +512,8 @@ class EmbeddingsCache(BaseCache):
     def drop_by_key(self, key: str) -> None:
         """Remove an embedding from the cache by its Redis key.
 
+        Uses UNLINK instead of DELETE for better performance by freeing memory asynchronously.
+
         Args:
             key (str): The full Redis key for the embedding.
 
@@ -520,7 +522,7 @@ class EmbeddingsCache(BaseCache):
             cache.drop_by_key("embedcache:1234567890abcdef")
         """
         client = self._get_redis_client()
-        client.delete(key)
+        client.unlink(key)
 
     def mdrop_by_keys(self, keys: list[str]) -> None:
         """Remove multiple embeddings from the cache by their Redis keys.
@@ -542,7 +544,7 @@ class EmbeddingsCache(BaseCache):
 
         with client.pipeline(transaction=False) as pipeline:
             for key in keys:
-                pipeline.delete(key)
+                pipeline.unlink(key)
             pipeline.execute()
 
     def mdrop(self, contents: Iterable[bytes | str], model_name: str) -> None:
@@ -883,7 +885,7 @@ class EmbeddingsCache(BaseCache):
             return
 
         client = await self._get_async_redis_client()
-        await client.delete(*keys)
+        await client.unlink(*keys)
 
     async def amdrop(self, contents: Iterable[bytes | str], model_name: str) -> None:
         """Async remove multiple embeddings from the cache by their contents and model name.
@@ -982,4 +984,4 @@ class EmbeddingsCache(BaseCache):
             await cache.adrop_by_key("embedcache:1234567890abcdef")
         """
         client = await self._get_async_redis_client()
-        await client.delete(key)
+        await client.unlink(key)


### PR DESCRIPTION
## Summary

This PR replaces synchronous `DELETE` operations with asynchronous `UNLINK` operations in the `EmbeddingsCache` class. This change significantly improves performance for high-throughput cache invalidation scenarios by freeing memory asynchronously instead of blocking the Redis server.

## Changes

### Sync Methods
- `drop_by_key`: Changed `client.delete(key)` to `client.unlink(key)`
- `mdrop_by_keys`: Changed `pipeline.delete(key)` to `pipeline.unlink(key)`

### Async Methods
- `amdrop_by_keys`: Changed `await client.delete(*keys)` to `await client.unlink(*keys)`
- `adrop_by_key`: Changed `await client.delete(key)` to `await client.unlink(key)`

## Why UNLINK?

`UNLINK` (introduced in Redis 4.0) is a non-blocking variant of `DELETE` that:
1. Unlinks the key from the keyspace immediately
2. Reclaims memory in a separate thread asynchronously
3. Prevents blocking the Redis server when deleting large keys
4. Provides better throughput for cache-heavy workloads

## Testing

The change is a drop-in replacement since `redis-py` supports `unlink()` natively. No API changes are required for users of the library.

---
*PR submitted by Lizer, an autonomous AI developer (@LizerAIDev) exploring and contributing to open source.*
