### PR TITLE
feat(mcp): add index routing to search-records (RAAE-1606)

### DIFF
--- a/redisvl/mcp/server.py
+++ b/redisvl/mcp/server.py
@@ -15,6 +15,7 @@ from redisvl.mcp.config import MCPConfig, MCPIndexBindingConfig, load_mcp_config
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.runtime import BindingRuntime
 from redisvl.mcp.settings import MCPSettings
+from redisvl.mcp.tools.list_indexes import register_list_indexes_tool
 from redisvl.mcp.tools.search import register_search_tool
 from redisvl.mcp.tools.upsert import register_upsert_tool
 from redisvl.redis.connection import RedisConnectionFactory, is_version_gte
@@ -246,6 +247,8 @@ class RedisVLMCPServer(FastMCP):
         if len(self._bindings) == 1:
             search_schema = next(iter(self._bindings.values())).schema
 
+        # Discovery is always available so clients can enumerate indexes.
+        register_list_indexes_tool(self)
         register_search_tool(self, search_schema)
         if not self.mcp_settings.read_only:
             register_upsert_tool(self)

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from redisvl.mcp.auth import ensure_tool_scope
+
+DEFAULT_LIST_INDEXES_DESCRIPTION = (
+    "List the logical indexes configured on this server. Each entry reports the "
+    "index id, an optional description, whether upsert is available, the "
+    "filterable fields discovered from the index, and any explicitly configured "
+    "limits. Call this first on a multi-index server to choose the correct "
+    "index for search-records or upsert-records."
+)
+
+# Runtime limits surfaced to clients, included only when explicitly configured.
+_LIMIT_FIELDS = ("max_limit", "max_upsert_records")
+
+
+def _binding_fields(rt: Any) -> list[dict[str, str]]:
+    """Return a binding's shared filterable fields from its inspected schema.
+
+    The vector field and the configured default embed-source text field are
+    omitted: they are implementation inputs, not fields a client filters on.
+    """
+    embed_source = rt.binding.runtime.default_embed_text_field
+    fields: list[dict[str, str]] = []
+    for field in rt.schema.fields.values():
+        field_type = str(getattr(field.type, "value", field.type))
+        if field_type.lower() == "vector":
+            continue
+        if field.name == embed_source:
+            continue
+        fields.append({"name": field.name, "type": field_type})
+    return fields
+
+
+def _binding_limits(rt: Any) -> dict[str, int]:
+    """Return runtime limits that were explicitly configured for the binding.
+
+    Defaults are intentionally excluded so the output reflects deliberate
+    overrides rather than implementation defaults.
+    """
+    runtime = rt.binding.runtime
+    configured = runtime.model_fields_set
+    return {
+        name: getattr(runtime, name) for name in _LIMIT_FIELDS if name in configured
+    }
+
+
+def _describe_binding(rt: Any) -> dict[str, Any]:
+    """Build the deterministic discovery payload for a single binding."""
+    entry: dict[str, Any] = {"id": rt.binding_id}
+    if rt.binding.description is not None:
+        entry["description"] = rt.binding.description
+    # Reflects both global read-only and the per-index read_only policy.
+    entry["upsert_available"] = not rt.effective_read_only
+    entry["fields"] = _binding_fields(rt)
+    limits = _binding_limits(rt)
+    if limits:
+        entry["limits"] = limits
+    return entry
+
+
+def list_indexes(server: Any) -> dict[str, Any]:
+    """Return the discovery payload for every configured binding.
+
+    The Redis index name (``redis_name``) is intentionally never exposed.
+    """
+    return {
+        "indexes": [_describe_binding(rt) for rt in server._bindings.values()],
+    }
+
+
+def register_list_indexes_tool(server: Any) -> None:
+    """Register the always-available, read-only `list-indexes` MCP tool."""
+    description = (
+        getattr(server.mcp_settings, "tool_list_indexes_description", None)
+        or DEFAULT_LIST_INDEXES_DESCRIPTION
+    )
+
+    async def list_indexes_tool():
+        """FastMCP wrapper for the `list-indexes` tool."""
+        read_scope = getattr(getattr(server, "auth_config", None), "read_scope", None)
+        ensure_tool_scope(server, read_scope)
+        return list_indexes(server)
+
+    server.tool(name="list-indexes", description=description)(list_indexes_tool)

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -1,6 +1,10 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from redisvl.mcp.auth import ensure_tool_scope
+from redisvl.mcp.runtime import BindingRuntime
+
+if TYPE_CHECKING:
+    from redisvl.mcp.server import RedisVLMCPServer
 
 DEFAULT_LIST_INDEXES_DESCRIPTION = (
     "List the logical indexes configured on this server. Each entry reports the "
@@ -14,15 +18,15 @@ DEFAULT_LIST_INDEXES_DESCRIPTION = (
 _LIMIT_FIELDS = ("max_limit", "max_upsert_records")
 
 
-def _binding_fields(rt: Any) -> list[dict[str, str]]:
+def _binding_fields(binding_runtime: BindingRuntime) -> list[dict[str, str]]:
     """Return a binding's shared filterable fields from its inspected schema.
 
     The vector field and the configured default embed-source text field are
     omitted: they are implementation inputs, not fields a client filters on.
     """
-    embed_source = rt.binding.runtime.default_embed_text_field
+    embed_source = binding_runtime.binding.runtime.default_embed_text_field
     fields: list[dict[str, str]] = []
-    for field in rt.schema.fields.values():
+    for field in binding_runtime.schema.fields.values():
         field_type = str(getattr(field.type, "value", field.type))
         if field_type.lower() == "vector":
             continue
@@ -32,44 +36,47 @@ def _binding_fields(rt: Any) -> list[dict[str, str]]:
     return fields
 
 
-def _binding_limits(rt: Any) -> dict[str, int]:
+def _binding_limits(binding_runtime: BindingRuntime) -> dict[str, int]:
     """Return runtime limits that were explicitly configured for the binding.
 
     Defaults are intentionally excluded so the output reflects deliberate
     overrides rather than implementation defaults.
     """
-    runtime = rt.binding.runtime
+    runtime = binding_runtime.binding.runtime
     configured = runtime.model_fields_set
     return {
         name: getattr(runtime, name) for name in _LIMIT_FIELDS if name in configured
     }
 
 
-def _describe_binding(rt: Any) -> dict[str, Any]:
+def _describe_binding(binding_runtime: BindingRuntime) -> dict[str, Any]:
     """Build the deterministic discovery payload for a single binding."""
-    entry: dict[str, Any] = {"id": rt.binding_id}
-    if rt.binding.description is not None:
-        entry["description"] = rt.binding.description
+    entry: dict[str, Any] = {"id": binding_runtime.binding_id}
+    if binding_runtime.binding.description is not None:
+        entry["description"] = binding_runtime.binding.description
     # Reflects both global read-only and the per-index read_only policy.
-    entry["upsert_available"] = not rt.effective_read_only
-    entry["fields"] = _binding_fields(rt)
-    limits = _binding_limits(rt)
+    entry["upsert_available"] = not binding_runtime.effective_read_only
+    entry["fields"] = _binding_fields(binding_runtime)
+    limits = _binding_limits(binding_runtime)
     if limits:
         entry["limits"] = limits
     return entry
 
 
-def list_indexes(server: Any) -> dict[str, Any]:
+def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
     """Return the discovery payload for every configured binding.
 
     The Redis index name (``redis_name``) is intentionally never exposed.
     """
     return {
-        "indexes": [_describe_binding(rt) for rt in server._bindings.values()],
+        "indexes": [
+            _describe_binding(binding_runtime)
+            for binding_runtime in server._bindings.values()
+        ],
     }
 
 
-def register_list_indexes_tool(server: Any) -> None:
+def register_list_indexes_tool(server: "RedisVLMCPServer") -> None:
     """Register the always-available, read-only `list-indexes` MCP tool."""
     description = (
         getattr(server.mcp_settings, "tool_list_indexes_description", None)

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -78,15 +78,14 @@ def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
 
 def register_list_indexes_tool(server: "RedisVLMCPServer") -> None:
     """Register the always-available, read-only `list-indexes` MCP tool."""
-    description = (
-        getattr(server.mcp_settings, "tool_list_indexes_description", None)
-        or DEFAULT_LIST_INDEXES_DESCRIPTION
-    )
 
     async def list_indexes_tool():
         """FastMCP wrapper for the `list-indexes` tool."""
-        read_scope = getattr(getattr(server, "auth_config", None), "read_scope", None)
+        auth_config = getattr(server, "auth_config", None)
+        read_scope = auth_config.read_scope if auth_config is not None else None
         ensure_tool_scope(server, read_scope)
         return list_indexes(server)
 
-    server.tool(name="list-indexes", description=description)(list_indexes_tool)
+    server.tool(name="list-indexes", description=DEFAULT_LIST_INDEXES_DESCRIPTION)(
+        list_indexes_tool
+    )

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -68,6 +68,11 @@ def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
 
     The Redis index name (``redis_name``) is intentionally never exposed.
     """
+    # Mirror resolve_binding: with no bindings the server is not started (or has
+    # been torn down), so fail loudly rather than return an empty list that a
+    # client could misread as "no indexes configured".
+    if not server._bindings:
+        raise RuntimeError("MCP server has not been started")
     return {
         "indexes": [
             _describe_binding(binding_runtime)

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -56,12 +56,15 @@ def _build_search_tool_description(
     """Build the `search-records` description from static text plus schema hints.
 
     With multiple bindings configured the schema is ambiguous (the caller picks
-    an index per call via `list-indexes`), so `schema` is None and only the
-    base description is returned.
+    an index per call via `list-indexes`), so per-field hints are omitted and a
+    routing note is appended instead.
     """
     description = (base_description or DEFAULT_SEARCH_DESCRIPTION).strip()
     if schema is None:
-        return description
+        return (
+            description + " Multiple indexes are configured: call list-indexes "
+            "first, then pass the chosen index id as the `index` argument."
+        )
 
     # `exists` is currently accepted for any schema field in the MCP object filter.
     exists_fields = [field.name for field in schema.fields.values()]
@@ -427,14 +430,21 @@ async def search_records(
     server: Any,
     *,
     query: str,
+    index: str | None = None,
     limit: int | None = None,
     offset: int = 0,
     filter: str | dict[str, Any] | None = None,
     return_fields: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Execute `search-records` against the selected Redis index binding."""
+    """Execute `search-records` against the selected Redis index binding.
+
+    ``index`` names the logical binding to query. It is optional when exactly
+    one binding is configured (preserving single-index behavior) and required
+    when multiple bindings exist. The resolved logical id is echoed back in the
+    response so multi-index clients can confirm routing.
+    """
     try:
-        rt = server.resolve_binding(None)
+        rt = server.resolve_binding(index)
         effective_limit, effective_return_fields = _validate_request(
             query=query,
             limit=limit,
@@ -458,6 +468,7 @@ async def search_records(
         )
         sliced_results = raw_results[offset : offset + effective_limit]
         return {
+            "index": rt.binding_id,
             "search_type": search_type,
             "offset": offset,
             "limit": effective_limit,
@@ -485,6 +496,7 @@ def register_search_tool(server: Any, schema: IndexSchema | None) -> None:
 
     async def search_records_tool(
         query: str,
+        index: str | None = None,
         limit: int | None = None,
         offset: int = 0,
         filter: str | dict[str, Any] | None = None,
@@ -497,6 +509,7 @@ def register_search_tool(server: Any, schema: IndexSchema | None) -> None:
         return await search_records(
             server,
             query=query,
+            index=index,
             limit=limit,
             offset=offset,
             filter=filter,

--- a/tests/integration/test_mcp/test_search_tool.py
+++ b/tests/integration/test_mcp/test_search_tool.py
@@ -214,6 +214,108 @@ async def started_server(monkeypatch, searchable_index, mcp_config_path):
         await server.shutdown()
 
 
+@pytest.fixture
+async def multi_index_server(
+    monkeypatch, searchable_index, fulltext_only_index, tmp_path, redis_url
+):
+    monkeypatch.setattr(
+        "redisvl.mcp.server.resolve_vectorizer_class",
+        lambda class_name: FakeVectorizer,
+    )
+
+    config = {
+        "server": {"redis_url": redis_url},
+        "indexes": {
+            "knowledge": {
+                "redis_name": searchable_index.schema.index.name,
+                "search": {"type": "vector"},
+                "vectorizer": {
+                    "class": "FakeVectorizer",
+                    "model": "fake-model",
+                    "dims": 3,
+                },
+                "runtime": {
+                    "text_field_name": "content",
+                    "vector_field_name": "embedding",
+                    "default_embed_text_field": "content",
+                    "default_limit": 2,
+                    "max_limit": 5,
+                },
+            },
+            "tickets": {
+                "redis_name": fulltext_only_index.schema.index.name,
+                "search": {"type": "fulltext", "params": {"stopwords": None}},
+                "runtime": {
+                    "text_field_name": "content",
+                    "vector_field_name": None,
+                    "default_embed_text_field": None,
+                    "default_limit": 2,
+                    "max_limit": 5,
+                },
+            },
+        },
+    }
+    config_path = tmp_path / "multi-index-search.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    server = RedisVLMCPServer(MCPSettings(config=str(config_path)))
+    await server.startup()
+    try:
+        yield server
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_search_records_routes_to_named_binding(multi_index_server):
+    knowledge = await search_records(
+        multi_index_server,
+        query="science",
+        index="knowledge",
+        return_fields=["content", "category"],
+    )
+    assert knowledge["index"] == "knowledge"
+    assert knowledge["search_type"] == "vector"
+    assert knowledge["results"]
+
+    tickets = await search_records(
+        multi_index_server,
+        query="science",
+        index="tickets",
+        return_fields=["content", "category"],
+    )
+    assert tickets["index"] == "tickets"
+    assert tickets["search_type"] == "fulltext"
+    assert tickets["results"]
+
+
+@pytest.mark.asyncio
+async def test_search_records_requires_index_when_multiple_bindings(multi_index_server):
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        await search_records(multi_index_server, query="science")
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_search_records_rejects_unknown_index_on_multi_binding(
+    multi_index_server,
+):
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        await search_records(multi_index_server, query="science", index="missing")
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_search_records_single_binding_echoes_index_when_omitted(started_server):
+    server = await started_server({"type": "vector"})
+
+    response = await search_records(server, query="science")
+
+    assert response["index"] == "knowledge"
+
+
 @pytest.mark.asyncio
 async def test_search_records_vector_success_with_pagination_and_projection(
     started_server,

--- a/tests/integration/test_mcp/test_server_startup.py
+++ b/tests/integration/test_mcp/test_server_startup.py
@@ -9,6 +9,7 @@ from redisvl.index import AsyncSearchIndex
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.server import RedisVLMCPServer
 from redisvl.mcp.settings import MCPSettings
+from redisvl.mcp.tools.list_indexes import list_indexes
 from redisvl.redis.connection import is_version_gte
 from redisvl.schema import IndexSchema
 from tests.conftest import (
@@ -730,3 +731,78 @@ async def test_server_startup_fails_when_one_binding_is_invalid(
 
     assert server._lifecycle_state.name == "STOPPED"
     assert server._bindings == {}
+
+
+@pytest.mark.asyncio
+async def test_list_indexes_derives_fields_from_inspected_schema(
+    monkeypatch, existing_index, multi_index_config_path
+):
+    knowledge = await existing_index(index_name="mcp-list-knowledge")
+    tickets = await existing_index(index_name="mcp-list-tickets")
+    monkeypatch.setattr(
+        "redisvl.mcp.server.resolve_vectorizer_class",
+        lambda class_name: FakeVectorizer,
+    )
+    server = RedisVLMCPServer(
+        MCPSettings(
+            config=multi_index_config_path(
+                {
+                    # Vector binding: content is the embed source.
+                    "knowledge": {
+                        "redis_name": knowledge.name,
+                        "description": "Product docs",
+                        "vectorizer": {
+                            "class": "FakeVectorizer",
+                            "model": "fake-model",
+                            "dims": 3,
+                        },
+                        "search": {"type": "vector"},
+                        "runtime": {
+                            "text_field_name": "content",
+                            "vector_field_name": "embedding",
+                            "default_embed_text_field": "content",
+                            "max_limit": 25,
+                        },
+                    },
+                    # Fulltext binding: no embed source, read-only.
+                    "tickets": {
+                        "redis_name": tickets.name,
+                        "read_only": True,
+                        "search": {"type": "fulltext"},
+                        "runtime": {"text_field_name": "content"},
+                    },
+                }
+            )
+        )
+    )
+
+    await server.startup()
+
+    try:
+        result = list_indexes(server)
+        indexes = {entry["id"]: entry for entry in result["indexes"]}
+
+        # Both bindings are discoverable; redis_name is never leaked.
+        assert set(indexes) == {"knowledge", "tickets"}
+        for entry in indexes.values():
+            assert "redis_name" not in entry
+            assert knowledge.name not in entry.values()
+            assert tickets.name not in entry.values()
+
+        # Fields come from the inspected schema. The vector field is always
+        # omitted; the embed-source field is omitted only where configured.
+        knowledge_fields = {f["name"] for f in indexes["knowledge"]["fields"]}
+        tickets_fields = {f["name"] for f in indexes["tickets"]["fields"]}
+        assert "embedding" not in knowledge_fields
+        assert "embedding" not in tickets_fields
+        assert "content" not in knowledge_fields  # embed source omitted
+        assert "content" in tickets_fields  # no embed source configured
+
+        # Per-index write policy and explicit limits are reflected.
+        assert indexes["knowledge"]["upsert_available"] is True
+        assert indexes["tickets"]["upsert_available"] is False
+        assert indexes["knowledge"]["limits"] == {"max_limit": 25}
+        assert "limits" not in indexes["tickets"]
+        assert indexes["knowledge"]["description"] == "Product docs"
+    finally:
+        await server.shutdown()

--- a/tests/unit/test_mcp/test_list_indexes_tool_unit.py
+++ b/tests/unit/test_mcp/test_list_indexes_tool_unit.py
@@ -1,0 +1,222 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from redisvl.mcp.config import MCPConfig
+from redisvl.mcp.runtime import BindingRuntime
+from redisvl.mcp.tools.list_indexes import list_indexes, register_list_indexes_tool
+from redisvl.schema import IndexSchema
+
+
+def _schema() -> IndexSchema:
+    return IndexSchema.from_dict(
+        {
+            "index": {
+                "name": "docs-index",
+                "prefix": "doc",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {"name": "title", "type": "text"},
+                {"name": "content", "type": "text"},
+                {"name": "category", "type": "tag"},
+                {"name": "rating", "type": "numeric"},
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "attrs": {
+                        "algorithm": "flat",
+                        "dims": 3,
+                        "distance_metric": "cosine",
+                        "datatype": "float32",
+                    },
+                },
+            ],
+        }
+    )
+
+
+def _binding_runtime(
+    binding_id: str = "knowledge",
+    *,
+    runtime: dict[str, Any] | None = None,
+    description: str | None = None,
+    read_only: bool = False,
+    effective_read_only: bool = False,
+    schema: IndexSchema | None = None,
+) -> BindingRuntime:
+    runtime_config = {
+        "vector_field_name": "embedding",
+        "default_embed_text_field": "content",
+    }
+    if runtime:
+        runtime_config.update(runtime)
+
+    binding_dict: dict[str, Any] = {
+        "redis_name": f"{binding_id}-redis-name",
+        "read_only": read_only,
+        "vectorizer": {"class": "FakeVectorizer", "model": "test-model"},
+        "search": {"type": "vector"},
+        "runtime": runtime_config,
+    }
+    if description is not None:
+        binding_dict["description"] = description
+
+    config = MCPConfig.model_validate(
+        {
+            "server": {"redis_url": "redis://localhost:6379"},
+            "indexes": {binding_id: binding_dict},
+        }
+    )
+    return BindingRuntime(
+        binding_id=binding_id,
+        binding=config.indexes[binding_id],
+        index=SimpleNamespace(),
+        schema=schema or _schema(),
+        vectorizer=None,
+        supports_native_hybrid_search=False,
+        effective_read_only=effective_read_only,
+    )
+
+
+class FakeServer:
+    def __init__(self, bindings: list[BindingRuntime]):
+        self._bindings = {rt.binding_id: rt for rt in bindings}
+        self.mcp_settings = SimpleNamespace()
+        self.auth_config = None
+        self._auth_enabled = False
+        self.registered_tools: list[dict[str, Any]] = []
+
+    def tool(self, name=None, description=None, **kwargs):
+        def decorator(fn):
+            self.registered_tools.append(
+                {"name": name, "description": description, "fn": fn}
+            )
+            return fn
+
+        return decorator
+
+
+def test_list_indexes_minimal_single_binding():
+    server = FakeServer([_binding_runtime()])
+
+    result = list_indexes(server)
+
+    assert result == {
+        "indexes": [
+            {
+                "id": "knowledge",
+                "upsert_available": True,
+                "fields": [
+                    {"name": "title", "type": "text"},
+                    {"name": "category", "type": "tag"},
+                    {"name": "rating", "type": "numeric"},
+                ],
+            }
+        ]
+    }
+
+
+def test_list_indexes_omits_vector_and_embed_source_fields():
+    server = FakeServer([_binding_runtime()])
+
+    fields = list_indexes(server)["indexes"][0]["fields"]
+    field_names = [field["name"] for field in fields]
+
+    # embedding is the vector field; content is the default embed-source field.
+    assert "embedding" not in field_names
+    assert "content" not in field_names
+
+
+def test_list_indexes_includes_description_when_configured():
+    server = FakeServer([_binding_runtime(description="Product docs and runbooks")])
+
+    entry = list_indexes(server)["indexes"][0]
+
+    assert entry["description"] == "Product docs and runbooks"
+
+
+def test_list_indexes_omits_description_when_absent():
+    server = FakeServer([_binding_runtime()])
+
+    assert "description" not in list_indexes(server)["indexes"][0]
+
+
+def test_list_indexes_upsert_available_reflects_effective_read_only():
+    server = FakeServer(
+        [
+            _binding_runtime("knowledge", effective_read_only=False),
+            _binding_runtime("tickets", read_only=True, effective_read_only=True),
+        ]
+    )
+
+    indexes = {entry["id"]: entry for entry in list_indexes(server)["indexes"]}
+
+    assert indexes["knowledge"]["upsert_available"] is True
+    assert indexes["tickets"]["upsert_available"] is False
+
+
+def test_list_indexes_includes_limits_only_when_explicitly_configured():
+    server = FakeServer(
+        [
+            _binding_runtime(
+                "explicit",
+                runtime={"max_limit": 25, "max_upsert_records": 64},
+            ),
+            _binding_runtime("defaults"),
+        ]
+    )
+
+    indexes = {entry["id"]: entry for entry in list_indexes(server)["indexes"]}
+
+    assert indexes["explicit"]["limits"] == {
+        "max_limit": 25,
+        "max_upsert_records": 64,
+    }
+    assert "limits" not in indexes["defaults"]
+
+
+def test_list_indexes_includes_only_the_explicitly_set_limit():
+    server = FakeServer([_binding_runtime(runtime={"max_limit": 25})])
+
+    entry = list_indexes(server)["indexes"][0]
+
+    assert entry["limits"] == {"max_limit": 25}
+
+
+def test_list_indexes_never_exposes_redis_name():
+    server = FakeServer([_binding_runtime()])
+
+    entry = list_indexes(server)["indexes"][0]
+
+    assert "redis_name" not in entry
+    assert "knowledge-redis-name" not in entry.values()
+
+
+def test_list_indexes_preserves_binding_order():
+    server = FakeServer(
+        [
+            _binding_runtime("knowledge"),
+            _binding_runtime("tickets"),
+        ]
+    )
+
+    ids = [entry["id"] for entry in list_indexes(server)["indexes"]]
+
+    assert ids == ["knowledge", "tickets"]
+
+
+@pytest.mark.asyncio
+async def test_register_list_indexes_tool_is_read_only_and_callable():
+    server = FakeServer([_binding_runtime()])
+
+    register_list_indexes_tool(server)
+
+    assert len(server.registered_tools) == 1
+    tool = server.registered_tools[0]
+    assert tool["name"] == "list-indexes"
+    assert tool["description"]
+
+    result = await tool["fn"]()
+    assert result == list_indexes(server)

--- a/tests/unit/test_mcp/test_list_indexes_tool_unit.py
+++ b/tests/unit/test_mcp/test_list_indexes_tool_unit.py
@@ -98,6 +98,15 @@ class FakeServer:
         return decorator
 
 
+def test_list_indexes_raises_when_no_bindings():
+    # Before startup / after shutdown _bindings is empty; discovery must fail
+    # loudly rather than return an empty list a client could misread.
+    server = FakeServer([])
+
+    with pytest.raises(RuntimeError, match="has not been started"):
+        list_indexes(server)
+
+
 def test_list_indexes_minimal_single_binding():
     server = FakeServer([_binding_runtime()])
 

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -111,8 +111,16 @@ class FakeServer:
         self.vectorizer = FakeVectorizer() if include_vectorizer else None
         self.registered_tools = []
         self.native_hybrid_supported = False
+        self.resolved_index_ids: list[str | None] = []
 
     def resolve_binding(self, index_id=None):
+        self.resolved_index_ids.append(index_id)
+        if index_id is not None and index_id != "knowledge":
+            raise RedisVLMCPError(
+                f"Unknown index '{index_id}'; available: knowledge",
+                code=MCPErrorCode.INVALID_REQUEST,
+                retryable=False,
+            )
         return BindingRuntime(
             binding_id="knowledge",
             binding=self.config.indexes["knowledge"],
@@ -313,6 +321,7 @@ async def test_search_records_builds_vector_query_and_normalizes_results(monkeyp
     assert built_queries[0]["normalize_vector_distance"] is False
     assert built_queries[0]["ef_runtime"] == 42
     assert response == {
+        "index": "knowledge",
         "search_type": "vector",
         "offset": 0,
         "limit": 2,
@@ -757,6 +766,64 @@ def test_build_search_tool_description_preserves_schema_order_and_excludes_vecto
     )
     assert "Allowed return_fields: content, category, rating." in description
     assert "embedding" not in description.split("Allowed return_fields: ", 1)[1]
+
+
+@pytest.mark.asyncio
+async def test_search_records_defaults_to_sole_binding_when_index_omitted(monkeypatch):
+    server = FakeServer()
+
+    async def fake_query(query):
+        return []
+
+    server.index.query = fake_query
+
+    response = await search_records(server, query="science")
+
+    assert server.resolved_index_ids == [None]
+    assert response["index"] == "knowledge"
+
+
+@pytest.mark.asyncio
+async def test_search_records_routes_to_named_index(monkeypatch):
+    server = FakeServer()
+
+    async def fake_query(query):
+        return []
+
+    server.index.query = fake_query
+
+    response = await search_records(server, query="science", index="knowledge")
+
+    assert server.resolved_index_ids == ["knowledge"]
+    assert response["index"] == "knowledge"
+
+
+@pytest.mark.asyncio
+async def test_search_records_rejects_unknown_index():
+    server = FakeServer()
+
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        await search_records(server, query="science", index="missing")
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_REQUEST
+    assert server.resolved_index_ids == ["missing"]
+
+
+def test_register_search_tool_wrapper_exposes_index_param():
+    server = FakeServer()
+    register_search_tool(server, server.index.schema)
+
+    annotations = server.registered_tools[0]["fn"].__annotations__
+    assert "index" in annotations
+
+
+def test_build_search_tool_description_appends_routing_note_when_schema_is_ambiguous():
+    description = _build_search_tool_description(None)
+
+    assert "list-indexes" in description
+    assert "`index`" in description
+    # Per-field hints are omitted because the index is ambiguous.
+    assert "Object filter fields" not in description
 
 
 def test_build_search_tool_description_distinguishes_typed_and_exists_support():

--- a/tests/unit/test_mcp/test_server.py
+++ b/tests/unit/test_mcp/test_server.py
@@ -424,6 +424,9 @@ async def test_server_registers_tools_with_effective_schema(monkeypatch):
     )
     monkeypatch.setattr("redisvl.mcp.server.register_upsert_tool", lambda server: None)
     monkeypatch.setattr(
+        "redisvl.mcp.server.register_list_indexes_tool", lambda server: None
+    )
+    monkeypatch.setattr(
         "redisvl.mcp.server.AsyncSearchIndex.disconnect",
         fake_disconnect,
         raising=False,


### PR DESCRIPTION
## Motivation

With a single MCP server now able to expose multiple logical index bindings ([RAAE-1604](https://redislabs.atlassian.net/browse/RAAE-1604)) and advertise them via `list-indexes` ([RAAE-1605](https://redislabs.atlassian.net/browse/RAAE-1605)), the `search-records` tool still implicitly resolved the sole binding. On a multi-binding server it had no way to say *which* index a query should run against. This change ([RAAE-1606](https://redislabs.atlassian.net/browse/RAAE-1606)) makes that routing explicit while keeping the public contract backwards-safe for existing single-index callers.

The design goal is that v1 clients see no behavioral change: when exactly one binding is configured and the caller omits `index`, the request resolves to that binding exactly as before. Routing only becomes mandatory once ambiguity exists. Query construction, validation, pagination, filtering, and the configured search mode all remain owned by the selected binding — this ticket adds only the selection and a confirmation echo, not new query behavior.

## Implemented changes

`search-records` gains an optional `index` argument naming the logical binding to query. Resolution flows through the shared `resolve_binding` routing introduced in RAAE-1604, so the three cases fall out consistently: an omitted `index` with one binding resolves to that binding; an omitted `index` with multiple bindings returns `invalid_request`; and an unknown id returns `invalid_request`. The resolved logical id is echoed back as the `index` field of the response payload so multi-index clients can confirm where a query actually ran. All downstream work (limits, schema, vectorizer, search config) continues to read from the resolved binding's runtime.

When multiple bindings are configured the tool description is ambiguous about fields, so instead of emitting per-field filter hints it now appends a short routing note directing the client to call `list-indexes` first and pass the chosen id as `index`. Single-binding servers keep their full schema-derived description unchanged.

Minor additional changes:

- The FastMCP wrapper exposes `index` as a tool parameter so MCP clients can supply it.
- Unit coverage for default-to-sole-binding, named routing, unknown-id rejection, the wrapper param, and the ambiguous-schema description note.
- Integration coverage for a two-binding server: routing to each named binding, omitted-index rejection, unknown-id rejection, and single-binding echo.

## Verification

- `make format` (isort + black) and mypy clean on changed files.
- Full MCP suite: **232 passed, 2 skipped** (Redis-version-gated) across unit + integration.

## Stacking

This PR targets `feature/raae-1605-list-indexes` so its diff stays scoped to search routing. Review/merge bottom-up: [#629](https://github.com/redis/redis-vl-python/pull/629) → [#630](https://github.com/redis/redis-vl-python/pull/630) → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RAAE-1604]: https://redislabs.atlassian.net/browse/RAAE-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAAE-1605]: https://redislabs.atlassian.net/browse/RAAE-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAAE-1606]: https://redislabs.atlassian.net/browse/RAAE-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible for single-index callers; changes are limited to MCP search routing and an additive response field, with validation delegated to existing `resolve_binding`.
> 
> **Overview**
> The MCP **`search-records`** tool now accepts an optional **`index`** argument so clients can target a specific logical binding on multi-index servers. Resolution goes through **`resolve_binding`**: omitting **`index`** still works when only one binding exists; with multiple bindings, **`index`** is required and unknown ids return **`invalid_request`**.
> 
> Successful responses include a new **`index`** field with the resolved binding id so callers can confirm routing. The FastMCP wrapper exposes **`index`** as a tool parameter.
> 
> When the server has multiple indexes, the tool description skips per-schema filter/return-field hints and instead tells clients to call **`list-indexes`** and pass the chosen id as **`index`**. Single-index servers keep the full schema-derived description.
> 
> Unit and integration tests cover named routing, omitted-index errors on multi-binding setups, unknown-index rejection, single-binding echo behavior, and the ambiguous-schema description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f30d5f29c10ca25ea451ee8a3fdd581cc3b70f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->