### PR TITLE
fix(docs): broken link to Redis Software page

### DIFF
--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -125,7 +125,7 @@ RedisVL requires Redis with [Redis Search](https://redis.io/docs/latest/develop/
 
 1. [Redis Cloud](https://redis.io/cloud), a fully managed cloud offering with a free tier
 2. [Redis 8+ (Docker)](https://redis.io/downloads/), for local development and testing
-3. [Redis Enterprise](https://redis.com/redis-enterprise/), a commercial self-hosted option
+3. [Redis Enterprise](https://redis.io/software/), a commercial self-hosted option
 
 ### Redis Cloud
 


### PR DESCRIPTION
Spotted while doing a sweep of the corresponding Redis docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL correction with no code or runtime impact.
> 
> **Overview**
> Updates the **Redis Enterprise** option in the installation guide so its hyperlink points to `https://redis.io/software/` instead of the outdated `https://redis.com/redis-enterprise/` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d2172cbd83f56429cd1986e1d93d8f197a280f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->