### PR TITLE
Use PyPI Trusted Publishing for publishing releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -251,6 +251,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [gate, release]
     if: needs.gate.outputs.should_release == 'true'
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Check out repository
@@ -281,6 +284,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI }}
-        run: uv publish
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Summary

- Switch PyPI publishing to Trusted Publishing via GitHub OIDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production packages are authenticated and published; misconfigured PyPI Trusted Publishing or job permissions would block releases until fixed.
> 
> **Overview**
> Release publishing no longer uses a long-lived **`PYPI`** secret with **`uv publish`**. The **`build-and-publish`** job now grants **`id-token: write`** (and **`contents: read`**) and uploads wheels/sdists with **`pypa/gh-action-pypi-publish@release/v1`**, which authenticates to PyPI through GitHub OIDC Trusted Publishing.
> 
> **`uv build`** is unchanged; only the upload step and job permissions differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc048fa469400e51fcede8b6755d28c723dc28a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->