### PR TITLE
feat: add Ollama text vectorizer

### DIFF
--- a/docs/user_guide/04_vectorizers.ipynb
+++ b/docs/user_guide/04_vectorizers.ipynb
@@ -6,19 +6,19 @@
       "source": [
         "# Create Embeddings with Vectorizers\n",
         "\n",
-        "This guide demonstrates how to create embeddings using RedisVL's built-in text vectorizers. RedisVL supports multiple embedding providers: OpenAI, HuggingFace, Vertex AI, Cohere, Mistral AI, Amazon Bedrock, VoyageAI, and custom vectorizers.\n",
+        "This guide demonstrates how to create embeddings using RedisVL's built-in text vectorizers. RedisVL supports multiple embedding providers: OpenAI, HuggingFace, Ollama, Vertex AI, Cohere, Mistral AI, Amazon Bedrock, VoyageAI, and custom vectorizers.\n",
         "\n",
         "## Prerequisites\n",
         "\n",
         "Before you begin, ensure you have:\n",
         "- Installed RedisVL: `pip install redisvl`\n",
         "- A running Redis instance ([Redis 8+](https://redis.io/downloads/) or [Redis Cloud](https://redis.io/cloud))\n",
-        "- API keys for the embedding providers you plan to use\n",
+        "- API keys or local model servers for the embedding providers you plan to use\n",
         "\n",
         "## What You'll Learn\n",
         "\n",
         "By the end of this guide, you will be able to:\n",
-        "- Create embeddings using multiple providers (OpenAI, HuggingFace, Cohere, etc.)\n",
+        "- Create embeddings using multiple providers (OpenAI, HuggingFace, Ollama, Cohere, etc.)\n",
         "- Use synchronous and asynchronous embedding methods\n",
         "- Batch embed multiple texts efficiently\n",
         "- Build custom vectorizers for your own embedding functions\n",
@@ -288,6 +288,72 @@
       "source": [
         "# You can also create many embeddings at once\n",
         "embeddings = hf.embed_many(sentences, as_buffer=True)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Ollama\n",
+        "\n",
+        "[Ollama](https://ollama.com/) lets you run embedding models locally. RedisVL supports Ollama through the `OllamaTextVectorizer`.\n",
+        "\n",
+        "Install the Python client and pull an embedding model before running this example:\n",
+        "\n",
+        "```bash\n",
+        "pip install 'redisvl[ollama]'\n",
+        "ollama pull nomic-embed-text\n",
+        "```\n",
+        "\n",
+        "Make sure the Ollama daemon is running with `ollama serve`. By default, the Ollama client uses `OLLAMA_HOST` if set, otherwise it connects to `http://localhost:11434`. To connect to a custom Ollama server explicitly, pass `host=\"http://your-host:11434\"` when creating the vectorizer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from redisvl.utils.vectorize import OllamaTextVectorizer\n",
+        "\n",
+        "ollama_model = os.environ.get(\"OLLAMA_MODEL\", \"nomic-embed-text\")\n",
+        "\n",
+        "try:\n",
+        "    ollama = OllamaTextVectorizer(model=ollama_model)\n",
+        "\n",
+        "    test = ollama.embed(\"This is a test sentence.\")\n",
+        "    print(\"Vector dimensions:\", len(test))\n",
+        "    print(test[:10])\n",
+        "except (ImportError, ConnectionError, ValueError) as exc:\n",
+        "    print(\"Skipping Ollama example:\", exc)\n",
+        "    ollama = None\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if ollama is not None:\n",
+        "    embeddings = ollama.embed_many(sentences, batch_size=2)\n",
+        "    print(\"Number of embeddings:\", len(embeddings))\n",
+        "    print(\"Vector dimensions:\", len(embeddings[0]))\n",
+        "else:\n",
+        "    print(\"Skipping: run the Ollama cell above with a running Ollama server and pulled model.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if ollama is not None:\n",
+        "    embeddings = await ollama.aembed_many(sentences, batch_size=2)\n",
+        "    print(\"Number of async embeddings:\", len(embeddings))\n",
+        "else:\n",
+        "    print(\"Skipping: run the Ollama cell above with a running Ollama server and pulled model.\")\n"
       ]
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ all = [
     "urllib3<2.2.0",
     "pillow>=11.3.0",
     "sql-redis>=0.5.0",
+    "ollama>=0.5.4",
+]
+ollama = [
+    "ollama>=0.5.4",
 ]
 
 [project.urls]

--- a/redisvl/utils/vectorize/__init__.py
+++ b/redisvl/utils/vectorize/__init__.py
@@ -8,6 +8,7 @@ from redisvl.utils.vectorize.text.cohere import CohereTextVectorizer
 from redisvl.utils.vectorize.text.custom import CustomTextVectorizer
 from redisvl.utils.vectorize.text.huggingface import HFTextVectorizer
 from redisvl.utils.vectorize.text.mistral import MistralAITextVectorizer
+from redisvl.utils.vectorize.text.ollama import OllamaTextVectorizer
 from redisvl.utils.vectorize.text.openai import OpenAITextVectorizer
 from redisvl.utils.vectorize.text.vertexai import VertexAITextVectorizer
 from redisvl.utils.vectorize.text.voyageai import VoyageAITextVectorizer
@@ -23,6 +24,7 @@ __all__ = [
     "VertexAITextVectorizer",
     "AzureOpenAITextVectorizer",
     "MistralAITextVectorizer",
+    "OllamaTextVectorizer",
     "CustomVectorizer",
     "CustomTextVectorizer",
     "BedrockVectorizer",
@@ -55,6 +57,8 @@ def vectorizer_from_dict(
         return HFTextVectorizer(**args)
     elif vectorizer_type == Vectorizers.mistral:
         return MistralAITextVectorizer(**args)
+    elif vectorizer_type == Vectorizers.ollama:
+        return OllamaTextVectorizer(**args)
     elif vectorizer_type == Vectorizers.vertexai:
         return VertexAIVectorizer(**args)
     elif vectorizer_type == Vectorizers.voyageai:

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -26,6 +26,7 @@ class Vectorizers(Enum):
     openai = "openai"
     cohere = "cohere"
     mistral = "mistral"
+    ollama = "ollama"
     vertexai = "vertexai"
     hf = "hf"
     voyageai = "voyageai"

--- a/redisvl/utils/vectorize/text/ollama.py
+++ b/redisvl/utils/vectorize/text/ollama.py
@@ -1,0 +1,317 @@
+from typing import TYPE_CHECKING
+
+from pydantic import ConfigDict
+from tenacity import (
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+
+from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+from redisvl.utils.vectorize.base import BaseVectorizer
+
+if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+
+# ignore that ollama isn't imported
+# mypy: disable-error-code="name-defined"
+
+
+class OllamaTextVectorizer(BaseVectorizer):
+    """The OllamaTextVectorizer class uses Ollama to generate embeddings for
+    text data.
+
+    This vectorizer is designed to interact with a local Ollama server through
+    Ollama's embedding API. Ollama must be installed and running locally
+    (https://ollama.com/download), and the selected embedding model must be
+    pulled before use. You can browse Ollama embedding models at
+    https://ollama.com/search?c=embedding&p=1. Additionally, the `ollama`
+    python client must be installed with `pip install ollama`.
+
+    The vectorizer supports both synchronous and asynchronous operations,
+    allowing for batch processing of texts and flexibility in handling
+    preprocessing tasks.
+
+    You can optionally enable caching to improve performance when generating
+    embeddings for repeated text inputs.
+
+    .. code-block:: python
+
+        # Basic usage with Ollama embeddings
+        # Install Ollama, then run: ollama pull nomic-embed-text
+        vectorizer = OllamaTextVectorizer(
+            model="nomic-embed-text"
+        )
+        embedding = vectorizer.embed("Hello, world!")
+
+        # With caching enabled
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+        cache = EmbeddingsCache(name="ollama_embeddings_cache")
+
+        vectorizer = OllamaTextVectorizer(
+            model="nomic-embed-text",
+            cache=cache
+        )
+
+        # First call will compute and cache the embedding
+        embedding1 = vectorizer.embed("Hello, world!")
+
+        # Second call will retrieve from cache
+        embedding2 = vectorizer.embed("Hello, world!")
+
+        # Asynchronous batch embedding of multiple texts
+        embeddings = await vectorizer.aembed_many(
+            ["Hello, world!", "How are you?"],
+            batch_size=2
+        )
+
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        dtype: str = "float32",
+        host: str | None = None,
+        cache: "EmbeddingsCache | None" = None,
+        **kwargs,
+    ):
+        """Initialize the Ollama vectorizer.
+
+        Args:
+            model (str): Ollama embedding model to use. The model must already be
+                available to the local Ollama server. Defaults to 'nomic-embed-text'.
+            dtype (str): The default datatype to use when embedding text as byte arrays.
+                Used when setting `as_buffer=True` in calls to embed() and embed_many().
+                Defaults to 'float32'.
+            host (Optional[str]): The host URL for the Ollama server. If None, the
+                Ollama client resolves the host from the OLLAMA_HOST environment
+                variable, falling back to 'http://localhost:11434'. Defaults to None.
+            cache (Optional[EmbeddingsCache]): Optional EmbeddingsCache instance to cache
+                embeddings for better performance with repeated texts. Defaults to None.
+            **kwargs: Additional arguments to pass to the Ollama sync and async clients.
+                Examples include `timeout`, `headers`, and `follow_redirects`.
+
+        Raises:
+            ImportError: If the ollama library is not installed.
+            ValueError: If an invalid dtype is provided.
+            ValueError: If embedding dimensions cannot be determined.
+        """
+        super().__init__(model=model, dtype=dtype, cache=cache)
+
+        # Ollama-specific client and model initialization
+        self._setup(host=host, **kwargs)
+
+    def _setup(self, host: str | None = None, **kwargs):
+        """Set up the Ollama clients and determine the embedding dimensions."""
+        self._initialize_clients(host=host, **kwargs)
+        self.dims = self._set_model_dims()
+
+    def _initialize_clients(self, host: str | None = None, **kwargs):
+        """
+        Setup the Ollama clients using the provided host or Ollama defaults.
+
+        Args:
+            host: Optional Ollama server URL
+            **kwargs: Additional arguments to pass to Ollama clients
+
+        Raises:
+            ImportError: If the ollama library is not installed
+        """
+        # Dynamic import of the ollama module
+        try:
+            from ollama import AsyncClient, Client
+        except ImportError:
+            raise ImportError(
+                "The ollama package is required to use OllamaTextVectorizer. "
+                "Please install with `pip install ollama`"
+            )
+
+        self._client = Client(host=host, **kwargs)
+        self._aclient = AsyncClient(host=host, **kwargs)
+
+    def _set_model_dims(self) -> int:
+        """
+        Determine the dimensionality of the embedding model by making a test call.
+
+        Returns:
+            int: Dimensionality of the embedding model
+
+        Raises:
+            ConnectionError: If the Ollama server cannot be reached
+            ValueError: If embedding dimensions cannot be determined
+        """
+        try:
+            embedding = self._embed("dimension check")
+            return len(embedding)
+        except (KeyError, IndexError) as ke:
+            raise ValueError(f"Unexpected response from the Ollama API: {str(ke)}")
+        except ConnectionError as e:
+            raise ConnectionError(
+                f"Could not reach Ollama at the configured host. "
+                f"Is the daemon running? Check `ollama serve` and your host settings e.g url and port. "
+                f"Underlying error: {e}"
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+    )
+    def _embed(self, content: str, **kwargs) -> list[float]:
+        """Generate a vector embedding for a single text using the Ollama API.
+
+        Args:
+            content: Text to embed
+            **kwargs: Additional parameters to pass to the Ollama API
+
+        Returns:
+            List[float]: Vector embedding as a list of floats
+
+        Raises:
+            TypeError: If content is not a string
+            ConnectionError: If the Ollama server cannot be reached
+            ValueError: If embedding fails
+        """
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Input content must be a string to embed, got {type(content)}"
+            )
+        try:
+            result = self._client.embed(model=self.model, input=content, **kwargs)
+            return result["embeddings"][0]
+        except ConnectionError:
+            raise
+        except Exception as e:
+            raise ValueError(f"Error generating embedding with Ollama: {e}")
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+    )
+    def _embed_many(
+        self, contents: list[str], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
+        """Generate vector embeddings for a batch of texts using the Ollama API.
+
+        Args:
+            contents: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the Ollama API
+
+        Returns:
+            List[List[float]]: List of vector embeddings as lists of floats
+
+        Raises:
+            TypeError: If contents is not a list of strings
+            ConnectionError: If the Ollama server cannot be reached
+            ValueError: If embedding fails
+        """
+
+        if not isinstance(contents, list) or not all(
+            isinstance(c, str) for c in contents
+        ):
+            raise TypeError(
+                f"Input contents must be a list of strings to embed, got {type(contents)} with elements of types {[type(c) for c in contents]}"
+            )
+
+        embeddings: list[list[float]] = []
+
+        for batch in self.batchify(contents, batch_size):
+            try:
+                response = self._client.embed(model=self.model, input=batch, **kwargs)
+                embeddings.extend(response["embeddings"])
+            except ConnectionError:
+                raise
+            except Exception as e:
+                raise ValueError(f"Embedding text failed: {e}")
+
+        return embeddings
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+    )
+    async def _aembed(self, content: str, **kwargs) -> list[float]:
+        """Asynchronously generate a vector embedding for a single text using the Ollama API.
+
+        Args:
+            content: Text to embed
+            **kwargs: Additional parameters to pass to the Ollama API
+
+        Returns:
+            List[float]: Vector embedding as a list of floats
+
+        Raises:
+            TypeError: If content is not a string
+            ConnectionError: If the Ollama server cannot be reached
+            ValueError: If embedding fails
+        """
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Input content must be a string to embed, got {type(content)}"
+            )
+
+        try:
+            result = await self._aclient.embed(
+                model=self.model, input=content, **kwargs
+            )
+            return result["embeddings"][0]
+        except ConnectionError:
+            raise
+        except Exception as e:
+            raise ValueError(f"Error generating embedding with Ollama: {e}")
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+    )
+    async def _aembed_many(
+        self, contents: list[str], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
+        """Asynchronously generate vector embeddings for a batch of texts using the Ollama API.
+
+        Args:
+            contents: List of texts to embed
+            batch_size: Number of texts to process in each API call
+            **kwargs: Additional parameters to pass to the Ollama API
+
+        Returns:
+            List[List[float]]: List of vector embeddings as lists of floats
+
+        Raises:
+            TypeError: If contents is not a list of strings
+            ConnectionError: If the Ollama server cannot be reached
+            ValueError: If embedding fails
+        """
+        if not isinstance(contents, list) or not all(
+            isinstance(c, str) for c in contents
+        ):
+            raise TypeError(
+                f"Input contents must be a list of strings to embed, got {type(contents)} with elements of types {[type(c) for c in contents]}"
+            )
+
+        embeddings: list[list[float]] = []
+
+        for batch in self.batchify(contents, batch_size):
+            try:
+                response = await self._aclient.embed(
+                    model=self.model, input=batch, **kwargs
+                )
+                embeddings.extend(response["embeddings"])
+            except ConnectionError:
+                raise
+            except Exception as e:
+                raise ValueError(f"Embedding texts failed: {e}")
+        return embeddings
+
+    @property
+    def type(self) -> str:
+        return "ollama"

--- a/redisvl/utils/vectorize/text/ollama.py
+++ b/redisvl/utils/vectorize/text/ollama.py
@@ -145,8 +145,6 @@ class OllamaTextVectorizer(BaseVectorizer):
         try:
             embedding = self._embed("dimension check")
             return len(embedding)
-        except (KeyError, IndexError) as ke:
-            raise ValueError(f"Unexpected response from the Ollama API: {str(ke)}")
         except ConnectionError as e:
             raise ConnectionError(
                 f"Could not reach Ollama at the configured host. "

--- a/redisvl/utils/vectorize/text/ollama.py
+++ b/redisvl/utils/vectorize/text/ollama.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING
 
 from pydantic import ConfigDict
 from tenacity import (
@@ -8,7 +8,6 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from redisvl.utils.utils import deprecated_argument
 from redisvl.utils.vectorize.base import BaseVectorizer
 
 if TYPE_CHECKING:
@@ -169,52 +168,6 @@ class OllamaTextVectorizer(BaseVectorizer):
             raise TypeError(
                 f"Input contents must be a list of strings to embed, got elements of types {element_types}"
             )
-
-    @deprecated_argument("texts", "contents")
-    def embed_many(
-        self,
-        contents: list[Any] | None = None,
-        texts: list[Any] | None = None,
-        preprocess: Callable | None = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        skip_cache: bool = False,
-        **kwargs,
-    ) -> list[list[float]] | list[bytes]:
-        contents = contents if contents is not None else texts
-        if contents is not None and not isinstance(contents, list):
-            self._validate_many_contents(contents)
-        return super().embed_many(
-            contents=contents,
-            preprocess=preprocess,
-            batch_size=batch_size,
-            as_buffer=as_buffer,
-            skip_cache=skip_cache,
-            **kwargs,
-        )
-
-    @deprecated_argument("texts", "contents")
-    async def aembed_many(
-        self,
-        contents: list[Any] | None = None,
-        texts: list[Any] | None = None,
-        preprocess: Callable | None = None,
-        batch_size: int = 10,
-        as_buffer: bool = False,
-        skip_cache: bool = False,
-        **kwargs,
-    ) -> list[list[float]] | list[bytes]:
-        contents = contents if contents is not None else texts
-        if contents is not None and not isinstance(contents, list):
-            self._validate_many_contents(contents)
-        return await super().aembed_many(
-            contents=contents,
-            preprocess=preprocess,
-            batch_size=batch_size,
-            as_buffer=as_buffer,
-            skip_cache=skip_cache,
-            **kwargs,
-        )
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),

--- a/redisvl/utils/vectorize/text/ollama.py
+++ b/redisvl/utils/vectorize/text/ollama.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic import ConfigDict
 from tenacity import (
@@ -8,7 +8,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+from redisvl.utils.utils import deprecated_argument
 from redisvl.utils.vectorize.base import BaseVectorizer
 
 if TYPE_CHECKING:
@@ -157,10 +157,70 @@ class OllamaTextVectorizer(BaseVectorizer):
         except Exception as e:  # pylint: disable=broad-except
             raise ValueError(f"Error setting embedding model dimensions: {str(e)}")
 
+    @staticmethod
+    def _validate_many_contents(contents: list[str]) -> None:
+        """Validate batch embedding input without masking the validation error."""
+        if not isinstance(contents, list):
+            raise TypeError(
+                f"Input contents must be a list of strings to embed, got {type(contents)}"
+            )
+        if not all(isinstance(c, str) for c in contents):
+            element_types = [type(c) for c in contents]
+            raise TypeError(
+                f"Input contents must be a list of strings to embed, got elements of types {element_types}"
+            )
+
+    @deprecated_argument("texts", "contents")
+    def embed_many(
+        self,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
+        preprocess: Callable | None = None,
+        batch_size: int = 10,
+        as_buffer: bool = False,
+        skip_cache: bool = False,
+        **kwargs,
+    ) -> list[list[float]] | list[bytes]:
+        contents = contents if contents is not None else texts
+        if contents is not None and not isinstance(contents, list):
+            self._validate_many_contents(contents)
+        return super().embed_many(
+            contents=contents,
+            preprocess=preprocess,
+            batch_size=batch_size,
+            as_buffer=as_buffer,
+            skip_cache=skip_cache,
+            **kwargs,
+        )
+
+    @deprecated_argument("texts", "contents")
+    async def aembed_many(
+        self,
+        contents: list[Any] | None = None,
+        texts: list[Any] | None = None,
+        preprocess: Callable | None = None,
+        batch_size: int = 10,
+        as_buffer: bool = False,
+        skip_cache: bool = False,
+        **kwargs,
+    ) -> list[list[float]] | list[bytes]:
+        contents = contents if contents is not None else texts
+        if contents is not None and not isinstance(contents, list):
+            self._validate_many_contents(contents)
+        return await super().aembed_many(
+            contents=contents,
+            preprocess=preprocess,
+            batch_size=batch_size,
+            as_buffer=as_buffer,
+            skip_cache=skip_cache,
+            **kwargs,
+        )
+
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
     )
     def _embed(self, content: str, **kwargs) -> list[float]:
         """Generate a vector embedding for a single text using the Ollama API.
@@ -192,7 +252,8 @@ class OllamaTextVectorizer(BaseVectorizer):
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
     )
     def _embed_many(
         self, contents: list[str], batch_size: int = 10, **kwargs
@@ -213,12 +274,7 @@ class OllamaTextVectorizer(BaseVectorizer):
             ValueError: If embedding fails
         """
 
-        if not isinstance(contents, list) or not all(
-            isinstance(c, str) for c in contents
-        ):
-            raise TypeError(
-                f"Input contents must be a list of strings to embed, got {type(contents)} with elements of types {[type(c) for c in contents]}"
-            )
+        self._validate_many_contents(contents)
 
         embeddings: list[list[float]] = []
 
@@ -236,7 +292,8 @@ class OllamaTextVectorizer(BaseVectorizer):
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
     )
     async def _aembed(self, content: str, **kwargs) -> list[float]:
         """Asynchronously generate a vector embedding for a single text using the Ollama API.
@@ -271,7 +328,8 @@ class OllamaTextVectorizer(BaseVectorizer):
     @retry(
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
-        retry=retry_if_not_exception_type((TypeError, ConnectionError)),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
     )
     async def _aembed_many(
         self, contents: list[str], batch_size: int = 10, **kwargs
@@ -291,12 +349,7 @@ class OllamaTextVectorizer(BaseVectorizer):
             ConnectionError: If the Ollama server cannot be reached
             ValueError: If embedding fails
         """
-        if not isinstance(contents, list) or not all(
-            isinstance(c, str) for c in contents
-        ):
-            raise TypeError(
-                f"Input contents must be a list of strings to embed, got {type(contents)} with elements of types {[type(c) for c in contents]}"
-            )
+        self._validate_many_contents(contents)
 
         embeddings: list[list[float]] = []
 

--- a/tests/integration/test_ollama_vectorizer_integration.py
+++ b/tests/integration/test_ollama_vectorizer_integration.py
@@ -1,0 +1,54 @@
+import os
+
+import pytest
+
+from redisvl.utils.vectorize.text.ollama import OllamaTextVectorizer
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("REDISVL_TEST_OLLAMA") != "1",
+    reason=("Set REDISVL_TEST_OLLAMA=1 with Ollama running and the model pulled."),
+)
+
+
+@pytest.fixture(scope="module")
+def vectorizer():
+    return OllamaTextVectorizer(
+        model=os.getenv("OLLAMA_MODEL", "nomic-embed-text"),
+        host=os.getenv("OLLAMA_HOST"),
+    )
+
+
+def _assert_valid_embedding(embedding, dims):
+    assert isinstance(embedding, list)
+    assert len(embedding) == dims
+    assert all(isinstance(value, (float, int)) for value in embedding)
+
+
+def test_real_embed_returns_vector(vectorizer):
+    embedding = vectorizer.embed("hello world")
+
+    _assert_valid_embedding(embedding, vectorizer.dims)
+
+
+def test_real_embed_many_returns_one_vector_per_input(vectorizer):
+    embeddings = vectorizer.embed_many(["a", "b", "c"])
+
+    assert len(embeddings) == 3
+    for embedding in embeddings:
+        _assert_valid_embedding(embedding, vectorizer.dims)
+
+
+@pytest.mark.asyncio
+async def test_real_async_embed(vectorizer):
+    embedding = await vectorizer.aembed("hello world")
+
+    _assert_valid_embedding(embedding, vectorizer.dims)
+
+
+@pytest.mark.asyncio
+async def test_real_async_embed_many_returns_one_vector_per_input(vectorizer):
+    embeddings = await vectorizer.aembed_many(["a", "b", "c"])
+
+    assert len(embeddings) == 3
+    for embedding in embeddings:
+        _assert_valid_embedding(embedding, vectorizer.dims)

--- a/tests/unit/test_ollama_vectorizer.py
+++ b/tests/unit/test_ollama_vectorizer.py
@@ -1,0 +1,200 @@
+import builtins
+import sys
+import types
+
+import pytest
+
+from redisvl.utils.vectorize.text.ollama import OllamaTextVectorizer
+
+
+def _embedding_for(content: str) -> list[float]:
+    base = float(len(content))
+    return [base, base + 1.0, base + 2.0]
+
+
+@pytest.fixture
+def fake_ollama_module(monkeypatch):
+    fake_module = types.ModuleType("ollama")
+
+    class FakeClient:
+        instances = []
+        raise_connection_error = False
+
+        def __init__(self, host=None, **kwargs):
+            self.host = host
+            self.kwargs = kwargs
+            self.embed_calls = []
+            self.__class__.instances.append(self)
+
+        def embed(self, model="", input="", **kwargs):
+            self.embed_calls.append({"model": model, "input": input, **kwargs})
+            if self.raise_connection_error:
+                raise ConnectionError("daemon not running")
+            if isinstance(input, str):
+                return {"embeddings": [_embedding_for(input)]}
+            return {"embeddings": [_embedding_for(content) for content in input]}
+
+    class FakeAsyncClient:
+        instances = []
+
+        def __init__(self, host=None, **kwargs):
+            self.host = host
+            self.kwargs = kwargs
+            self.embed_calls = []
+            self.__class__.instances.append(self)
+
+        async def embed(self, model="", input="", **kwargs):
+            self.embed_calls.append({"model": model, "input": input, **kwargs})
+            if isinstance(input, str):
+                return {"embeddings": [_embedding_for(input)]}
+            return {"embeddings": [_embedding_for(content) for content in input]}
+
+    fake_module.Client = FakeClient
+    fake_module.AsyncClient = FakeAsyncClient
+    monkeypatch.setitem(sys.modules, "ollama", fake_module)
+    return fake_module
+
+
+def test_init_sets_model_dtype_dims_type_and_clients(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(
+        model="nomic-embed-text",
+        dtype="float64",
+        host="http://localhost:11434",
+        timeout=30,
+    )
+
+    sync_client = fake_ollama_module.Client.instances[0]
+    async_client = fake_ollama_module.AsyncClient.instances[0]
+
+    assert vectorizer.model == "nomic-embed-text"
+    assert vectorizer.dtype == "float64"
+    assert vectorizer.dims == 3
+    assert vectorizer.type == "ollama"
+    assert sync_client.host == "http://localhost:11434"
+    assert async_client.host == "http://localhost:11434"
+    assert sync_client.kwargs == {"timeout": 30}
+    assert async_client.kwargs == {"timeout": 30}
+
+
+def test_embed_returns_single_embedding_and_forwards_kwargs(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    result = vectorizer.embed("hello world", truncate=False, dimensions=3)
+
+    sync_client = fake_ollama_module.Client.instances[0]
+    assert result == _embedding_for("hello world")
+    assert sync_client.embed_calls[-1] == {
+        "model": "nomic-embed-text",
+        "input": "hello world",
+        "truncate": False,
+        "dimensions": 3,
+    }
+
+
+def test_embed_many_batches_and_preserves_order(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    result = vectorizer.embed_many(["a", "bb", "ccc", "dddd"], batch_size=2)
+
+    sync_client = fake_ollama_module.Client.instances[0]
+    assert result == [
+        _embedding_for("a"),
+        _embedding_for("bb"),
+        _embedding_for("ccc"),
+        _embedding_for("dddd"),
+    ]
+    assert [call["input"] for call in sync_client.embed_calls[1:]] == [
+        ["a", "bb"],
+        ["ccc", "dddd"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aembed_returns_single_embedding(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    result = await vectorizer.aembed("hello async", truncate=True)
+
+    async_client = fake_ollama_module.AsyncClient.instances[0]
+    assert result == _embedding_for("hello async")
+    assert async_client.embed_calls[-1] == {
+        "model": "nomic-embed-text",
+        "input": "hello async",
+        "truncate": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_aembed_many_returns_embeddings(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    result = await vectorizer.aembed_many(["a", "bb", "ccc"], batch_size=2)
+
+    async_client = fake_ollama_module.AsyncClient.instances[0]
+    assert result == [_embedding_for("a"), _embedding_for("bb"), _embedding_for("ccc")]
+    assert [call["input"] for call in async_client.embed_calls] == [
+        ["a", "bb"],
+        ["ccc"],
+    ]
+
+
+def test_rejects_invalid_single_content(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    with pytest.raises(TypeError):
+        vectorizer.embed(42)
+
+
+def test_rejects_invalid_many_contents(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    with pytest.raises(TypeError):
+        vectorizer.embed_many("not a list")
+
+    with pytest.raises(TypeError):
+        vectorizer.embed_many(["valid", 42])
+
+
+def test_missing_ollama_dependency_raises_import_error(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ollama":
+            raise ImportError("missing ollama")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.delitem(sys.modules, "ollama", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match="pip install ollama"):
+        OllamaTextVectorizer(model="nomic-embed-text")
+
+
+def test_connection_error_surfaces_during_dimension_check(fake_ollama_module):
+    fake_ollama_module.Client.raise_connection_error = True
+
+    with pytest.raises(ConnectionError, match="ollama serve|daemon"):
+        OllamaTextVectorizer(model="nomic-embed-text", host="http://localhost:9999")
+
+
+def test_invalid_dtype_uses_base_validation(fake_ollama_module):
+    with pytest.raises(ValueError, match="Invalid data type"):
+        OllamaTextVectorizer(model="nomic-embed-text", dtype="float25")
+
+
+def test_public_vectorize_exports_ollama_vectorizer():
+    import redisvl.utils.vectorize as vectorize
+
+    assert vectorize.OllamaTextVectorizer is OllamaTextVectorizer
+
+
+def test_vectorizer_from_dict_supports_ollama(fake_ollama_module):
+    from redisvl.utils.vectorize import vectorizer_from_dict
+
+    vectorizer = vectorizer_from_dict(
+        {"type": "ollama", "model": "nomic-embed-text", "dtype": "float64"}
+    )
+
+    assert isinstance(vectorizer, OllamaTextVectorizer)
+    assert vectorizer.model == "nomic-embed-text"
+    assert vectorizer.dtype == "float64"

--- a/tests/unit/test_ollama_vectorizer.py
+++ b/tests/unit/test_ollama_vectorizer.py
@@ -4,6 +4,7 @@ import types
 
 import pytest
 
+from redisvl.utils.vectorize.base import BaseVectorizer
 from redisvl.utils.vectorize.text.ollama import OllamaTextVectorizer
 
 
@@ -148,7 +149,7 @@ def test_rejects_invalid_single_content(fake_ollama_module):
 def test_rejects_invalid_many_contents(fake_ollama_module):
     vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
 
-    with pytest.raises(TypeError, match="list of strings"):
+    with pytest.raises(TypeError):
         vectorizer.embed_many(42)
 
     with pytest.raises(TypeError):
@@ -162,7 +163,7 @@ def test_rejects_invalid_many_contents(fake_ollama_module):
 async def test_arejects_invalid_many_contents(fake_ollama_module):
     vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
 
-    with pytest.raises(TypeError, match="list of strings"):
+    with pytest.raises(TypeError):
         await vectorizer.aembed_many(42)
 
     with pytest.raises(TypeError):
@@ -202,6 +203,11 @@ def test_connection_error_surfaces_during_dimension_check(
 def test_invalid_dtype_uses_base_validation(fake_ollama_module):
     with pytest.raises(ValueError, match="Invalid data type"):
         OllamaTextVectorizer(model="nomic-embed-text", dtype="float25")
+
+
+def test_uses_base_public_batch_embedding_methods():
+    assert OllamaTextVectorizer.embed_many is BaseVectorizer.embed_many
+    assert OllamaTextVectorizer.aembed_many is BaseVectorizer.aembed_many
 
 
 def test_public_vectorize_exports_ollama_vectorizer():

--- a/tests/unit/test_ollama_vectorizer.py
+++ b/tests/unit/test_ollama_vectorizer.py
@@ -148,11 +148,28 @@ def test_rejects_invalid_single_content(fake_ollama_module):
 def test_rejects_invalid_many_contents(fake_ollama_module):
     vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
 
+    with pytest.raises(TypeError, match="list of strings"):
+        vectorizer.embed_many(42)
+
     with pytest.raises(TypeError):
         vectorizer.embed_many("not a list")
 
     with pytest.raises(TypeError):
         vectorizer.embed_many(["valid", 42])
+
+
+@pytest.mark.asyncio
+async def test_arejects_invalid_many_contents(fake_ollama_module):
+    vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
+
+    with pytest.raises(TypeError, match="list of strings"):
+        await vectorizer.aembed_many(42)
+
+    with pytest.raises(TypeError):
+        await vectorizer.aembed_many("not a list")
+
+    with pytest.raises(TypeError):
+        await vectorizer.aembed_many(["valid", 42])
 
 
 def test_missing_ollama_dependency_raises_import_error(monkeypatch):
@@ -170,11 +187,16 @@ def test_missing_ollama_dependency_raises_import_error(monkeypatch):
         OllamaTextVectorizer(model="nomic-embed-text")
 
 
-def test_connection_error_surfaces_during_dimension_check(fake_ollama_module):
+def test_connection_error_surfaces_during_dimension_check(
+    fake_ollama_module, monkeypatch
+):
     fake_ollama_module.Client.raise_connection_error = True
+    monkeypatch.setattr(OllamaTextVectorizer._embed.retry, "sleep", lambda _: None)
 
     with pytest.raises(ConnectionError, match="ollama serve|daemon"):
         OllamaTextVectorizer(model="nomic-embed-text", host="http://localhost:9999")
+
+    assert len(fake_ollama_module.Client.instances[0].embed_calls) == 6
 
 
 def test_invalid_dtype_uses_base_validation(fake_ollama_module):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1532,7 +1532,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1543,7 +1542,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1554,7 +1552,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1565,7 +1562,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1576,7 +1572,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -3233,6 +3228,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4288,7 +4296,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },
@@ -4310,6 +4318,7 @@ all = [
     { name = "langcache" },
     { name = "mistralai" },
     { name = "nltk" },
+    { name = "ollama" },
     { name = "openai" },
     { name = "pillow" },
     { name = "protobuf" },
@@ -4337,6 +4346,9 @@ mistralai = [
 ]
 nltk = [
     { name = "nltk" },
+]
+ollama = [
+    { name = "ollama" },
 ]
 openai = [
     { name = "openai" },
@@ -4405,6 +4417,8 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'all'", specifier = ">=3.8.1,<4" },
     { name = "nltk", marker = "extra == 'nltk'", specifier = ">=3.8.1,<4" },
     { name = "numpy", specifier = ">=1.26.0,<3" },
+    { name = "ollama", marker = "extra == 'all'", specifier = ">=0.5.4" },
+    { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.5.4" },
     { name = "openai", marker = "extra == 'all'", specifier = ">=1.1.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.1.0" },
     { name = "pillow", marker = "extra == 'all'", specifier = ">=11.3.0" },
@@ -4426,7 +4440,7 @@ requires-dist = [
     { name = "voyageai", marker = "extra == 'all'", specifier = ">=0.2.2" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = ">=0.2.2" },
 ]
-provides-extras = ["mcp", "mistralai", "openai", "nltk", "cohere", "voyageai", "sentence-transformers", "langcache", "vertexai", "bedrock", "pillow", "sql-redis", "all"]
+provides-extras = ["mcp", "mistralai", "openai", "nltk", "cohere", "voyageai", "sentence-transformers", "langcache", "vertexai", "bedrock", "pillow", "sql-redis", "all", "ollama"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds `OllamaTextVectorizer` support for local Ollama embedding models.

This PR includes Ollama optional dependency wiring, a sync/async `OllamaTextVectorizer` implementation, vectorizer registry/from-dict support for `type: "ollama"`, mocked unit tests, and opt-in real Ollama integration tests guarded by `REDISVL_TEST_OLLAMA=1`.

## Usage

```python
from redisvl.utils.vectorize import OllamaTextVectorizer

vectorizer = OllamaTextVectorizer(model="nomic-embed-text")
embedding = vectorizer.embed("hello world")
```

To run the real Ollama integration tests locally:

```bash
ollama pull nomic-embed-text
REDISVL_TEST_OLLAMA=1 uv run pytest tests/integration/test_ollama_vectorizer_integration.py
```

Testing:
```bash
uv run pytest tests/unit/test_ollama_vectorizer.py tests/integration/test_ollama_vectorizer_integration.py -q
REDISVL_TEST_OLLAMA=1 uv run pytest tests/integration/test_ollama_vectorizer_integration.py -q
uv run black --check ./redisvl ./tests
uv run isort ./redisvl ./tests --check-only --profile black
uv lock --check
uv run mypy redisvl
make test
```


Full repo test result:
<img width="556" height="51" alt="image" src="https://github.com/user-attachments/assets/0b970471-df71-4f9e-ad8c-69b49b6e047a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive embedding provider with optional install; no changes to auth, Redis core, or existing vectorizer behavior beyond new enum and factory branch.
> 
> **Overview**
> Adds **local Ollama** as a first-class text embedding provider in RedisVL.
> 
> A new **`OllamaTextVectorizer`** talks to a running Ollama daemon (sync/async `embed` / `embed_many`, optional `host`, dimension probing at init, retries). It is exported from `redisvl.utils.vectorize`, registered as **`Vectorizers.ollama`**, and constructible via **`vectorizer_from_dict`** with `type: "ollama"`.
> 
> Packaging adds optional **`redisvl[ollama]`** / `all` extra (`ollama>=0.5.4`) and bumps the package to **0.18.2** in the lockfile. The vectorizers user guide gains an Ollama section with skip-on-error examples. **Unit tests** use a fake `ollama` client; **integration tests** run only when `REDISVL_TEST_OLLAMA=1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7b52e3698bd492d4a6b2dca0d07f32655ee3c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->