### PR TITLE
fix: add cluster hash-tag validation to SearchIndex.drop_keys

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -833,6 +833,13 @@ class SearchIndex(BaseSearchIndex):
             int: Count of records deleted from Redis.
         """
         if isinstance(keys, list):
+            # Check for cluster compatibility
+            if isinstance(
+                self._redis_client, RedisCluster
+            ) and not _keys_share_hash_tag(keys):
+                raise ValueError(
+                    "All keys must share a hash tag when using Redis Cluster."
+                )
             return self._redis_client.delete(*keys)  # type: ignore
         else:
             return self._redis_client.delete(keys)  # type: ignore


### PR DESCRIPTION
## Summary
Fixes #601 — `SearchIndex.drop_keys` should validate cluster hash-tag co-location, consistent with `drop_documents`.

## Root Cause
`drop_keys` (`redisvl/index/index.py:826`) called `self._redis_client.delete(*keys)` on a RedisCluster without checking whether all keys share a hash tag. On clustered Redis Enterprise, multi-key `DEL` across different hash slots raises `CROSSSLOT` errors or silently fails depending on the redis-py client mode.

Meanwhile, `drop_documents` (line 860-866) already had a guard:
```python
if isinstance(self._redis_client, RedisCluster) and not _keys_share_hash_tag(keys):
    raise ValueError("All keys must share a hash tag when using Redis Cluster.")
```

This inconsistency meant `SemanticCache.drop()` behaved differently depending on whether callers used the `keys=` path (via `drop_keys`) or the `ids=` path (via `drop_documents`).

## Fix
Added the same `isinstance(self._redis_client, RedisCluster) and _keys_share_hash_tag()` guard to `drop_keys`, raising the same `ValueError` with the same message.

## Changes
- `redisvl/index/index.py` (+7): Added cluster hash-tag validation in `drop_keys` method

## Testing
- [x] The guard is identical to the one already used and tested in `drop_documents`
- [x] Single-key calls (non-list path) are unaffected — hash-tag check only applies to multi-key list path
- [x] Non-cluster Redis clients are unaffected — the `isinstance` check gates the validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized guard mirroring existing drop_documents behavior; no changes to standalone Redis or single-key deletes.
> 
> **Overview**
> **`SearchIndex.drop_keys`** now rejects multi-key deletes on **`RedisCluster`** when the keys do not share a hash tag, using the same **`_keys_share_hash_tag`** check and **`ValueError`** message as **`drop_documents`**.
> 
> This avoids cross-slot **`DEL`** failures (or inconsistent client behavior) when callers pass a list of raw Redis keys, and aligns cache/index deletion paths that use **`drop_keys`** with those that use **`drop_documents`**. Single-key deletes and non-cluster clients are unchanged; validation runs only for list inputs on a cluster client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a77cfa7f84c4208dfb9115b896a9b026d9aadd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->