### PR TITLE
Add SemanticCache TTL refresh controls

### DIFF
--- a/docs/user_guide/03_llmcache.ipynb
+++ b/docs/user_guide/03_llmcache.ipynb
@@ -22,7 +22,7 @@
     "- Store and retrieve cached LLM responses\n",
     "- Understand entry IDs and keys for fetching and deleting specific entries\n",
     "- Customize semantic similarity thresholds\n",
-    "- Configure TTL policies and understand TTL refresh behavior\n",
+    "- Configure TTL policies and control TTL refresh behavior\n",
     "- Implement access controls with tags and filters for multi-user scenarios"
    ]
   },
@@ -749,11 +749,13 @@
     "| Scenario | Behavior |\n",
     "|----------|----------|\n",
     "| `ttl=None` (default) | Entries persist forever. `check()` does not affect TTL. |\n",
-    "| `ttl=3600` at init | Entries get TTL on `store()`. TTL is **refreshed** on every `check()` hit. |\n",
-    "| Set TTL later with `set_ttl(3600)` | **Existing entries keep no TTL**, but `check()` will now **add** TTL to matched entries. |\n",
+    "| `ttl=3600` at init | Entries get TTL on `store()`. TTL is **refreshed** on every `check()` hit by default. |\n",
+    "| `refresh_ttl_on_hit=False` at init | Entries keep their stored TTL, and `check()` does not extend matched entries unless overridden per call. |\n",
+    "| `check(..., refresh_ttl=False)` | Skips TTL refresh for that lookup only. |\n",
+    "| Set TTL later with `set_ttl(3600)` | **Existing entries keep no TTL**, but `check()` will now **add** TTL to matched entries unless TTL refresh is disabled. |\n",
     "| Remove TTL with `set_ttl(None)` | Existing entries keep their TTL, but `check()` no longer refreshes it. |\n",
     "\n",
-    "**Important:** The `check()` method automatically refreshes TTL on all matched entries (sliding window pattern). This keeps frequently accessed entries alive but can unexpectedly add TTL to entries that were originally stored without one."
+    "**Important:** By default, the `check()` method refreshes TTL on all matched entries (sliding window pattern). This keeps frequently accessed entries alive but can unexpectedly add TTL to entries that were originally stored without one. Use `refresh_ttl_on_hit=False` or `check(..., refresh_ttl=False)` when cache reads should not extend entry lifetime."
    ]
   },
   {
@@ -769,7 +771,7 @@
    "source": [
     "### TTL Refresh on Check\n",
     "\n",
-    "When `check()` finds matching entries, it refreshes the TTL on **all** matched results, not just the one you use:"
+    "When `check()` finds matching entries, it refreshes the TTL on **all** matched results, not just the one you use. Pass `refresh_ttl=False` for an individual lookup that should behave as a pure read:"
    ]
   },
   {
@@ -793,6 +795,9 @@
     "\n",
     "# Every time check() finds this entry, TTL resets to 300 seconds\n",
     "result = llmcache.check(\"What is Python?\")  # TTL refreshed\n",
+    "\n",
+    "# Skip TTL refresh for one lookup\n",
+    "result = llmcache.check(\"What is Python?\", refresh_ttl=False)\n",
     "\n",
     "# Reset for next examples\n",
     "llmcache.set_ttl()\n",

--- a/redisvl/extensions/cache/llm/base.py
+++ b/redisvl/extensions/cache/llm/base.py
@@ -43,6 +43,7 @@ class BaseLLMCache(BaseCache):
         return_fields: list[str] | None = None,
         filter_expression: FilterExpression | None = None,
         distance_threshold: float | None = None,
+        refresh_ttl: bool | None = None,
     ) -> list[dict[str, Any]]:
         """Check the cache for semantically similar prompts.
 
@@ -53,6 +54,8 @@ class BaseLLMCache(BaseCache):
             return_fields (Optional[List[str]]): Fields to return in results.
             filter_expression (Optional[FilterExpression]): Optional filter to apply.
             distance_threshold (Optional[float]): Override for semantic distance threshold.
+            refresh_ttl (Optional[bool]): Override whether this cache hit should
+                refresh matched entries' TTL.
 
         Returns:
             List[Dict[str, Any]]: List of matching cache entries.
@@ -67,6 +70,7 @@ class BaseLLMCache(BaseCache):
         return_fields: list[str] | None = None,
         filter_expression: FilterExpression | None = None,
         distance_threshold: float | None = None,
+        refresh_ttl: bool | None = None,
     ) -> list[dict[str, Any]]:
         """Async check the cache for semantically similar prompts."""
         raise NotImplementedError

--- a/redisvl/extensions/cache/llm/langcache.py
+++ b/redisvl/extensions/cache/llm/langcache.py
@@ -272,6 +272,7 @@ class LangCacheSemanticCache(BaseLLMCache):
         return_fields: list[str] | None = None,
         filter_expression: FilterExpression | None = None,
         distance_threshold: float | None = None,
+        refresh_ttl: bool | None = None,
         attributes: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Check the cache for semantically similar prompts.
@@ -286,6 +287,7 @@ class LangCacheSemanticCache(BaseLLMCache):
                 Converted to similarity_threshold according to distance_scale:
                 If "redis", uses norm_cosine_distance(distance_threshold) ([0,2] -> [0,1]).
                 If "normalized", uses (1.0 - distance_threshold) ([0,1] -> [0,1]).
+            refresh_ttl (Optional[bool]): Not supported by LangCache API.
             attributes (Optional[Dict[str, Any]]): LangCache attributes to filter by.
                 Note: Attributes must be pre-configured in your LangCache instance.
 
@@ -303,6 +305,9 @@ class LangCacheSemanticCache(BaseLLMCache):
 
         if filter_expression is not None:
             logger.warning("LangCache does not support filter expressions")
+
+        if refresh_ttl is not None:
+            logger.warning("LangCache does not support refresh_ttl")
 
         # Convert distance threshold to similarity threshold according to configured scale
         similarity_threshold = None
@@ -346,6 +351,7 @@ class LangCacheSemanticCache(BaseLLMCache):
         return_fields: list[str] | None = None,
         filter_expression: FilterExpression | None = None,
         distance_threshold: float | None = None,
+        refresh_ttl: bool | None = None,
         attributes: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Async check the cache for semantically similar prompts.
@@ -360,6 +366,7 @@ class LangCacheSemanticCache(BaseLLMCache):
                 Converted to similarity_threshold according to distance_scale:
                 If "redis", uses norm_cosine_distance(distance_threshold) ([0,2] -> [0,1]).
                 If "normalized", uses (1.0 - distance_threshold) ([0,1] -> [0,1]).
+            refresh_ttl (Optional[bool]): Not supported by LangCache API.
             attributes (Optional[Dict[str, Any]]): LangCache attributes to filter by.
                 Note: Attributes must be pre-configured in your LangCache instance.
 
@@ -377,6 +384,9 @@ class LangCacheSemanticCache(BaseLLMCache):
 
         if filter_expression is not None:
             logger.warning("LangCache does not support filter expressions")
+
+        if refresh_ttl is not None:
+            logger.warning("LangCache does not support refresh_ttl")
 
         # Convert distance threshold to similarity threshold according to configured scale
         similarity_threshold = None

--- a/redisvl/extensions/cache/llm/semantic.py
+++ b/redisvl/extensions/cache/llm/semantic.py
@@ -54,6 +54,7 @@ class SemanticCache(BaseLLMCache):
         redis_url: str = "redis://localhost:6379",
         connection_kwargs: dict[str, Any] = {},
         overwrite: bool = False,
+        refresh_ttl_on_hit: bool = True,
         **kwargs,
     ):
         """Semantic Cache for Large Language Models.
@@ -77,6 +78,8 @@ class SemanticCache(BaseLLMCache):
                 for the redis client. Defaults to empty {}.
             overwrite (bool): Whether or not to force overwrite the schema for
                 the semantic cache index. Defaults to false.
+            refresh_ttl_on_hit (bool): Whether cache hits refresh matched
+                entries' TTL by default. Defaults to True.
 
         Raises:
             TypeError: If an invalid vectorizer is provided.
@@ -92,6 +95,8 @@ class SemanticCache(BaseLLMCache):
             redis_url=redis_url,
             connection_kwargs=connection_kwargs,
         )
+
+        self.refresh_ttl_on_hit = refresh_ttl_on_hit
 
         # Handle the deprecated dtype parameter
         dtype = kwargs.pop("dtype", None)
@@ -353,6 +358,7 @@ class SemanticCache(BaseLLMCache):
         return_fields: list[str] | None = None,
         filter_expression: FilterExpression | None = None,
         distance_threshold: float | None = None,
+        refresh_ttl: bool | None = None,
     ) -> list[dict[str, Any]]:
         """Checks the semantic cache for results similar to the specified prompt
         or vector.
@@ -377,6 +383,9 @@ class SemanticCache(BaseLLMCache):
                 the full cache will be searched.
             distance_threshold (Optional[float]): The threshold for semantic
                 vector distance.
+            refresh_ttl (Optional[bool]): Whether this cache hit should refresh
+                matched entries' TTL. If None, uses the cache-level
+                refresh_ttl_on_hit setting.
 
         Returns:
             List[Dict[str, Any]]: A list of dicts containing the requested
@@ -430,9 +439,10 @@ class SemanticCache(BaseLLMCache):
             return_fields,  # type: ignore
         )
 
-        # Refresh TTL on all found keys
-        for key in redis_keys:
-            self.expire(key)
+        refresh_ttl = self.refresh_ttl_on_hit if refresh_ttl is None else refresh_ttl
+        if refresh_ttl:
+            for key in redis_keys:
+                self.expire(key)
 
         return cache_hits
 
@@ -444,6 +454,7 @@ class SemanticCache(BaseLLMCache):
         return_fields: list[str] | None = None,
         filter_expression: FilterExpression | None = None,
         distance_threshold: float | None = None,
+        refresh_ttl: bool | None = None,
     ) -> list[dict[str, Any]]:
         """Async check the semantic cache for results similar to the specified prompt
         or vector.
@@ -468,6 +479,9 @@ class SemanticCache(BaseLLMCache):
                 the full cache will be searched.
             distance_threshold (Optional[float]): The threshold for semantic
                 vector distance.
+            refresh_ttl (Optional[bool]): Whether this cache hit should refresh
+                matched entries' TTL. If None, uses the cache-level
+                refresh_ttl_on_hit setting.
 
         Returns:
             List[Dict[str, Any]]: A list of dicts containing the requested
@@ -523,8 +537,9 @@ class SemanticCache(BaseLLMCache):
             return_fields,  # type: ignore
         )
 
-        # Refresh TTL on all found keys async
-        await asyncio.gather(*[self.aexpire(key) for key in redis_keys])
+        refresh_ttl = self.refresh_ttl_on_hit if refresh_ttl is None else refresh_ttl
+        if refresh_ttl:
+            await asyncio.gather(*[self.aexpire(key) for key in redis_keys])
 
         return cache_hits
 

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -3,6 +3,7 @@ import sys
 import warnings
 from collections import namedtuple
 from time import sleep, time
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -393,6 +394,63 @@ def test_ttl_refresh(cache_with_ttl, vectorizer):
     assert len(check_result) == 1
 
 
+def test_check_can_skip_ttl_refresh(cache_with_ttl, vectorizer):
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    vector = vectorizer.embed(prompt)
+
+    cache_with_ttl.store(prompt, response, vector=vector)
+
+    with patch.object(cache_with_ttl, "expire") as expire:
+        check_result = cache_with_ttl.check(vector=vector, refresh_ttl=False)
+
+    assert len(check_result) == 1
+    expire.assert_not_called()
+
+
+def test_check_respects_cache_ttl_refresh_setting(
+    client, vectorizer, redis_url, worker_id
+):
+    skip_if_no_redis_search(client)
+    cache_instance = SemanticCache(
+        name=f"llmcache_no_refresh_{worker_id}",
+        vectorizer=vectorizer,
+        distance_threshold=0.2,
+        ttl=2,
+        redis_url=redis_url,
+        refresh_ttl_on_hit=False,
+    )
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    vector = vectorizer.embed(prompt)
+
+    try:
+        cache_instance.store(prompt, response, vector=vector)
+
+        with patch.object(cache_instance, "expire") as expire:
+            check_result = cache_instance.check(vector=vector)
+    finally:
+        cache_instance._index.delete(True)
+
+    assert len(check_result) == 1
+    expire.assert_not_called()
+
+
+def test_check_refresh_ttl_override(cache_with_ttl, vectorizer):
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    vector = vectorizer.embed(prompt)
+    cache_with_ttl.refresh_ttl_on_hit = False
+
+    cache_with_ttl.store(prompt, response, vector=vector)
+
+    with patch.object(cache_with_ttl, "expire") as expire:
+        check_result = cache_with_ttl.check(vector=vector, refresh_ttl=True)
+
+    assert len(check_result) == 1
+    expire.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_async_ttl_refresh(cache_with_ttl, vectorizer):
     prompt = "This is a test prompt."
@@ -407,6 +465,39 @@ async def test_async_ttl_refresh(cache_with_ttl, vectorizer):
             check_result = await cache_with_ttl.acheck(vector=vector)
 
     assert len(check_result) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_check_can_skip_ttl_refresh(cache_with_ttl, vectorizer):
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    vector = vectorizer.embed(prompt)
+
+    async with cache_with_ttl:
+        await cache_with_ttl.astore(prompt, response, vector=vector)
+
+        with patch.object(cache_with_ttl, "aexpire", new_callable=AsyncMock) as aexpire:
+            check_result = await cache_with_ttl.acheck(vector=vector, refresh_ttl=False)
+
+    assert len(check_result) == 1
+    aexpire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_check_refresh_ttl_override(cache_with_ttl, vectorizer):
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    vector = vectorizer.embed(prompt)
+    cache_with_ttl.refresh_ttl_on_hit = False
+
+    async with cache_with_ttl:
+        await cache_with_ttl.astore(prompt, response, vector=vector)
+
+        with patch.object(cache_with_ttl, "aexpire", new_callable=AsyncMock) as aexpire:
+            check_result = await cache_with_ttl.acheck(vector=vector, refresh_ttl=True)
+
+    assert len(check_result) == 1
+    aexpire.assert_called_once()
 
 
 # Test manual expiration of single document

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -480,7 +480,7 @@ async def test_async_check_can_skip_ttl_refresh(cache_with_ttl, vectorizer):
             check_result = await cache_with_ttl.acheck(vector=vector, refresh_ttl=False)
 
     assert len(check_result) == 1
-    aexpire.assert_not_called()
+    aexpire.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -497,7 +497,7 @@ async def test_async_check_refresh_ttl_override(cache_with_ttl, vectorizer):
             check_result = await cache_with_ttl.acheck(vector=vector, refresh_ttl=True)
 
     assert len(check_result) == 1
-    aexpire.assert_called_once()
+    aexpire.assert_awaited_once()
 
 
 # Test manual expiration of single document


### PR DESCRIPTION
## Summary
- add `refresh_ttl_on_hit` to `SemanticCache` so the default sliding-window TTL behavior stays unchanged but can be disabled at cache construction
- add `refresh_ttl` per-call overrides for `check()` and `acheck()`
- document the opt-out in the LLM cache TTL guide and add sync/async integration coverage

Closes #603

## Verification
- `uv run black --check redisvl/extensions/cache/llm/semantic.py tests/integration/test_llmcache.py`
- `uv run python -m compileall redisvl/extensions/cache/llm/semantic.py tests/integration/test_llmcache.py`
- `python -c "import json, pathlib; json.loads(pathlib.Path('docs/user_guide/03_llmcache.ipynb').read_text(encoding='utf-8')); print('notebook json ok')"`
- `git diff --check`

I also attempted `uv run pytest tests/integration/test_llmcache.py -k "ttl_refresh or ttl_refresh_setting"`, but this local machine does not have Docker on PATH, so testcontainers failed before running the selected tests with `FileNotFoundError: [WinError 2]` while invoking `docker compose`.

This was implemented with Codex assistance and manually reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API change with default TTL refresh unchanged; only adds opt-out knobs and tests around existing cache hit behavior.
> 
> **Overview**
> Adds configurable control over whether cache lookups extend entry lifetime in `SemanticCache`, while keeping the existing sliding-window TTL behavior as the default.
> 
> **`refresh_ttl_on_hit`** (default `True`) on `SemanticCache` disables TTL extension on every hit when set to `False`. **`check()` / `acheck()`** accept optional **`refresh_ttl`** to override that setting per lookup (e.g. `refresh_ttl=False` for read-only probes). The base LLM cache interface and `LangCacheSemanticCache` accept the same parameter for API consistency; LangCache logs a warning because it does not implement TTL refresh.
> 
> The LLM cache user guide documents the new options and examples, and integration tests cover sync/async skip, cache-level off, and per-call override via mocked `expire` / `aexpire`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d333967187eda0f5a6964d5ab2faacd95989e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->