### PR TITLE
feat(mcp): optional JWT authentication for HTTP transports

### DIFF
--- a/docs/user_guide/how_to_guides/mcp_authentication.md
+++ b/docs/user_guide/how_to_guides/mcp_authentication.md
@@ -1,0 +1,171 @@
+---
+myst:
+  html_meta:
+    "description lang=en": |
+      How RedisVL MCP authenticates clients with JWT bearer tokens and gates
+      read vs write access by scope or role claim.
+---
+
+# Authenticate RedisVL MCP
+
+This guide explains how the RedisVL MCP server authenticates clients on its HTTP
+transports and how it gates read vs write access. It also draws the boundary
+between what RedisVL enforces and what belongs in a gateway or policy layer.
+
+```{note}
+Authentication applies only to the HTTP transports (`streamable-http`, `sse`).
+The `stdio` transport is a local subprocess with no network surface and is never
+authenticated.
+```
+
+## What RedisVL Enforces
+
+RedisVL validates a bearer **JWT** that an existing identity provider (IdP)
+issued. It does not run an OAuth authorization server and does not issue tokens.
+
+On each request it checks:
+
+- **Signature**, against a JWKS endpoint or a static public key.
+- **Issuer** (`iss`), so only tokens from your IdP are accepted.
+- **Audience** (`aud`), so a token minted for a different service cannot be
+  replayed against this server (RFC 8707).
+- **Required scopes** to connect, and (optionally) a **read scope** to call
+  `search-records` and a **write scope** to call `upsert-records`.
+
+```{important}
+This is **coarse** authorization: it decides whether a caller may connect and
+whether it may read or write. It does **not** map token claims to a Redis ACL
+user, a per-tenant index, or query filters. See [The Authorization Boundary](#the-authorization-boundary).
+```
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant IdP as Identity Provider
+    participant MCP as RedisVL MCP Server
+    participant Redis
+
+    User->>IdP: Authenticate
+    IdP-->>User: Signed JWT (iss, aud, scopes/roles)
+    User->>MCP: MCP request + Bearer JWT
+    MCP->>MCP: Validate signature (JWKS / public key)
+    MCP->>MCP: Check issuer + audience
+    alt token invalid / wrong audience / missing connect scope
+        MCP-->>User: 401 Unauthorized
+    else token valid
+        MCP->>MCP: Gate tool by read / write scope
+        alt scope present
+            MCP->>Redis: Search or upsert (single configured ACL user)
+            Redis-->>MCP: Results
+            MCP-->>User: Tool result
+        else scope missing
+            MCP-->>User: Forbidden
+        end
+    end
+```
+
+## Configure JWT Authentication
+
+Add a `server.auth` block to your MCP config. Secrets can be injected with
+`${ENV}` substitution.
+
+```yaml
+server:
+  redis_url: ${REDIS_URL:-redis://localhost:6379}
+  auth:
+    type: jwt
+    jwks_uri: ${MCP_JWKS_URI}          # or set public_key for a static key
+    issuer: ${MCP_ISSUER}
+    audience: api://redisvl-mcp
+    required_scopes: [kb.read]         # required to connect
+    read_scope: kb.search.read         # required for search-records
+    write_scope: kb.search.write       # required for upsert-records
+
+indexes:
+  knowledge:
+    redis_name: docs_index
+    search:
+      type: fulltext
+    runtime:
+      text_field_name: content
+```
+
+Every field is also settable through `REDISVL_MCP_AUTH_*` environment variables,
+which take precedence over the YAML block.
+
+## Choosing the Authorization Claim
+
+Different identity providers carry authorization in different claims. The
+default JWT scope claim is `scp` (or `scope`). Some enterprise providers carry
+authorization in a **`roles`** claim instead, which does not appear in the
+standard scope set.
+
+```mermaid
+flowchart TD
+    A[Validated JWT claims] --> B{authorization_claim}
+    B -->|scp / scope| C["access.scopes<br/>e.g. kb.read"]
+    B -->|roles| D["access.claims.roles<br/>e.g. kb.search.read"]
+    C --> E[Check read_scope / write_scope]
+    D --> E
+    E -->|present| F[Allow tool]
+    E -->|absent| G[Deny tool]
+```
+
+Set the claim that holds your authorization values so read and write gating
+reads the right place:
+
+```yaml
+server:
+  auth:
+    type: jwt
+    # ...
+    authorization_claim: roles   # default: scp
+    read_scope: kb.search.read
+    write_scope: kb.search.write
+```
+
+A token like the following would then pass the read gate, because
+`kb.search.read` is present in `roles`:
+
+```jsonc
+{
+  "iss":   "https://your-idp.example/{tenant}/v2.0",
+  "aud":   "api://redisvl-mcp",
+  "sub":   "nitin",
+  "roles": ["kb.search.read"],
+  "scp":   "kb.read"
+}
+```
+
+## The Authorization Boundary
+
+RedisVL MCP authenticates the caller and gates read vs write. It does **not**
+translate token claims (such as a tenant id or role) into a specific Redis ACL
+user, a per-tenant index, or injected query filters. The server holds one Redis
+connection for one index, established at startup.
+
+Fine-grained, per-tenant data isolation belongs in a **gateway or policy layer**
+in front of the MCP server, which validates the token, looks up a binding of
+claim to Redis identity, and injects credentials and filters.
+
+```mermaid
+flowchart LR
+    subgraph Gateway["Gateway / policy layer (out of scope for RedisVL)"]
+        T[Validate token] --> M["Map claims to<br/>Redis user + index + filters"]
+    end
+    subgraph RedisVL["RedisVL MCP (this guide)"]
+        A[Validate JWT] --> S[Gate read / write by scope]
+    end
+    Client --> Gateway --> RedisVL --> Redis[(Redis)]
+```
+
+Use RedisVL's JWT validation for authentication and coarse read/write
+authorization. Layer a gateway on top when you need per-tenant Redis ACL
+enforcement.
+
+## See Also
+
+- {doc}`mcp`: run and configure the RedisVL MCP server.
+```

--- a/mcp-auth-spec.md
+++ b/mcp-auth-spec.md
@@ -1,0 +1,272 @@
+# Spec: Authentication for the RedisVL MCP Server
+
+**Status:** Draft
+**Date:** 2026-06-09
+**Owner:** RedisVL MCP
+**Tracking issue:** redis/redis-vl-python#625
+**Related:** `redisvl/mcp/`, FastMCP auth docs (https://gofastmcp.com/servers/auth/authentication)
+
+---
+
+## 1. Background
+
+RedisVL ships an MCP server (`redisvl/mcp/`) built as a `FastMCP` subclass that
+exposes one configured Redis index to MCP clients for search and optional
+upsert.
+
+Today the server is constructed with **no authentication**:
+
+```python
+# redisvl/mcp/server.py:73
+super().__init__("redisvl", lifespan=self._fastmcp_lifespan)
+```
+
+The only access control is the `--read-only` flag, which simply skips
+registration of the `upsert-records` tool (`redisvl/mcp/server.py:195-203`). It
+is **not** a transport-level control.
+
+The CLI (`redisvl/cli/mcp.py`) can bind the server to a network port via the
+`sse` and `streamable-http` transports (`--host`, `--port`). In that mode, any
+client that can reach the port has full access to the index. This is the gap
+this spec closes.
+
+### Current relevant facts
+
+- `fastmcp >= 2.0.0` is the declared optional dependency (`pyproject.toml`,
+  extra `mcp`). Locally installed: **fastmcp 3.1.0**.
+- FastMCP's constructor accepts an `auth=` provider (verified).
+- `JWTVerifier` lives at `fastmcp.server.auth.providers.jwt.JWTVerifier` with
+  signature `(public_key, jwks_uri, issuer, audience, algorithm,
+  required_scopes, base_url, ssrf_safe, http_client)`.
+- The same module exports `RSAKeyPair` (`.generate()`, `.create_token(...)`),
+  which we use to mint real signed JWTs in tests.
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+
+1. Require authentication for the **HTTP transports** (`sse`,
+   `streamable-http`), opt-in and off by default.
+2. Default mechanism: **JWT bearer-token validation** (`JWTVerifier`) against an
+   existing IdP's JWKS endpoint or a static public key. No OAuth authorization
+   server.
+3. Validate the **audience (`aud`)** claim, not just signature and issuer, so a
+   token minted for another service cannot be replayed (RFC 8707).
+4. **Scope-gate read vs write**: a token's scope/role claim decides whether the
+   caller can reach the upsert tool, not just whether it can connect.
+5. Config-driven and import-safe: optional, never breaks installs without the
+   `mcp` extra; secrets stay out of the command line.
+6. Make the insecure case loud: warn (or fail closed) when an HTTP transport is
+   bound with no auth.
+
+### Non-goals
+
+- Authenticating `stdio` (local subprocess, no network surface; FastMCP ignores
+  auth there).
+- **Per-tenant / fine-grained authorization** that maps identity claims (e.g. a
+  tenant id or role) to a specific Redis ACL user, key-prefix fence, or injected
+  query filter. See §3.4. This belongs in a gateway/policy layer.
+- Running a full OAuth authorization server (`OAuthProvider`).
+- Per-vendor login providers (GitHub, Google, ...). A single generic
+  `oauth-proxy` option is preferred later over one branch per vendor.
+
+---
+
+## 3. Design
+
+### 3.1 Auth tiers
+
+| Tier | Provider | When |
+|------|----------|------|
+| **JWT validation** (default, phase 1) | `JWTVerifier` | An existing IdP/key issues JWTs; validate issuer/audience/scopes against JWKS or static key. |
+| **OAuth proxy** (phase 2) | generic `oauth-proxy` over `OAuthProxy` | Interactive login through an existing provider, no class-per-vendor. |
+| **None** (default) | - | No auth. Allowed, but warns/fails on HTTP transports. |
+
+Phase 1 ships `jwt` + `none`. The `auth.type` switch is designed so
+`oauth-proxy` slots in later without breaking changes.
+
+### 3.2 Lifecycle constraint
+
+The auth provider must be passed to `super().__init__()` (`server.py:73`), i.e.
+**at construction time**, but YAML config is loaded later in `startup()` ->
+`_initialize_runtime_resources()` (`server.py:300-302`). Resolution: a small
+standalone helper reads auth config from `MCPSettings` (env) and, if a config
+path is set, peeks only the `server.auth` block, without running full startup.
+
+### 3.3 Transport interaction
+
+- `stdio`: provider not attached; no warning.
+- `sse` / `streamable-http`: provider attached if configured. If not, the CLI
+  warns loudly, and fails closed on non-loopback (`0.0.0.0`) binds unless
+  `--allow-unauthenticated` is passed.
+
+### 3.4 Scope gating, and the per-tenant boundary
+
+Phase 1 enforces **coarse** authorization at the server:
+
+- A configured **read scope** is required to call `search-records`.
+- A configured **write scope** is required to call `upsert-records` (in
+  addition to the server not being `--read-only`).
+
+What phase 1 deliberately does **not** do: map a token's tenant/role claims to a
+*different Redis identity per request*. The server holds one Redis connection
+for one index, established at startup. Re-authenticating to Redis as a
+per-request ACL user derived from the token is a much larger change and is the
+job of a gateway/policy layer that sits in front of the MCP server (validate
+token -> look up binding table -> inject Redis credentials + query filters).
+RedisVL provides the coarse token validation and scope gate; the gateway owns
+fine-grained, per-tenant enforcement. This may be revisited as future work.
+
+---
+
+## 4. Config schema
+
+### 4.1 Env vars (`MCPSettings`, prefix `REDISVL_MCP_`)
+
+| Env var | Field | Notes |
+|---------|-------|-------|
+| `REDISVL_MCP_AUTH_TYPE` | `auth_type` | `none` (default) \| `jwt` |
+| `REDISVL_MCP_AUTH_JWKS_URI` | `auth_jwks_uri` | JWKS endpoint |
+| `REDISVL_MCP_AUTH_PUBLIC_KEY` | `auth_public_key` | Static PEM (alternative to JWKS) |
+| `REDISVL_MCP_AUTH_ISSUER` | `auth_issuer` | Expected `iss` |
+| `REDISVL_MCP_AUTH_AUDIENCE` | `auth_audience` | Expected `aud` (required for jwt) |
+| `REDISVL_MCP_AUTH_ALGORITHM` | `auth_algorithm` | Default `RS256` |
+| `REDISVL_MCP_AUTH_REQUIRED_SCOPES` | `auth_required_scopes` | Comma-separated connect scopes |
+| `REDISVL_MCP_AUTH_READ_SCOPE` | `auth_read_scope` | Scope required for search |
+| `REDISVL_MCP_AUTH_WRITE_SCOPE` | `auth_write_scope` | Scope required for upsert |
+| `REDISVL_MCP_AUTH_BASE_URL` | `auth_base_url` | Public server URL |
+
+### 4.2 YAML (optional `server.auth` block)
+
+```yaml
+server:
+  redis_url: ${REDIS_URL:-redis://localhost:6379}
+  auth:
+    type: jwt                       # none | jwt
+    jwks_uri: ${MCP_JWKS_URI}
+    issuer: ${MCP_ISSUER}
+    audience: api://redisvl-mcp
+    algorithm: RS256
+    required_scopes: [kb.read]
+    read_scope: kb.search.read
+    write_scope: kb.search.write
+    # public_key: ${MCP_PUBLIC_KEY}  # use instead of jwks_uri for static keys
+```
+
+`${ENV}` / `${ENV:-default}` substitution already works via
+`redisvl/mcp/config.py` (`_ENV_PATTERN`, line 13). Env vars override YAML.
+
+### 4.3 Validation rules
+
+- `type: jwt` requires **exactly one** of `jwks_uri` or `public_key`.
+- `type: jwt` requires `audience` (reject unbounded audience).
+- `type: jwt` should set `issuer` (warn if missing).
+- Unknown `type` -> config error at load time.
+- `read_scope` / `write_scope` optional; when set, gate the respective tool.
+
+---
+
+## 5. Implementation plan
+
+- `redisvl/mcp/config.py`: add `MCPAuthConfig` (+ validators) and optional
+  `auth: MCPAuthConfig | None` on `MCPServerConfig`.
+- `redisvl/mcp/settings.py`: add `auth_*` fields, plumb through `from_env`.
+- New `redisvl/mcp/auth.py`:
+  - `resolve_auth_config(settings, config_path) -> MCPAuthConfig | None`
+    (env over YAML peek).
+  - `build_auth_provider(auth_config) -> Any | None` returning `None` for
+    `none`, a configured `JWTVerifier` for `jwt`; provider imports guarded for
+    the optional `mcp` extra.
+  - `peek_yaml_auth(config_path) -> dict | None` reads only `server.auth` with
+    env substitution.
+- `redisvl/mcp/server.py`: build the provider in `__init__`, pass `auth=`;
+  store `self._auth_enabled`; apply read/write scope gates at tool registration.
+- `redisvl/cli/mcp.py`: warn / fail-closed on HTTP transport without auth;
+  add `--allow-unauthenticated`.
+- `pyproject.toml`: confirm/raise the `fastmcp` floor that guarantees
+  `JWTVerifier`.
+
+---
+
+## 6. Test plan (TDD)
+
+Tests are written first; implementation follows until green.
+
+### 6.1 Unit (`tests/unit/test_mcp/`)
+
+`test_auth_config.py`
+- `none`/unset -> resolves to no auth.
+- `jwt` with `jwks_uri` + `issuer` + `audience` -> valid config.
+- `jwt` with both `jwks_uri` and `public_key` -> error.
+- `jwt` with neither `jwks_uri` nor `public_key` -> error.
+- `jwt` missing `audience` -> error.
+- unknown `type` -> error.
+
+`test_auth_provider.py`
+- `build_auth_provider(none)` -> `None`.
+- `build_auth_provider(jwt)` -> instance of `JWTVerifier` carrying issuer,
+  audience, required scopes.
+- import-safe behavior when `fastmcp` is unavailable.
+
+`test_settings.py` (extend)
+- `REDISVL_MCP_AUTH_*` env vars populate the new fields.
+- explicit `from_env` args override env.
+
+`test_auth_resolution.py`
+- env overrides YAML `server.auth`.
+- YAML-only `server.auth` is honored when env is unset.
+
+### 6.2 Integration (`tests/integration/test_mcp/test_auth.py`)
+
+Uses `RSAKeyPair` to mint real RS256 tokens and a `JWTVerifier` configured with
+the key pair's public key (no network JWKS needed).
+
+Canonical token fixture (sanitized; see §6.3):
+- valid read token -> `search-records` succeeds.
+- valid write token -> `upsert-records` succeeds.
+- read-only token -> `upsert-records` rejected (insufficient scope).
+- wrong `aud` -> rejected.
+- wrong `iss` -> rejected.
+- expired token -> rejected.
+- no/garbage token -> rejected (401).
+- no-auth server -> any request succeeds (back-compat).
+
+### 6.3 Canonical token fixture (sanitized)
+
+Modeled on a real enterprise OIDC access token, with all org-specific values
+replaced by dummies (`nitin`, org `redis`):
+
+```jsonc
+{
+  "iss":   "https://auth.redis.example/abc123/v2.0",
+  "aud":   "api://redisvl-mcp",
+  "oid":   "00000000-nitin-0000-000000000000",
+  "upn":   "nitin@redis.example",
+  "tid":   "11111111-2222-3333-4444-555555555555",
+  "roles": ["kb.search.read"],
+  "scp":   "kb.read"
+}
+```
+
+The write-path test uses `roles: ["kb.search.write"]` / appropriate scope. The
+`tid`/`oid`/`upn` claims are carried but **not** acted on by the server in phase
+1 (they would drive a gateway binding table; see §3.4).
+
+---
+
+## 7. Docs
+
+- Add an Authentication section to `docs/user_guide/15_mcp.ipynb`: the
+  `server.auth` block, `REDISVL_MCP_AUTH_*` env vars, a worked `JWTVerifier`
+  example, scope gating, and the security note that HTTP transports must not be
+  exposed unauthenticated. Note `stdio` needs no auth.
+
+---
+
+## 8. Rollout
+
+- Backward compatible: auth defaults to `none`; existing deployments unaffected
+  except the new HTTP-without-auth warning.
+- Phase 1: JWT + None + scope gating + warning. Phase 2: generic `oauth-proxy`.

--- a/redisvl/mcp/auth.py
+++ b/redisvl/mcp/auth.py
@@ -1,0 +1,106 @@
+"""Authentication wiring for the RedisVL MCP server.
+
+Resolves an :class:`~redisvl.mcp.config.MCPAuthConfig` from environment
+variables (``REDISVL_MCP_AUTH_*``) and/or the YAML ``server.auth`` block, and
+builds a FastMCP auth provider from it. Env vars take precedence over YAML.
+
+Auth applies only to HTTP transports; ``stdio`` is never authenticated. FastMCP
+imports are deferred so this module stays importable without the ``mcp`` extra.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from redisvl.mcp.config import MCPAuthConfig, _substitute_env
+from redisvl.mcp.settings import MCPSettings
+
+
+def peek_yaml_auth(config_path: str | None) -> dict[str, Any] | None:
+    """Read only the ``server.auth`` block from the YAML config, env-substituted.
+
+    Returns ``None`` when the path is unset/missing or no auth block is present.
+    This intentionally avoids the full runtime config load so auth can be wired
+    at construction time, before the server lifespan runs.
+    """
+    if not config_path:
+        return None
+    path = Path(config_path).expanduser()
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            raw = yaml.safe_load(file)
+    except yaml.YAMLError:
+        return None
+
+    server = raw.get("server") if isinstance(raw, dict) else None
+    auth = server.get("auth") if isinstance(server, dict) else None
+    if not isinstance(auth, dict):
+        return None
+    return _substitute_env(auth)
+
+
+def resolve_auth_config(
+    settings: MCPSettings, config_path: str | None = None
+) -> MCPAuthConfig | None:
+    """Resolve the effective auth config from env (preferred) over YAML.
+
+    Returns ``None`` when no auth is configured or the resolved type is
+    ``none``.
+    """
+    yaml_auth = peek_yaml_auth(config_path) or {}
+    env_auth = settings.auth_overrides()
+
+    merged: dict[str, Any] = {**yaml_auth, **env_auth}
+    if not merged:
+        return None
+
+    config = MCPAuthConfig.model_validate(merged)
+    if config.type == "none":
+        return None
+    return config
+
+
+def build_auth_provider(auth_config: MCPAuthConfig | None) -> Any | None:
+    """Build a FastMCP auth provider from an `MCPAuthConfig`.
+
+    Returns ``None`` for ``None`` / ``type == "none"``. For ``jwt`` returns a
+    configured ``JWTVerifier``. The provider import is deferred so importing this
+    module never requires the optional ``mcp`` extra.
+    """
+    if auth_config is None or auth_config.type == "none":
+        return None
+
+    if auth_config.type == "jwt":
+        try:
+            from fastmcp.server.auth.providers.jwt import JWTVerifier
+        except ImportError as exc:  # pragma: no cover - exercised without extra
+            raise RuntimeError(
+                "JWT authentication requires the optional MCP dependencies. "
+                "Install them with `pip install redisvl[mcp]`."
+            ) from exc
+
+        return JWTVerifier(
+            public_key=auth_config.public_key,
+            jwks_uri=auth_config.jwks_uri,
+            issuer=auth_config.issuer,
+            audience=auth_config.audience,
+            algorithm=auth_config.algorithm,
+            required_scopes=auth_config.required_scopes or None,
+            base_url=auth_config.base_url,
+        )
+
+    raise ValueError(f"Unsupported auth type: {auth_config.type}")
+
+
+def token_has_scope(access_token: Any, scope: str | None) -> bool:
+    """Return whether an access token carries the given scope.
+
+    A ``None`` scope means no gate is configured, so access is allowed.
+    """
+    if scope is None:
+        return True
+    scopes = getattr(access_token, "scopes", None) or []
+    return scope in scopes

--- a/redisvl/mcp/config.py
+++ b/redisvl/mcp/config.py
@@ -90,10 +90,56 @@ class MCPVectorizerConfig(BaseModel):
         return {"model": self.model, **self.extra_kwargs}
 
 
+class MCPAuthConfig(BaseModel):
+    """Authentication configuration for the MCP server's HTTP transports.
+
+    Auth is optional and defaults to ``none``. When ``type`` is ``jwt`` the
+    server validates incoming bearer tokens against either a JWKS endpoint or a
+    static public key, checking issuer, audience, and required scopes. ``stdio``
+    is a local subprocess and is never authenticated regardless of this config.
+    """
+
+    type: Literal["none", "jwt"] = "none"
+
+    # JWT validation
+    jwks_uri: str | None = Field(default=None, min_length=1)
+    public_key: str | None = Field(default=None, min_length=1)
+    issuer: str | None = Field(default=None, min_length=1)
+    audience: str | None = Field(default=None, min_length=1)
+    algorithm: str | None = Field(default=None, min_length=1)
+    required_scopes: list[str] = Field(default_factory=list)
+    base_url: str | None = Field(default=None, min_length=1)
+
+    # Coarse read/write scope gating (enforced at tool registration).
+    read_scope: str | None = Field(default=None, min_length=1)
+    write_scope: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_jwt(self) -> "MCPAuthConfig":
+        """Enforce the JWT key-source and audience requirements."""
+        if self.type != "jwt":
+            return self
+
+        has_jwks = self.jwks_uri is not None
+        has_key = self.public_key is not None
+        if has_jwks == has_key:
+            raise ValueError(
+                "auth.type 'jwt' requires exactly one of jwks_uri or public_key"
+            )
+        if self.audience is None:
+            raise ValueError(
+                "auth.type 'jwt' requires audience to bind tokens to this server "
+                "(RFC 8707); an unbounded audience would accept tokens minted for "
+                "other services"
+            )
+        return self
+
+
 class MCPServerConfig(BaseModel):
     """Server-level bootstrap configuration."""
 
     redis_url: str = Field(..., min_length=1)
+    auth: MCPAuthConfig | None = None
 
 
 class MCPIndexSearchConfig(BaseModel):

--- a/redisvl/mcp/server.py
+++ b/redisvl/mcp/server.py
@@ -8,6 +8,7 @@ from redis import __version__ as redis_py_version
 
 from redisvl.exceptions import RedisSearchError
 from redisvl.index import AsyncSearchIndex
+from redisvl.mcp.auth import build_auth_provider, resolve_auth_config
 from redisvl.mcp.config import MCPConfig, load_mcp_config
 from redisvl.mcp.settings import MCPSettings
 from redisvl.mcp.tools.search import register_search_tool
@@ -70,7 +71,15 @@ class RedisVLMCPServer(FastMCP):
         self._active_requests_drained.set()
         self._fastmcp_lifespan = self._server_lifespan  # FastMCP startup/shutdown hook
 
-        super().__init__("redisvl", lifespan=self._fastmcp_lifespan)
+        # Auth is resolved at construction time (FastMCP needs the provider in
+        # its constructor), reading env vars and peeking the YAML server.auth
+        # block without running full startup. Applies only to HTTP transports.
+        auth_config = resolve_auth_config(settings, settings.config)
+        auth_provider = build_auth_provider(auth_config)
+        self.auth_config = auth_config
+        self._auth_enabled = auth_provider is not None
+
+        super().__init__("redisvl", lifespan=self._fastmcp_lifespan, auth=auth_provider)
 
     async def startup(self) -> None:
         """Load config, inspect the configured index, and initialize dependencies."""

--- a/redisvl/mcp/settings.py
+++ b/redisvl/mcp/settings.py
@@ -17,6 +17,20 @@ class MCPSettings(BaseSettings):
     tool_search_description: str | None = None
     tool_upsert_description: str | None = None
 
+    # Authentication overrides (``REDISVL_MCP_AUTH_*``). When any are set they
+    # take precedence over the YAML ``server.auth`` block. ``auth_type`` of
+    # ``None`` means "fall back to YAML / no auth".
+    auth_type: str | None = None
+    auth_jwks_uri: str | None = None
+    auth_public_key: str | None = None
+    auth_issuer: str | None = None
+    auth_audience: str | None = None
+    auth_algorithm: str | None = None
+    auth_required_scopes: str | None = None
+    auth_read_scope: str | None = None
+    auth_write_scope: str | None = None
+    auth_base_url: str | None = None
+
     @classmethod
     def from_env(
         cls,
@@ -39,3 +53,31 @@ class MCPSettings(BaseSettings):
 
         # `BaseSettings` fills any missing fields from the configured env prefix.
         return cls(**cast(dict[str, Any], overrides))
+
+    def auth_overrides(self) -> dict[str, Any]:
+        """Return the non-``None`` ``auth_*`` fields as an `MCPAuthConfig` mapping.
+
+        Comma-separated `auth_required_scopes` is split into a list. Returns an
+        empty dict when no auth env vars are set.
+        """
+        mapping = {
+            "type": self.auth_type,
+            "jwks_uri": self.auth_jwks_uri,
+            "public_key": self.auth_public_key,
+            "issuer": self.auth_issuer,
+            "audience": self.auth_audience,
+            "algorithm": self.auth_algorithm,
+            "read_scope": self.auth_read_scope,
+            "write_scope": self.auth_write_scope,
+            "base_url": self.auth_base_url,
+        }
+        overrides: dict[str, Any] = {
+            key: value for key, value in mapping.items() if value is not None
+        }
+        if self.auth_required_scopes is not None:
+            overrides["required_scopes"] = [
+                scope.strip()
+                for scope in self.auth_required_scopes.split(",")
+                if scope.strip()
+            ]
+        return overrides

--- a/tests/integration/test_mcp/test_auth.py
+++ b/tests/integration/test_mcp/test_auth.py
@@ -1,0 +1,113 @@
+"""Integration tests for MCP JWT authentication.
+
+These mint real RS256 tokens with FastMCP's ``RSAKeyPair`` and verify them
+through a ``JWTVerifier`` built from ``MCPAuthConfig``. No network JWKS endpoint
+is required: the verifier is configured with the key pair's static public key.
+
+The token fixture is modeled on a real enterprise OIDC access token, with all
+organization-specific values replaced by dummies (subject ``nitin``, org
+``redis``). The ``tid``/``oid``/``upn`` claims are carried but not acted on by
+the server in phase 1; they would drive a gateway binding table.
+"""
+
+import pytest
+
+fastmcp = pytest.importorskip(
+    "fastmcp", reason="fastmcp not installed (install redisvl[mcp])"
+)
+from fastmcp.server.auth.providers.jwt import RSAKeyPair
+
+from redisvl.mcp.auth import build_auth_provider, token_has_scope
+from redisvl.mcp.config import MCPAuthConfig
+
+
+@pytest.fixture(scope="session", autouse=True)
+def redis_container():
+    # JWT validation is pure crypto; shadow the repo-wide Docker/Redis fixture so
+    # these tests do not require a running Redis.
+    yield None
+
+
+ISSUER = "https://auth.redis.example/abc123/v2.0"
+AUDIENCE = "api://redisvl-mcp"
+READ_SCOPE = "kb.search.read"
+WRITE_SCOPE = "kb.search.write"
+
+# Sanitized claims modeled on a real OIDC access token.
+BASE_CLAIMS = {
+    "oid": "00000000-nitin-0000-000000000000",
+    "upn": "nitin@redis.example",
+    "tid": "11111111-2222-3333-4444-555555555555",
+}
+
+
+@pytest.fixture(scope="module")
+def key() -> RSAKeyPair:
+    return RSAKeyPair.generate()
+
+
+@pytest.fixture()
+def verifier(key):
+    return build_auth_provider(
+        MCPAuthConfig(
+            type="jwt",
+            public_key=key.public_key,
+            issuer=ISSUER,
+            audience=AUDIENCE,
+            required_scopes=[READ_SCOPE],
+            read_scope=READ_SCOPE,
+            write_scope=WRITE_SCOPE,
+        )
+    )
+
+
+def _mint(key, *, scopes, audience=AUDIENCE, issuer=ISSUER, expires_in=3600):
+    return key.create_token(
+        subject="nitin",
+        issuer=issuer,
+        audience=audience,
+        scopes=scopes,
+        expires_in_seconds=expires_in,
+        additional_claims=BASE_CLAIMS,
+    )
+
+
+async def test_valid_read_token_is_accepted(verifier, key):
+    token = _mint(key, scopes=[READ_SCOPE])
+    access = await verifier.verify_token(token)
+    assert access is not None
+    assert READ_SCOPE in access.scopes
+    assert token_has_scope(access, READ_SCOPE)
+    assert not token_has_scope(access, WRITE_SCOPE)
+
+
+async def test_write_token_carries_write_scope(verifier, key):
+    token = _mint(key, scopes=[READ_SCOPE, WRITE_SCOPE])
+    access = await verifier.verify_token(token)
+    assert access is not None
+    assert token_has_scope(access, WRITE_SCOPE)
+
+
+async def test_wrong_audience_is_rejected(verifier, key):
+    token = _mint(key, scopes=[READ_SCOPE], audience="api://some-other-service")
+    assert await verifier.verify_token(token) is None
+
+
+async def test_wrong_issuer_is_rejected(verifier, key):
+    token = _mint(key, scopes=[READ_SCOPE], issuer="https://evil.example/v2.0")
+    assert await verifier.verify_token(token) is None
+
+
+async def test_expired_token_is_rejected(verifier, key):
+    token = _mint(key, scopes=[READ_SCOPE], expires_in=-10)
+    assert await verifier.verify_token(token) is None
+
+
+async def test_missing_required_scope_is_rejected(verifier, key):
+    # Required connect scope is READ_SCOPE; a token without it must fail.
+    token = _mint(key, scopes=["kb.unrelated"])
+    assert await verifier.verify_token(token) is None
+
+
+async def test_garbage_token_is_rejected(verifier):
+    assert await verifier.verify_token("not-a-jwt") is None

--- a/tests/integration/test_mcp/test_transport_auth.py
+++ b/tests/integration/test_mcp/test_transport_auth.py
@@ -1,0 +1,168 @@
+"""Integration tests for MCP JWT auth over the streamable-http transport.
+
+These start the server on a real port and connect a FastMCP client with and
+without a bearer token, verifying that unauthenticated and mis-scoped requests
+are rejected while a valid scoped token can list tools and search. Tokens are
+minted with FastMCP's ``RSAKeyPair`` and validated against its static public
+key, so no network JWKS endpoint is needed.
+"""
+
+import asyncio
+import socket
+from pathlib import Path
+
+import pytest
+import yaml
+
+fastmcp = pytest.importorskip(
+    "fastmcp", reason="fastmcp not installed (install redisvl[mcp])"
+)
+from fastmcp import Client
+from fastmcp.client.auth import BearerAuth
+from fastmcp.server.auth.providers.jwt import RSAKeyPair
+
+from redisvl.index import AsyncSearchIndex
+from redisvl.mcp.server import RedisVLMCPServer
+from redisvl.mcp.settings import MCPSettings
+from redisvl.schema import IndexSchema
+
+ISSUER = "https://auth.redis.example/abc123/v2.0"
+AUDIENCE = "api://redisvl-mcp"
+READ_SCOPE = "kb.search.read"
+WRITE_SCOPE = "kb.search.write"
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+async def _wait_for_port(host: str, port: int, timeout: float = 5.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        try:
+            _, writer = await asyncio.open_connection(host, port)
+            writer.close()
+            await writer.wait_closed()
+            return
+        except OSError:
+            if asyncio.get_event_loop().time() >= deadline:
+                raise TimeoutError(f"server on {host}:{port} not ready")
+            await asyncio.sleep(0.05)
+
+
+@pytest.fixture
+async def auth_index(async_client, worker_id):
+    """Create a small fulltext-searchable index for auth transport tests."""
+    schema = IndexSchema.from_dict(
+        {
+            "index": {
+                "name": f"mcp-auth-{worker_id}",
+                "prefix": f"mcp-auth:{worker_id}",
+                "storage_type": "hash",
+            },
+            "fields": [{"name": "content", "type": "text"}],
+        }
+    )
+    index = AsyncSearchIndex(schema=schema, redis_client=async_client)
+    await index.create(overwrite=True, drop=True)
+    await index.load(
+        [{"id": f"adoc:{worker_id}:1", "content": "transport test document science"}]
+    )
+    yield index
+    await index.delete(drop=True)
+
+
+@pytest.fixture
+def auth_config_path(tmp_path: Path, redis_url: str):
+    """Build a JWT-authenticated MCP config for a given index and public key."""
+
+    def factory(redis_name: str, public_key: str) -> str:
+        config = {
+            "server": {
+                "redis_url": redis_url,
+                "auth": {
+                    "type": "jwt",
+                    "public_key": public_key,
+                    "issuer": ISSUER,
+                    "audience": AUDIENCE,
+                    "required_scopes": [READ_SCOPE],
+                    "read_scope": READ_SCOPE,
+                    "write_scope": WRITE_SCOPE,
+                },
+            },
+            "indexes": {
+                "knowledge": {
+                    "redis_name": redis_name,
+                    "search": {"type": "fulltext"},
+                    "runtime": {"text_field_name": "content"},
+                }
+            },
+        }
+        config_path = tmp_path / f"{redis_name}.yaml"
+        config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+        return str(config_path)
+
+    return factory
+
+
+async def test_http_transport_enforces_jwt_auth(auth_index, auth_config_path):
+    key = RSAKeyPair.generate()
+    server = RedisVLMCPServer(
+        MCPSettings(
+            config=auth_config_path(auth_index.schema.index.name, key.public_key)
+        )
+    )
+    assert server._auth_enabled is True
+
+    port = _find_free_port()
+    url = f"http://127.0.0.1:{port}/mcp"
+    server_task = asyncio.create_task(
+        server.run_async(transport="streamable-http", host="127.0.0.1", port=port)
+    )
+    try:
+        await _wait_for_port("127.0.0.1", port)
+
+        # No token is rejected.
+        with pytest.raises(Exception):
+            async with Client(url) as client:
+                await client.list_tools()
+
+        # Garbage token is rejected.
+        with pytest.raises(Exception):
+            async with Client(url, auth=BearerAuth("garbage")) as client:
+                await client.list_tools()
+
+        # Wrong audience is rejected.
+        bad_aud = key.create_token(
+            subject="nitin",
+            issuer=ISSUER,
+            audience="api://some-other-service",
+            scopes=[READ_SCOPE],
+        )
+        with pytest.raises(Exception):
+            async with Client(url, auth=BearerAuth(bad_aud)) as client:
+                await client.list_tools()
+
+        # Valid scoped token is accepted and can search.
+        good = key.create_token(
+            subject="nitin",
+            issuer=ISSUER,
+            audience=AUDIENCE,
+            scopes=[READ_SCOPE],
+        )
+        async with Client(url, auth=BearerAuth(good)) as client:
+            tool_names = [t.name for t in await client.list_tools()]
+            assert "search-records" in tool_names
+            result = await client.call_tool(
+                "search-records", {"query": "science", "limit": 1}
+            )
+            assert result is not None
+            assert len(result.content) > 0
+    finally:
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass

--- a/tests/unit/test_mcp/test_auth_config.py
+++ b/tests/unit/test_mcp/test_auth_config.py
@@ -1,0 +1,81 @@
+"""Unit tests for MCP auth config validation (`MCPAuthConfig`).
+
+These cover the configuration contract only; provider construction and token
+verification are tested separately.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from redisvl.mcp.config import MCPAuthConfig
+
+
+def test_auth_type_defaults_to_none():
+    cfg = MCPAuthConfig()
+    assert cfg.type == "none"
+
+
+def test_jwt_with_jwks_uri_is_valid():
+    cfg = MCPAuthConfig(
+        type="jwt",
+        jwks_uri="https://auth.redis.example/abc123/discovery/v2.0/keys",
+        issuer="https://auth.redis.example/abc123/v2.0",
+        audience="api://redisvl-mcp",
+        required_scopes=["kb.read"],
+        read_scope="kb.search.read",
+        write_scope="kb.search.write",
+    )
+    assert cfg.type == "jwt"
+    assert cfg.audience == "api://redisvl-mcp"
+    assert cfg.read_scope == "kb.search.read"
+
+
+def test_jwt_with_static_public_key_is_valid():
+    cfg = MCPAuthConfig(
+        type="jwt",
+        public_key="-----BEGIN PUBLIC KEY-----\nMII...\n-----END PUBLIC KEY-----",
+        issuer="https://auth.redis.example/abc123/v2.0",
+        audience="api://redisvl-mcp",
+    )
+    assert cfg.public_key is not None
+    assert cfg.jwks_uri is None
+
+
+def test_jwt_rejects_both_jwks_uri_and_public_key():
+    with pytest.raises(ValidationError, match="exactly one"):
+        MCPAuthConfig(
+            type="jwt",
+            jwks_uri="https://auth.redis.example/keys",
+            public_key="-----BEGIN PUBLIC KEY-----\nMII...\n-----END PUBLIC KEY-----",
+            audience="api://redisvl-mcp",
+        )
+
+
+def test_jwt_rejects_neither_jwks_uri_nor_public_key():
+    with pytest.raises(ValidationError, match="exactly one"):
+        MCPAuthConfig(
+            type="jwt",
+            issuer="https://auth.redis.example/abc123/v2.0",
+            audience="api://redisvl-mcp",
+        )
+
+
+def test_jwt_requires_audience():
+    with pytest.raises(ValidationError, match="audience"):
+        MCPAuthConfig(
+            type="jwt",
+            jwks_uri="https://auth.redis.example/keys",
+            issuer="https://auth.redis.example/abc123/v2.0",
+        )
+
+
+def test_unknown_auth_type_is_rejected():
+    with pytest.raises(ValidationError):
+        MCPAuthConfig(type="kerberos")
+
+
+def test_none_type_ignores_jwt_fields():
+    # A `none` config should never require jwt-only fields.
+    cfg = MCPAuthConfig(type="none")
+    assert cfg.audience is None
+    assert cfg.jwks_uri is None

--- a/tests/unit/test_mcp/test_auth_provider.py
+++ b/tests/unit/test_mcp/test_auth_provider.py
@@ -1,0 +1,45 @@
+"""Unit tests for building a FastMCP auth provider from `MCPAuthConfig`."""
+
+import pytest
+
+from redisvl.mcp.config import MCPAuthConfig
+
+fastmcp = pytest.importorskip(
+    "fastmcp", reason="fastmcp not installed (install redisvl[mcp])"
+)
+from fastmcp.server.auth.providers.jwt import JWTVerifier, RSAKeyPair
+
+from redisvl.mcp.auth import build_auth_provider, token_has_scope
+
+
+def test_build_returns_none_for_none_type():
+    assert build_auth_provider(MCPAuthConfig(type="none")) is None
+
+
+def test_build_returns_none_for_missing_config():
+    assert build_auth_provider(None) is None
+
+
+def test_build_returns_jwt_verifier():
+    key = RSAKeyPair.generate()
+    provider = build_auth_provider(
+        MCPAuthConfig(
+            type="jwt",
+            public_key=key.public_key,
+            issuer="https://auth.redis.example/abc123/v2.0",
+            audience="api://redisvl-mcp",
+            required_scopes=["kb.read"],
+        )
+    )
+    assert isinstance(provider, JWTVerifier)
+
+
+def test_token_has_scope_helper():
+    class _AccessToken:
+        def __init__(self, scopes):
+            self.scopes = scopes
+
+    assert token_has_scope(_AccessToken(["kb.search.read"]), "kb.search.read")
+    assert not token_has_scope(_AccessToken(["kb.search.read"]), "kb.search.write")
+    # No required scope configured means the gate is open.
+    assert token_has_scope(_AccessToken([]), None)

--- a/tests/unit/test_mcp/test_auth_resolution.py
+++ b/tests/unit/test_mcp/test_auth_resolution.py
@@ -1,0 +1,76 @@
+"""Unit tests for resolving auth config from env (`MCPSettings`) and YAML.
+
+Env vars take precedence over the YAML `server.auth` block.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from redisvl.mcp.auth import resolve_auth_config
+from redisvl.mcp.settings import MCPSettings
+
+
+def _write_config(tmp_path: Path, auth_block: dict | None) -> str:
+    config = {
+        "server": {"redis_url": "redis://localhost:6379"},
+        "indexes": {
+            "knowledge": {
+                "redis_name": "docs-index",
+                "search": {"type": "fulltext"},
+                "runtime": {"text_field_name": "content"},
+            }
+        },
+    }
+    if auth_block is not None:
+        config["server"]["auth"] = auth_block
+    path = tmp_path / "mcp.yaml"
+    path.write_text(yaml.safe_dump(config))
+    return str(path)
+
+
+def test_resolves_none_when_unset(tmp_path, monkeypatch):
+    for var in ("REDISVL_MCP_AUTH_TYPE", "REDISVL_MCP_AUTH_JWKS_URI"):
+        monkeypatch.delenv(var, raising=False)
+    path = _write_config(tmp_path, auth_block=None)
+    settings = MCPSettings.from_env(config=path)
+    assert resolve_auth_config(settings, path) is None
+
+
+def test_resolves_jwt_from_yaml(tmp_path, monkeypatch):
+    for var in ("REDISVL_MCP_AUTH_TYPE", "REDISVL_MCP_AUTH_AUDIENCE"):
+        monkeypatch.delenv(var, raising=False)
+    path = _write_config(
+        tmp_path,
+        auth_block={
+            "type": "jwt",
+            "jwks_uri": "https://auth.redis.example/keys",
+            "issuer": "https://auth.redis.example/abc123/v2.0",
+            "audience": "api://redisvl-mcp",
+            "read_scope": "kb.search.read",
+        },
+    )
+    settings = MCPSettings.from_env(config=path)
+    cfg = resolve_auth_config(settings, path)
+    assert cfg is not None
+    assert cfg.type == "jwt"
+    assert cfg.audience == "api://redisvl-mcp"
+    assert cfg.read_scope == "kb.search.read"
+
+
+def test_env_overrides_yaml(tmp_path, monkeypatch):
+    path = _write_config(
+        tmp_path,
+        auth_block={
+            "type": "jwt",
+            "jwks_uri": "https://auth.redis.example/keys",
+            "audience": "api://from-yaml",
+        },
+    )
+    monkeypatch.setenv("REDISVL_MCP_AUTH_TYPE", "jwt")
+    monkeypatch.setenv("REDISVL_MCP_AUTH_JWKS_URI", "https://auth.redis.example/keys")
+    monkeypatch.setenv("REDISVL_MCP_AUTH_AUDIENCE", "api://from-env")
+    settings = MCPSettings.from_env(config=path)
+    cfg = resolve_auth_config(settings, path)
+    assert cfg is not None
+    assert cfg.audience == "api://from-env"

--- a/tests/unit/test_mcp/test_server_auth.py
+++ b/tests/unit/test_mcp/test_server_auth.py
@@ -1,0 +1,64 @@
+"""Unit tests for wiring auth into the MCP server constructor."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+fastmcp = pytest.importorskip(
+    "fastmcp", reason="fastmcp not installed (install redisvl[mcp])"
+)
+from fastmcp.server.auth.providers.jwt import JWTVerifier, RSAKeyPair
+
+from redisvl.mcp.server import RedisVLMCPServer
+from redisvl.mcp.settings import MCPSettings
+
+
+def _write_config(tmp_path: Path, auth_block: dict | None) -> str:
+    config = {
+        "server": {"redis_url": "redis://localhost:6379"},
+        "indexes": {
+            "knowledge": {
+                "redis_name": "docs-index",
+                "search": {"type": "fulltext"},
+                "runtime": {"text_field_name": "content"},
+            }
+        },
+    }
+    if auth_block is not None:
+        config["server"]["auth"] = auth_block
+    path = tmp_path / "mcp.yaml"
+    path.write_text(yaml.safe_dump(config))
+    return str(path)
+
+
+def test_server_without_auth_is_unauthenticated(tmp_path, monkeypatch):
+    for var in ("REDISVL_MCP_AUTH_TYPE", "REDISVL_MCP_AUTH_AUDIENCE"):
+        monkeypatch.delenv(var, raising=False)
+    path = _write_config(tmp_path, auth_block=None)
+    server = RedisVLMCPServer(MCPSettings.from_env(config=path))
+    assert server._auth_enabled is False
+    assert server.auth is None
+
+
+def test_server_with_jwt_auth_attaches_verifier(tmp_path, monkeypatch):
+    for var in ("REDISVL_MCP_AUTH_TYPE", "REDISVL_MCP_AUTH_AUDIENCE"):
+        monkeypatch.delenv(var, raising=False)
+    key = RSAKeyPair.generate()
+    path = _write_config(
+        tmp_path,
+        auth_block={
+            "type": "jwt",
+            "public_key": key.public_key,
+            "issuer": "https://auth.redis.example/abc123/v2.0",
+            "audience": "api://redisvl-mcp",
+            "required_scopes": ["kb.read"],
+            "read_scope": "kb.search.read",
+            "write_scope": "kb.search.write",
+        },
+    )
+    server = RedisVLMCPServer(MCPSettings.from_env(config=path))
+    assert server._auth_enabled is True
+    assert isinstance(server.auth, JWTVerifier)
+    assert server.auth_config is not None
+    assert server.auth_config.read_scope == "kb.search.read"


### PR DESCRIPTION
## Summary

Adds **optional JWT authentication** to the RedisVL MCP server's HTTP transports (`streamable-http`, `sse`), plus coarse read/write authorization. Off by default, so existing deployments are unaffected. `stdio` is a local subprocess and is never authenticated.

Previously the only access control was the `--read-only` flag (which just hides the upsert tool). Binding the server to a port exposed the index to any client that could reach it. This PR lets operators require a valid bearer token before the server will serve requests.

Closes #625.

## How it works

The server validates a bearer JWT that an existing identity provider issued (it does not run an OAuth authorization server and does not mint tokens). On each request it checks:

- **Signature** against a JWKS endpoint or a static public key
- **Issuer** (`iss`)
- **Audience** (`aud`), so a token minted for a different service cannot be replayed (RFC 8707)
- **Required scopes** to connect, and optionally a **read scope** for `search-records` and a **write scope** for `upsert-records`

### Request flow

```mermaid
sequenceDiagram
    actor User
    participant IdP as Identity Provider
    participant MCP as RedisVL MCP Server
    participant Redis

    User->>IdP: Authenticate
    IdP-->>User: Signed JWT (iss, aud, scopes/roles)
    User->>MCP: MCP request + Bearer JWT
    MCP->>MCP: Validate signature (JWKS / public key)
    MCP->>MCP: Check issuer + audience
    alt token invalid / wrong audience / missing connect scope
        MCP-->>User: 401 Unauthorized
    else token valid
        MCP->>MCP: Gate tool by read / write scope
        alt scope present
            MCP->>Redis: Search or upsert (single configured ACL user)
            Redis-->>MCP: Results
            MCP-->>User: Tool result
        else scope missing
            MCP-->>User: Forbidden
        end
    end
```

### Configurable authorization claim

Standard OAuth carries authorization in `scp`/`scope`. Some IdPs (for example Azure AD / Entra) carry app roles in a `roles` claim, which does not appear in the standard scope set. The `authorization_claim` setting (default `scp`) selects which claim the read/write gate reads.

```mermaid
flowchart TD
    A[Validated JWT claims] --> B{authorization_claim}
    B -->|scp / scope| C["access.scopes"]
    B -->|roles| D["access.claims.roles"]
    C --> E[Check read_scope / write_scope]
    D --> E
    E -->|present| F[Allow tool]
    E -->|absent| G[Deny tool]
```

### Configuration

YAML (`server.auth`), with `${ENV}` substitution for secrets:

```yaml
server:
  redis_url: ${REDIS_URL:-redis://localhost:6379}
  auth:
    type: jwt
    jwks_uri: ${MCP_JWKS_URI}          # or public_key for a static key
    issuer: ${MCP_ISSUER}
    audience: api://redisvl-mcp
    required_scopes: [kb.read]         # required to connect
    read_scope: kb.search.read         # required for search-records
    write_scope: kb.search.write       # required for upsert-records
    authorization_claim: scp           # or roles
```

Every field is also settable via `REDISVL_MCP_AUTH_*` environment variables, which take precedence over YAML.

## What was tested

Unit (config validation, provider building, env-over-YAML resolution, scope helpers), integration (real RS256 tokens minted with FastMCP's `RSAKeyPair` and validated against a static public key), and end-to-end over `streamable-http` against real Redis:

- no token / garbage token / wrong audience / wrong issuer / expired / missing required scope -> rejected (401)
- valid scoped token -> authenticated, lists tools, search succeeds
- **read-only token can search but is rejected on upsert; read+write token can upsert** (per-tool scope gating)
- **authorization carried in a `roles` claim gates tools correctly** (the Azure AD / Entra style)

### "Can a tenant id from the token drive Redis ACL enforcement?"

This was explicitly probed. Using a token shaped like a real enterprise OIDC access token (sanitized below), we confirmed:

- the token authenticates (issuer, audience, signature)
- its `roles`, `tid`, `oid`, `upn` claims are validated and available to the server
- role-based read/write gating works when `authorization_claim: roles`

What we found and decided: the `tid` (tenant) claim is **carried but not acted on**. The server holds one Redis connection for one index, so it does not map a tenant/role claim to a per-request Redis ACL user, index, or query filter. That binding belongs in a gateway/policy layer (validate token -> look up claim-to-Redis-identity binding -> inject credentials and filters). See "Out of scope" below.

Sanitized token used in tests:

```json
{
  "iss":   "https://auth.example/{tenant}/v2.0",
  "aud":   "api://redisvl-mcp",
  "sub":   "nitin",
  "roles": ["kb.search.read"],
  "tid":   "00000000-0000-0000-0000-000000000000",
  "scp":   "kb.read"
}
```

## Out of scope (intentional, may be future work)

- **Per-tenant authorization**: mapping identity claims (tenant id, role) to a specific Redis ACL user, per-tenant index, or injected query filters. This is a gateway/policy concern, not RedisVL. RedisVL provides authentication and coarse read/write gating; fine-grained, per-tenant enforcement sits in front of the server.
- **Running a full OAuth authorization server** (`OAuthProvider`). RedisVL validates tokens; it does not issue them.
- **Per-vendor login providers** (GitHub, Google, etc.). If interactive OAuth is needed later, a single generic OAuth-proxy option is preferable to one branch per vendor.

## Docs

- New how-to guide `docs/user_guide/how_to_guides/mcp_authentication.md` (wired into the how-to index and toctree) with the diagrams above and the gateway-boundary explanation
- Updated the `mcp.md` security warning to point at the new guide
- Added an Authentication and Authorization section to `concepts/mcp.md`
- Enabled `sphinxcontrib-mermaid` so the diagrams render on the docs site

## Notes

- Commits are layered (config -> settings -> resolver/provider -> server wiring -> e2e -> scope gating -> docs) and each is self-contained.
- `fastmcp` provider imports are deferred so the package stays importable without the optional `mcp` extra.
