### PR TITLE
docs: fix 404 vector range query link in docstring

### DIFF
--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -926,7 +926,7 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
             TypeError: If filter_expression is not of type redisvl.query.FilterExpression
 
         Note:
-            Learn more about vector range queries: https://redis.io/docs/interact/search-and-query/search/vectors/#range-query
+            Learn more about vector range queries: https://redis.io/docs/latest/develop/ai/search-and-query/vectors/#range-query
 
         """
         self._vector = vector


### PR DESCRIPTION
## Summary
Fixes #622

The `VectorRangeQuery` docstring linked to a stale Redis docs URL that now returns a 404:

- Old (404): `https://redis.io/docs/interact/search-and-query/search/vectors/#range-query`
- New (200): `https://redis.io/docs/latest/develop/ai/search-and-query/vectors/#range-query`

The new URL matches the style already used by the `VectorQuery` docstring link in the same file.

## Notes
- Docstring-only change; no code behavior is affected, so the commit carries `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation URL change only; no executable code paths are affected.
> 
> **Overview**
> Updates the **VectorRangeQuery** docstring “Note” link from the old `redis.io/docs/interact/...` path (404) to `redis.io/docs/latest/develop/ai/search-and-query/vectors/#range-query`, matching the **VectorQuery** docstring in the same file.
> 
> Docstring-only; no runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285447dd651ed994135aba55894eafb03e830381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->