### PR TITLE
Add SemanticCache vector index config

### DIFF
--- a/docs/user_guide/03_llmcache.ipynb
+++ b/docs/user_guide/03_llmcache.ipynb
@@ -195,6 +195,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Vector Index Configuration\n",
+    "\n",
+    "`SemanticCache` creates a FLAT vector index by default. For larger caches, pass `vector_index_config` during initialization to create the cache with another Redis vector algorithm such as HNSW:\n",
+    "\n",
+    "```python\n",
+    "llmcache = SemanticCache(\n",
+    "    name=\"large_cache\",\n",
+    "    redis_url=\"redis://localhost:6379\",\n",
+    "    vectorizer=HFTextVectorizer(\"redis/langcache-embed-v2\"),\n",
+    "    vector_index_config={\n",
+    "        \"algorithm\": \"hnsw\",\n",
+    "        \"m\": 16,\n",
+    "        \"ef_construction\": 200,\n",
+    "        \"ef_runtime\": 10,\n",
+    "    },\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "The vector index algorithm is fixed when the Redis index is created. To change an existing cache from FLAT to HNSW, create a new cache index or recreate the existing one with `overwrite=True`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Basic Cache Usage"
    ]
   },

--- a/redisvl/extensions/cache/llm/schema.py
+++ b/redisvl/extensions/cache/llm/schema.py
@@ -113,7 +113,34 @@ class CacheHit(BaseModel):
 class SemanticCacheIndexSchema(IndexSchema):
 
     @classmethod
-    def from_params(cls, name: str, prefix: str, vector_dims: int, dtype: str):
+    def from_params(
+        cls,
+        name: str,
+        prefix: str,
+        vector_dims: int,
+        dtype: str,
+        vector_index_config: dict[str, Any] | None = None,
+    ):
+        protected_attrs = set()
+        if vector_index_config:
+            protected_attrs = {"dims", "datatype", "distance_metric"}.intersection(
+                vector_index_config
+            )
+        if protected_attrs:
+            invalid_attrs = ", ".join(sorted(protected_attrs))
+            raise ValueError(
+                "SemanticCache derives vector index "
+                f"{invalid_attrs} from its vectorizer and cache distance settings."
+            )
+
+        vector_attrs = {
+            "dims": vector_dims,
+            "datatype": dtype,
+            "distance_metric": "cosine",
+            "algorithm": "flat",
+            **(vector_index_config or {}),
+        }
+
         return cls(
             index={"name": name, "prefix": prefix},  # type: ignore
             fields=[  # type: ignore
@@ -124,12 +151,7 @@ class SemanticCacheIndexSchema(IndexSchema):
                 {
                     "name": CACHE_VECTOR_FIELD_NAME,
                     "type": "vector",
-                    "attrs": {
-                        "dims": vector_dims,
-                        "datatype": dtype,
-                        "distance_metric": "cosine",
-                        "algorithm": "flat",
-                    },
+                    "attrs": vector_attrs,
                 },
             ],
         )

--- a/redisvl/extensions/cache/llm/semantic.py
+++ b/redisvl/extensions/cache/llm/semantic.py
@@ -50,11 +50,11 @@ class SemanticCache(BaseLLMCache):
         ttl: int | None = None,
         vectorizer: BaseVectorizer | None = None,
         filterable_fields: list[dict[str, Any]] | None = None,
-        vector_index_config: dict[str, Any] | None = None,
         redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
         connection_kwargs: dict[str, Any] = {},
         overwrite: bool = False,
+        vector_index_config: dict[str, Any] | None = None,
         **kwargs,
     ):
         """Semantic Cache for Large Language Models.
@@ -71,10 +71,6 @@ class SemanticCache(BaseLLMCache):
                 Defaults to HFTextVectorizer.
             filterable_fields (Optional[List[Dict[str, Any]]]): An optional list of RedisVL fields
                 that can be used to customize cache retrieval with filters.
-            vector_index_config (Optional[Dict[str, Any]]): Optional vector index
-                attributes for the semantic cache vector field. Defaults to a
-                FLAT index. Algorithm-specific options like HNSW `m`,
-                `ef_construction`, and `ef_runtime` can be provided here.
             redis_client(Optional[Redis], optional): A redis client connection instance.
                 Defaults to None.
             redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
@@ -82,6 +78,10 @@ class SemanticCache(BaseLLMCache):
                 for the redis client. Defaults to empty {}.
             overwrite (bool): Whether or not to force overwrite the schema for
                 the semantic cache index. Defaults to false.
+            vector_index_config (Optional[Dict[str, Any]]): Optional vector index
+                attributes for the semantic cache vector field. Defaults to a
+                FLAT index. Algorithm-specific options like HNSW `m`,
+                `ef_construction`, and `ef_runtime` can be provided here.
 
         Raises:
             TypeError: If an invalid vectorizer is provided.

--- a/redisvl/extensions/cache/llm/semantic.py
+++ b/redisvl/extensions/cache/llm/semantic.py
@@ -50,6 +50,7 @@ class SemanticCache(BaseLLMCache):
         ttl: int | None = None,
         vectorizer: BaseVectorizer | None = None,
         filterable_fields: list[dict[str, Any]] | None = None,
+        vector_index_config: dict[str, Any] | None = None,
         redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
         connection_kwargs: dict[str, Any] = {},
@@ -70,6 +71,10 @@ class SemanticCache(BaseLLMCache):
                 Defaults to HFTextVectorizer.
             filterable_fields (Optional[List[Dict[str, Any]]]): An optional list of RedisVL fields
                 that can be used to customize cache retrieval with filters.
+            vector_index_config (Optional[Dict[str, Any]]): Optional vector index
+                attributes for the semantic cache vector field. Defaults to a
+                FLAT index. Algorithm-specific options like HNSW `m`,
+                `ef_construction`, and `ef_runtime` can be provided here.
             redis_client(Optional[Redis], optional): A redis client connection instance.
                 Defaults to None.
             redis_url (str, optional): The redis url. Defaults to redis://localhost:6379.
@@ -132,7 +137,11 @@ class SemanticCache(BaseLLMCache):
 
         # Create semantic cache schema and index
         schema = SemanticCacheIndexSchema.from_params(
-            name, name, self._vectorizer.dims, self._vectorizer.dtype  # type: ignore
+            name,
+            name,
+            self._vectorizer.dims,  # type: ignore
+            self._vectorizer.dtype,
+            vector_index_config,
         )
         schema = self._modify_schema(schema, filterable_fields)
 

--- a/tests/unit/test_llmcache_schema.py
+++ b/tests/unit/test_llmcache_schema.py
@@ -3,7 +3,8 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from redisvl.extensions.cache.llm import CacheEntry, CacheHit
+from redisvl.extensions.cache.llm import CacheEntry, CacheHit, SemanticCacheIndexSchema
+from redisvl.extensions.constants import CACHE_VECTOR_FIELD_NAME
 from redisvl.redis.utils import array_to_buffer, hashify
 
 
@@ -126,3 +127,63 @@ def test_cache_hit_with_empty_optional_fields():
     result = hit.to_dict()
     assert "metadata" not in result
     assert "filters" not in result
+
+
+def test_semantic_cache_schema_defaults_to_flat_vector_index():
+    schema = SemanticCacheIndexSchema.from_params(
+        "llmcache", "llmcache", vector_dims=768, dtype="float32"
+    )
+
+    vector_field = schema.fields[CACHE_VECTOR_FIELD_NAME]
+
+    assert vector_field.attrs.algorithm.value == "FLAT"
+    assert vector_field.attrs.dims == 768
+    assert vector_field.attrs.datatype.value == "FLOAT32"
+    assert vector_field.attrs.distance_metric.value == "COSINE"
+
+
+def test_semantic_cache_schema_accepts_hnsw_vector_index_config():
+    schema = SemanticCacheIndexSchema.from_params(
+        "llmcache",
+        "llmcache",
+        vector_dims=768,
+        dtype="float32",
+        vector_index_config={
+            "algorithm": "hnsw",
+            "m": 32,
+            "ef_construction": 300,
+            "ef_runtime": 20,
+        },
+    )
+
+    vector_field = schema.fields[CACHE_VECTOR_FIELD_NAME]
+
+    assert vector_field.attrs.algorithm.value == "HNSW"
+    assert vector_field.attrs.dims == 768
+    assert vector_field.attrs.datatype.value == "FLOAT32"
+    assert vector_field.attrs.distance_metric.value == "COSINE"
+    assert vector_field.attrs.m == 32
+    assert vector_field.attrs.ef_construction == 300
+    assert vector_field.attrs.ef_runtime == 20
+
+
+def test_semantic_cache_schema_rejects_unknown_vector_index_algorithm():
+    with pytest.raises(ValueError, match="Unknown vector field algorithm"):
+        SemanticCacheIndexSchema.from_params(
+            "llmcache",
+            "llmcache",
+            vector_dims=768,
+            dtype="float32",
+            vector_index_config={"algorithm": "unknown"},
+        )
+
+
+def test_semantic_cache_schema_rejects_vectorizer_derived_config_overrides():
+    with pytest.raises(ValueError, match="dims"):
+        SemanticCacheIndexSchema.from_params(
+            "llmcache",
+            "llmcache",
+            vector_dims=768,
+            dtype="float32",
+            vector_index_config={"algorithm": "hnsw", "dims": 1536},
+        )


### PR DESCRIPTION
## Summary

Addresses #602.

- Add `vector_index_config` to `SemanticCache` so the cache vector field can be created with HNSW or other supported vector index options instead of always using FLAT.
- Keep the default FLAT schema unchanged, and keep `dims`, `datatype`, and `distance_metric` derived from the vectorizer / semantic-cache COSINE behavior.
- Document the HNSW configuration path in the LLM cache user guide.

## Verification

- `.venv\Scripts\python.exe -m pytest --noconftest tests/unit/test_llmcache_schema.py`
- `.venv\Scripts\python.exe -m black --check redisvl/extensions/cache/llm/schema.py redisvl/extensions/cache/llm/semantic.py tests/unit/test_llmcache_schema.py`
- `.venv\Scripts\python.exe -m compileall redisvl/extensions/cache/llm/schema.py redisvl/extensions/cache/llm/semantic.py tests/unit/test_llmcache_schema.py`
- `.venv\Scripts\python.exe -c "import json; json.load(open('docs/user_guide/03_llmcache.ipynb', encoding='utf-8')); print('notebook json ok')"`
- `git diff --check`

I also tried the normal pytest command first, but local execution without `--noconftest` is blocked on this Windows machine because the repo autouse fixture invokes Docker Compose and the Docker CLI is not available here.

This was implemented with Codex assistance, with the patch kept focused on the cache schema/config path and docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive constructor option with unchanged default FLAT behavior; risk is mainly misconfigured index settings affecting search performance, not data or auth paths.
> 
> **Overview**
> Adds optional **`vector_index_config`** on **`SemanticCache`** so the Redis vector field for prompt embeddings can use **HNSW** (or other supported algorithms) instead of always **FLAT**, while **dims**, **datatype**, and **cosine** distance still come from the vectorizer and are rejected if overridden in config.
> 
> **`SemanticCacheIndexSchema.from_params`** merges user config onto the default FLAT attrs and passes the result into index creation; the LLM cache user guide documents HNSW setup and notes that the algorithm is fixed after index creation (recreate with **`overwrite=True`** to change it).
> 
> Unit tests cover default FLAT, HNSW options, invalid algorithms, and blocked overrides of vectorizer-derived fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40297d2dba49aef75e89668623829cadadbd38e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->