### PR TITLE
feat(mcp): add list-indexes discovery tool (RAAE-1605)

### DIFF
--- a/redisvl/mcp/server.py
+++ b/redisvl/mcp/server.py
@@ -15,6 +15,7 @@ from redisvl.mcp.config import MCPConfig, MCPIndexBindingConfig, load_mcp_config
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.runtime import BindingRuntime
 from redisvl.mcp.settings import MCPSettings
+from redisvl.mcp.tools.list_indexes import register_list_indexes_tool
 from redisvl.mcp.tools.search import register_search_tool
 from redisvl.mcp.tools.upsert import register_upsert_tool
 from redisvl.redis.connection import RedisConnectionFactory, is_version_gte
@@ -246,6 +247,8 @@ class RedisVLMCPServer(FastMCP):
         if len(self._bindings) == 1:
             search_schema = next(iter(self._bindings.values())).schema
 
+        # Discovery is always available so clients can enumerate indexes.
+        register_list_indexes_tool(self)
         register_search_tool(self, search_schema)
         if not self.mcp_settings.read_only:
             register_upsert_tool(self)

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from redisvl.mcp.auth import ensure_tool_scope
+
+DEFAULT_LIST_INDEXES_DESCRIPTION = (
+    "List the logical indexes configured on this server. Each entry reports the "
+    "index id, an optional description, whether upsert is available, the "
+    "filterable fields discovered from the index, and any explicitly configured "
+    "limits. Call this first on a multi-index server to choose the correct "
+    "index for search-records or upsert-records."
+)
+
+# Runtime limits surfaced to clients, included only when explicitly configured.
+_LIMIT_FIELDS = ("max_limit", "max_upsert_records")
+
+
+def _binding_fields(rt: Any) -> list[dict[str, str]]:
+    """Return a binding's shared filterable fields from its inspected schema.
+
+    The vector field and the configured default embed-source text field are
+    omitted: they are implementation inputs, not fields a client filters on.
+    """
+    embed_source = rt.binding.runtime.default_embed_text_field
+    fields: list[dict[str, str]] = []
+    for field in rt.schema.fields.values():
+        field_type = str(getattr(field.type, "value", field.type))
+        if field_type.lower() == "vector":
+            continue
+        if field.name == embed_source:
+            continue
+        fields.append({"name": field.name, "type": field_type})
+    return fields
+
+
+def _binding_limits(rt: Any) -> dict[str, int]:
+    """Return runtime limits that were explicitly configured for the binding.
+
+    Defaults are intentionally excluded so the output reflects deliberate
+    overrides rather than implementation defaults.
+    """
+    runtime = rt.binding.runtime
+    configured = runtime.model_fields_set
+    return {
+        name: getattr(runtime, name) for name in _LIMIT_FIELDS if name in configured
+    }
+
+
+def _describe_binding(rt: Any) -> dict[str, Any]:
+    """Build the deterministic discovery payload for a single binding."""
+    entry: dict[str, Any] = {"id": rt.binding_id}
+    if rt.binding.description is not None:
+        entry["description"] = rt.binding.description
+    # Reflects both global read-only and the per-index read_only policy.
+    entry["upsert_available"] = not rt.effective_read_only
+    entry["fields"] = _binding_fields(rt)
+    limits = _binding_limits(rt)
+    if limits:
+        entry["limits"] = limits
+    return entry
+
+
+def list_indexes(server: Any) -> dict[str, Any]:
+    """Return the discovery payload for every configured binding.
+
+    The Redis index name (``redis_name``) is intentionally never exposed.
+    """
+    return {
+        "indexes": [_describe_binding(rt) for rt in server._bindings.values()],
+    }
+
+
+def register_list_indexes_tool(server: Any) -> None:
+    """Register the always-available, read-only `list-indexes` MCP tool."""
+    description = (
+        getattr(server.mcp_settings, "tool_list_indexes_description", None)
+        or DEFAULT_LIST_INDEXES_DESCRIPTION
+    )
+
+    async def list_indexes_tool():
+        """FastMCP wrapper for the `list-indexes` tool."""
+        read_scope = getattr(getattr(server, "auth_config", None), "read_scope", None)
+        ensure_tool_scope(server, read_scope)
+        return list_indexes(server)
+
+    server.tool(name="list-indexes", description=description)(list_indexes_tool)

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -1,6 +1,10 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from redisvl.mcp.auth import ensure_tool_scope
+from redisvl.mcp.runtime import BindingRuntime
+
+if TYPE_CHECKING:
+    from redisvl.mcp.server import RedisVLMCPServer
 
 DEFAULT_LIST_INDEXES_DESCRIPTION = (
     "List the logical indexes configured on this server. Each entry reports the "
@@ -14,15 +18,15 @@ DEFAULT_LIST_INDEXES_DESCRIPTION = (
 _LIMIT_FIELDS = ("max_limit", "max_upsert_records")
 
 
-def _binding_fields(rt: Any) -> list[dict[str, str]]:
+def _binding_fields(binding_runtime: BindingRuntime) -> list[dict[str, str]]:
     """Return a binding's shared filterable fields from its inspected schema.
 
     The vector field and the configured default embed-source text field are
     omitted: they are implementation inputs, not fields a client filters on.
     """
-    embed_source = rt.binding.runtime.default_embed_text_field
+    embed_source = binding_runtime.binding.runtime.default_embed_text_field
     fields: list[dict[str, str]] = []
-    for field in rt.schema.fields.values():
+    for field in binding_runtime.schema.fields.values():
         field_type = str(getattr(field.type, "value", field.type))
         if field_type.lower() == "vector":
             continue
@@ -32,44 +36,47 @@ def _binding_fields(rt: Any) -> list[dict[str, str]]:
     return fields
 
 
-def _binding_limits(rt: Any) -> dict[str, int]:
+def _binding_limits(binding_runtime: BindingRuntime) -> dict[str, int]:
     """Return runtime limits that were explicitly configured for the binding.
 
     Defaults are intentionally excluded so the output reflects deliberate
     overrides rather than implementation defaults.
     """
-    runtime = rt.binding.runtime
+    runtime = binding_runtime.binding.runtime
     configured = runtime.model_fields_set
     return {
         name: getattr(runtime, name) for name in _LIMIT_FIELDS if name in configured
     }
 
 
-def _describe_binding(rt: Any) -> dict[str, Any]:
+def _describe_binding(binding_runtime: BindingRuntime) -> dict[str, Any]:
     """Build the deterministic discovery payload for a single binding."""
-    entry: dict[str, Any] = {"id": rt.binding_id}
-    if rt.binding.description is not None:
-        entry["description"] = rt.binding.description
+    entry: dict[str, Any] = {"id": binding_runtime.binding_id}
+    if binding_runtime.binding.description is not None:
+        entry["description"] = binding_runtime.binding.description
     # Reflects both global read-only and the per-index read_only policy.
-    entry["upsert_available"] = not rt.effective_read_only
-    entry["fields"] = _binding_fields(rt)
-    limits = _binding_limits(rt)
+    entry["upsert_available"] = not binding_runtime.effective_read_only
+    entry["fields"] = _binding_fields(binding_runtime)
+    limits = _binding_limits(binding_runtime)
     if limits:
         entry["limits"] = limits
     return entry
 
 
-def list_indexes(server: Any) -> dict[str, Any]:
+def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
     """Return the discovery payload for every configured binding.
 
     The Redis index name (``redis_name``) is intentionally never exposed.
     """
     return {
-        "indexes": [_describe_binding(rt) for rt in server._bindings.values()],
+        "indexes": [
+            _describe_binding(binding_runtime)
+            for binding_runtime in server._bindings.values()
+        ],
     }
 
 
-def register_list_indexes_tool(server: Any) -> None:
+def register_list_indexes_tool(server: "RedisVLMCPServer") -> None:
     """Register the always-available, read-only `list-indexes` MCP tool."""
     description = (
         getattr(server.mcp_settings, "tool_list_indexes_description", None)

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -78,15 +78,14 @@ def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
 
 def register_list_indexes_tool(server: "RedisVLMCPServer") -> None:
     """Register the always-available, read-only `list-indexes` MCP tool."""
-    description = (
-        getattr(server.mcp_settings, "tool_list_indexes_description", None)
-        or DEFAULT_LIST_INDEXES_DESCRIPTION
-    )
 
     async def list_indexes_tool():
         """FastMCP wrapper for the `list-indexes` tool."""
-        read_scope = getattr(getattr(server, "auth_config", None), "read_scope", None)
+        auth_config = getattr(server, "auth_config", None)
+        read_scope = auth_config.read_scope if auth_config is not None else None
         ensure_tool_scope(server, read_scope)
         return list_indexes(server)
 
-    server.tool(name="list-indexes", description=description)(list_indexes_tool)
+    server.tool(name="list-indexes", description=DEFAULT_LIST_INDEXES_DESCRIPTION)(
+        list_indexes_tool
+    )

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -68,6 +68,11 @@ def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
 
     The Redis index name (``redis_name``) is intentionally never exposed.
     """
+    # Mirror resolve_binding: with no bindings the server is not started (or has
+    # been torn down), so fail loudly rather than return an empty list that a
+    # client could misread as "no indexes configured".
+    if not server._bindings:
+        raise RuntimeError("MCP server has not been started")
     return {
         "indexes": [
             _describe_binding(binding_runtime)

--- a/tests/integration/test_mcp/test_server_startup.py
+++ b/tests/integration/test_mcp/test_server_startup.py
@@ -9,6 +9,7 @@ from redisvl.index import AsyncSearchIndex
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.server import RedisVLMCPServer
 from redisvl.mcp.settings import MCPSettings
+from redisvl.mcp.tools.list_indexes import list_indexes
 from redisvl.redis.connection import is_version_gte
 from redisvl.schema import IndexSchema
 from tests.conftest import (
@@ -730,3 +731,78 @@ async def test_server_startup_fails_when_one_binding_is_invalid(
 
     assert server._lifecycle_state.name == "STOPPED"
     assert server._bindings == {}
+
+
+@pytest.mark.asyncio
+async def test_list_indexes_derives_fields_from_inspected_schema(
+    monkeypatch, existing_index, multi_index_config_path
+):
+    knowledge = await existing_index(index_name="mcp-list-knowledge")
+    tickets = await existing_index(index_name="mcp-list-tickets")
+    monkeypatch.setattr(
+        "redisvl.mcp.server.resolve_vectorizer_class",
+        lambda class_name: FakeVectorizer,
+    )
+    server = RedisVLMCPServer(
+        MCPSettings(
+            config=multi_index_config_path(
+                {
+                    # Vector binding: content is the embed source.
+                    "knowledge": {
+                        "redis_name": knowledge.name,
+                        "description": "Product docs",
+                        "vectorizer": {
+                            "class": "FakeVectorizer",
+                            "model": "fake-model",
+                            "dims": 3,
+                        },
+                        "search": {"type": "vector"},
+                        "runtime": {
+                            "text_field_name": "content",
+                            "vector_field_name": "embedding",
+                            "default_embed_text_field": "content",
+                            "max_limit": 25,
+                        },
+                    },
+                    # Fulltext binding: no embed source, read-only.
+                    "tickets": {
+                        "redis_name": tickets.name,
+                        "read_only": True,
+                        "search": {"type": "fulltext"},
+                        "runtime": {"text_field_name": "content"},
+                    },
+                }
+            )
+        )
+    )
+
+    await server.startup()
+
+    try:
+        result = list_indexes(server)
+        indexes = {entry["id"]: entry for entry in result["indexes"]}
+
+        # Both bindings are discoverable; redis_name is never leaked.
+        assert set(indexes) == {"knowledge", "tickets"}
+        for entry in indexes.values():
+            assert "redis_name" not in entry
+            assert knowledge.name not in entry.values()
+            assert tickets.name not in entry.values()
+
+        # Fields come from the inspected schema. The vector field is always
+        # omitted; the embed-source field is omitted only where configured.
+        knowledge_fields = {f["name"] for f in indexes["knowledge"]["fields"]}
+        tickets_fields = {f["name"] for f in indexes["tickets"]["fields"]}
+        assert "embedding" not in knowledge_fields
+        assert "embedding" not in tickets_fields
+        assert "content" not in knowledge_fields  # embed source omitted
+        assert "content" in tickets_fields  # no embed source configured
+
+        # Per-index write policy and explicit limits are reflected.
+        assert indexes["knowledge"]["upsert_available"] is True
+        assert indexes["tickets"]["upsert_available"] is False
+        assert indexes["knowledge"]["limits"] == {"max_limit": 25}
+        assert "limits" not in indexes["tickets"]
+        assert indexes["knowledge"]["description"] == "Product docs"
+    finally:
+        await server.shutdown()

--- a/tests/unit/test_mcp/test_list_indexes_tool_unit.py
+++ b/tests/unit/test_mcp/test_list_indexes_tool_unit.py
@@ -1,0 +1,222 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from redisvl.mcp.config import MCPConfig
+from redisvl.mcp.runtime import BindingRuntime
+from redisvl.mcp.tools.list_indexes import list_indexes, register_list_indexes_tool
+from redisvl.schema import IndexSchema
+
+
+def _schema() -> IndexSchema:
+    return IndexSchema.from_dict(
+        {
+            "index": {
+                "name": "docs-index",
+                "prefix": "doc",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {"name": "title", "type": "text"},
+                {"name": "content", "type": "text"},
+                {"name": "category", "type": "tag"},
+                {"name": "rating", "type": "numeric"},
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "attrs": {
+                        "algorithm": "flat",
+                        "dims": 3,
+                        "distance_metric": "cosine",
+                        "datatype": "float32",
+                    },
+                },
+            ],
+        }
+    )
+
+
+def _binding_runtime(
+    binding_id: str = "knowledge",
+    *,
+    runtime: dict[str, Any] | None = None,
+    description: str | None = None,
+    read_only: bool = False,
+    effective_read_only: bool = False,
+    schema: IndexSchema | None = None,
+) -> BindingRuntime:
+    runtime_config = {
+        "vector_field_name": "embedding",
+        "default_embed_text_field": "content",
+    }
+    if runtime:
+        runtime_config.update(runtime)
+
+    binding_dict: dict[str, Any] = {
+        "redis_name": f"{binding_id}-redis-name",
+        "read_only": read_only,
+        "vectorizer": {"class": "FakeVectorizer", "model": "test-model"},
+        "search": {"type": "vector"},
+        "runtime": runtime_config,
+    }
+    if description is not None:
+        binding_dict["description"] = description
+
+    config = MCPConfig.model_validate(
+        {
+            "server": {"redis_url": "redis://localhost:6379"},
+            "indexes": {binding_id: binding_dict},
+        }
+    )
+    return BindingRuntime(
+        binding_id=binding_id,
+        binding=config.indexes[binding_id],
+        index=SimpleNamespace(),
+        schema=schema or _schema(),
+        vectorizer=None,
+        supports_native_hybrid_search=False,
+        effective_read_only=effective_read_only,
+    )
+
+
+class FakeServer:
+    def __init__(self, bindings: list[BindingRuntime]):
+        self._bindings = {rt.binding_id: rt for rt in bindings}
+        self.mcp_settings = SimpleNamespace()
+        self.auth_config = None
+        self._auth_enabled = False
+        self.registered_tools: list[dict[str, Any]] = []
+
+    def tool(self, name=None, description=None, **kwargs):
+        def decorator(fn):
+            self.registered_tools.append(
+                {"name": name, "description": description, "fn": fn}
+            )
+            return fn
+
+        return decorator
+
+
+def test_list_indexes_minimal_single_binding():
+    server = FakeServer([_binding_runtime()])
+
+    result = list_indexes(server)
+
+    assert result == {
+        "indexes": [
+            {
+                "id": "knowledge",
+                "upsert_available": True,
+                "fields": [
+                    {"name": "title", "type": "text"},
+                    {"name": "category", "type": "tag"},
+                    {"name": "rating", "type": "numeric"},
+                ],
+            }
+        ]
+    }
+
+
+def test_list_indexes_omits_vector_and_embed_source_fields():
+    server = FakeServer([_binding_runtime()])
+
+    fields = list_indexes(server)["indexes"][0]["fields"]
+    field_names = [field["name"] for field in fields]
+
+    # embedding is the vector field; content is the default embed-source field.
+    assert "embedding" not in field_names
+    assert "content" not in field_names
+
+
+def test_list_indexes_includes_description_when_configured():
+    server = FakeServer([_binding_runtime(description="Product docs and runbooks")])
+
+    entry = list_indexes(server)["indexes"][0]
+
+    assert entry["description"] == "Product docs and runbooks"
+
+
+def test_list_indexes_omits_description_when_absent():
+    server = FakeServer([_binding_runtime()])
+
+    assert "description" not in list_indexes(server)["indexes"][0]
+
+
+def test_list_indexes_upsert_available_reflects_effective_read_only():
+    server = FakeServer(
+        [
+            _binding_runtime("knowledge", effective_read_only=False),
+            _binding_runtime("tickets", read_only=True, effective_read_only=True),
+        ]
+    )
+
+    indexes = {entry["id"]: entry for entry in list_indexes(server)["indexes"]}
+
+    assert indexes["knowledge"]["upsert_available"] is True
+    assert indexes["tickets"]["upsert_available"] is False
+
+
+def test_list_indexes_includes_limits_only_when_explicitly_configured():
+    server = FakeServer(
+        [
+            _binding_runtime(
+                "explicit",
+                runtime={"max_limit": 25, "max_upsert_records": 64},
+            ),
+            _binding_runtime("defaults"),
+        ]
+    )
+
+    indexes = {entry["id"]: entry for entry in list_indexes(server)["indexes"]}
+
+    assert indexes["explicit"]["limits"] == {
+        "max_limit": 25,
+        "max_upsert_records": 64,
+    }
+    assert "limits" not in indexes["defaults"]
+
+
+def test_list_indexes_includes_only_the_explicitly_set_limit():
+    server = FakeServer([_binding_runtime(runtime={"max_limit": 25})])
+
+    entry = list_indexes(server)["indexes"][0]
+
+    assert entry["limits"] == {"max_limit": 25}
+
+
+def test_list_indexes_never_exposes_redis_name():
+    server = FakeServer([_binding_runtime()])
+
+    entry = list_indexes(server)["indexes"][0]
+
+    assert "redis_name" not in entry
+    assert "knowledge-redis-name" not in entry.values()
+
+
+def test_list_indexes_preserves_binding_order():
+    server = FakeServer(
+        [
+            _binding_runtime("knowledge"),
+            _binding_runtime("tickets"),
+        ]
+    )
+
+    ids = [entry["id"] for entry in list_indexes(server)["indexes"]]
+
+    assert ids == ["knowledge", "tickets"]
+
+
+@pytest.mark.asyncio
+async def test_register_list_indexes_tool_is_read_only_and_callable():
+    server = FakeServer([_binding_runtime()])
+
+    register_list_indexes_tool(server)
+
+    assert len(server.registered_tools) == 1
+    tool = server.registered_tools[0]
+    assert tool["name"] == "list-indexes"
+    assert tool["description"]
+
+    result = await tool["fn"]()
+    assert result == list_indexes(server)

--- a/tests/unit/test_mcp/test_list_indexes_tool_unit.py
+++ b/tests/unit/test_mcp/test_list_indexes_tool_unit.py
@@ -98,6 +98,15 @@ class FakeServer:
         return decorator
 
 
+def test_list_indexes_raises_when_no_bindings():
+    # Before startup / after shutdown _bindings is empty; discovery must fail
+    # loudly rather than return an empty list a client could misread.
+    server = FakeServer([])
+
+    with pytest.raises(RuntimeError, match="has not been started"):
+        list_indexes(server)
+
+
 def test_list_indexes_minimal_single_binding():
     server = FakeServer([_binding_runtime()])
 

--- a/tests/unit/test_mcp/test_server.py
+++ b/tests/unit/test_mcp/test_server.py
@@ -424,6 +424,9 @@ async def test_server_registers_tools_with_effective_schema(monkeypatch):
     )
     monkeypatch.setattr("redisvl.mcp.server.register_upsert_tool", lambda server: None)
     monkeypatch.setattr(
+        "redisvl.mcp.server.register_list_indexes_tool", lambda server: None
+    )
+    monkeypatch.setattr(
         "redisvl.mcp.server.AsyncSearchIndex.disconnect",
         fake_disconnect,
         raising=False,


### PR DESCRIPTION
> Stacked on #629 (RAAE-1604). Review/merge that first; this PR targets the 1604 branch so the diff is scoped to the discovery tool.

## Motivation

Once a single MCP server can expose multiple logical indexes ([RAAE-1604](https://redislabs.atlassian.net/browse/RAAE-1604)), clients need a lightweight way to discover what's available so they can pick the right index instead of guessing. This PR ([RAAE-1605](https://redislabs.atlassian.net/browse/RAAE-1605)) adds an always-registered, read-only `list-indexes` tool for exactly that, and it grounds discovery in the schema the server already inspected at startup rather than asking users to re-declare field metadata in config.

## Implementation

The new tool (`redisvl/mcp/tools/list_indexes.py`) returns one entry per configured binding, in configured order: the logical `id`, an optional `description`, an `upsert_available` flag, the shared filterable `fields`, and — only when explicitly configured — a `limits` object. `upsert_available` is simply `not effective_read_only`, so it already reflects both the global `--read-only` flag and the per-index `read_only` policy resolved at startup. The `fields` list is built from the binding's effective (inspected + overridden) schema that already lives on its `BindingRuntime`, so the output stays consistent with what the index actually contains; the vector field and the configured default embed-source text field are omitted because they are implementation inputs rather than fields a client would filter on. The Redis index name (`redis_name`) is deliberately never exposed. Limits are included only when the operator set them explicitly — detected via the runtime model's `model_fields_set` — so defaults don't masquerade as deliberate overrides; per the contract this covers `max_limit` and `max_upsert_records`.

The tool is registered unconditionally during the server's tool registration (alongside `search-records` and the conditionally-registered `upsert-records`) and is gated by the same read scope as search when auth is enabled, since it is read-only.

- Output is deterministic and ordered by configured binding.
- No new configuration surface or settings are required.

## Verification

- `mypy` clean; `black`/`isort` formatted.
- New unit coverage: field omission (vector + embed-source), description/limits inclusion rules, `redis_name` secrecy, read-only reflection, single- and multi-binding output, and tool registration.
- New integration test starts a real two-binding server (one vector, one fulltext) and asserts the discovered fields come from the inspected schema and follow the omission rules.
- Full MCP suite green: 178 unit + 45 integration (2 skipped on Redis-version gates) against Redis 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RAAE-1604]: https://redislabs.atlassian.net/browse/RAAE-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAAE-1605]: https://redislabs.atlassian.net/browse/RAAE-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only discovery metadata with no new config; behavior is additive and gated like existing search tools when auth is enabled.
> 
> **Overview**
> Adds a read-only **`list-indexes`** MCP tool so clients can discover logical indexes on multi-binding servers before calling **`search-records`** or **`upsert-records`**.
> 
> The tool is **always registered** during `_register_tools` (alongside search; upsert remains conditional). Each binding is returned in config order with **`id`**, optional **`description`**, **`upsert_available`** (`not effective_read_only`), filterable **`fields`** from the startup-inspected schema (vector and default embed-source text omitted), and **`limits`** only when **`max_limit`** / **`max_upsert_records`** were explicitly set. **`redis_name`** is never exposed; empty bindings raise **`RuntimeError`** like other pre-startup paths. When auth is on, the tool uses the same **read scope** as search.
> 
> Unit and integration tests cover payload rules, registration, and a two-binding startup scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ce686e0ef11a4872cab82836aed3eccf5be659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->