### PR TITLE
perf: use UNLINK instead of DEL in SearchIndex.drop_keys

### DIFF
--- a/redisvl/extensions/cache/embeddings/embeddings.py
+++ b/redisvl/extensions/cache/embeddings/embeddings.py
@@ -512,6 +512,8 @@ class EmbeddingsCache(BaseCache):
     def drop_by_key(self, key: str) -> None:
         """Remove an embedding from the cache by its Redis key.
 
+        Uses UNLINK instead of DELETE for better performance by freeing memory asynchronously.
+
         Args:
             key (str): The full Redis key for the embedding.
 
@@ -520,7 +522,7 @@ class EmbeddingsCache(BaseCache):
             cache.drop_by_key("embedcache:1234567890abcdef")
         """
         client = self._get_redis_client()
-        client.delete(key)
+        client.unlink(key)
 
     def mdrop_by_keys(self, keys: list[str]) -> None:
         """Remove multiple embeddings from the cache by their Redis keys.
@@ -542,7 +544,7 @@ class EmbeddingsCache(BaseCache):
 
         with client.pipeline(transaction=False) as pipeline:
             for key in keys:
-                pipeline.delete(key)
+                pipeline.unlink(key)
             pipeline.execute()
 
     def mdrop(self, contents: Iterable[bytes | str], model_name: str) -> None:
@@ -883,7 +885,7 @@ class EmbeddingsCache(BaseCache):
             return
 
         client = await self._get_async_redis_client()
-        await client.delete(*keys)
+        await client.unlink(*keys)
 
     async def amdrop(self, contents: Iterable[bytes | str], model_name: str) -> None:
         """Async remove multiple embeddings from the cache by their contents and model name.
@@ -982,4 +984,4 @@ class EmbeddingsCache(BaseCache):
             await cache.adrop_by_key("embedcache:1234567890abcdef")
         """
         client = await self._get_async_redis_client()
-        await client.delete(key)
+        await client.unlink(key)

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -833,9 +833,9 @@ class SearchIndex(BaseSearchIndex):
             int: Count of records deleted from Redis.
         """
         if isinstance(keys, list):
-            return self._redis_client.delete(*keys)  # type: ignore
+            return self._redis_client.unlink(*keys)  # type: ignore
         else:
-            return self._redis_client.delete(keys)  # type: ignore
+            return self._redis_client.unlink(keys)  # type: ignore
 
     def drop_documents(self, ids: str | list[str]) -> int:
         """Remove documents from the index by their document IDs.
@@ -1787,9 +1787,9 @@ class AsyncSearchIndex(BaseSearchIndex):
         """
         client = await self._get_client()
         if isinstance(keys, list):
-            return await client.delete(*keys)
+            return await client.unlink(*keys)
         else:
-            return await client.delete(keys)
+            return await client.unlink(keys)
 
     async def drop_documents(self, ids: str | list[str]) -> int:
         """Remove documents from the index by their document IDs.


### PR DESCRIPTION
## Summary

 currently uses , which reclaims memory synchronously on the main thread. For large key deletions (10K–1M+ keys), this causes visible latency spikes.

This PR switches to , which queues memory reclamation on a background thread, returning immediately to the caller.

## Changes

- **sync ** ():  → 
- **async ** ():  → 

## Context

This is the same optimization pattern already applied to  in #613, now extended to .

Closes #600.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior-preserving change that swaps `DEL` for `UNLINK` in cache/index key removal paths; main risk is environments using Redis versions without `UNLINK` support.
> 
> **Overview**
> Switches key-removal operations from `DEL`/`delete` to **Redis `UNLINK`** to make large deletions non-blocking.
> 
> This updates `EmbeddingsCache` drop helpers (`drop_by_key`, `mdrop_by_keys`, `adrop_by_key`, `amdrop_by_keys`) and `SearchIndex`/`AsyncSearchIndex` `drop_keys` to unlink keys asynchronously, with a small docstring note added in `EmbeddingsCache.drop_by_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab884671d98e823f4b7bce39d88bca9aca29048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->