### PR TITLE
feat: GoogleGenAIVectorizer — migrate Google embeddings to the supported google-genai SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}

--- a/docs/api/vectorizer.rst
+++ b/docs/api/vectorizer.rst
@@ -8,7 +8,8 @@ Vectorizers
    compatibility:
 
    - ``VoyageAITextVectorizer`` → Use ``VoyageAIVectorizer`` instead
-   - ``VertexAITextVectorizer`` → Use ``VertexAIVectorizer`` instead
+   - ``VertexAITextVectorizer`` → Use ``GoogleGenAIVectorizer`` instead
+     (``VertexAIVectorizer`` is itself deprecated; see below)
    - ``BedrockTextVectorizer`` → Use ``BedrockVectorizer`` instead
    - ``CustomTextVectorizer`` → Use ``CustomVectorizer`` instead
 
@@ -59,11 +60,27 @@ VertexAIVectorizer
 .. currentmodule:: redisvl.utils.vectorize.vertexai
 
 .. note::
-    For backwards compatibility, an alias ``VertexAITextVectorizer`` is available
-    in the ``redisvl.utils.vectorize.text`` module. This alias is deprecated
-    as of version 0.13.0 and will be removed in a future major release.
+    ``VertexAIVectorizer`` is **deprecated**. It uses Google's Vertex AI
+    model-garden SDK, which Google has deprecated with a scheduled removal. Use
+    :class:`~redisvl.utils.vectorize.googlegenai.GoogleGenAIVectorizer` for text
+    embeddings on the supported ``google-genai`` SDK. The alias
+    ``VertexAITextVectorizer`` (in ``redisvl.utils.vectorize.text``) is likewise
+    deprecated. Multimodal (image/video) migration is tracked in
+    `issue #620 <https://github.com/redis/redis-vl-python/issues/620>`_.
 
 .. autoclass:: VertexAIVectorizer
+   :show-inheritance:
+   :members:
+
+
+GoogleGenAIVectorizer
+=====================
+
+.. _googlegenaivectorizer_api:
+
+.. currentmodule:: redisvl.utils.vectorize.googlegenai
+
+.. autoclass:: GoogleGenAIVectorizer
    :show-inheritance:
    :members:
 

--- a/docs/concepts/utilities.md
+++ b/docs/concepts/utilities.md
@@ -35,7 +35,7 @@ Vectorizers handle batching internally, breaking large batches into provider-app
 
 ### Supported Providers
 
-RedisVL includes vectorizers for OpenAI, Azure OpenAI, Cohere, HuggingFace (local), Mistral, Google Vertex AI, AWS Bedrock, VoyageAI, and others. See the {doc}`/api/vectorizer` for the complete list. You can also create custom vectorizers that wrap any embedding function.
+RedisVL includes vectorizers for OpenAI, Azure OpenAI, Cohere, HuggingFace (local), Mistral, Google (via `google-genai`, covering both Vertex AI and the Gemini Developer API), AWS Bedrock, VoyageAI, and others. See the {doc}`/api/vectorizer` for the complete list. You can also create custom vectorizers that wrap any embedding function.
 
 ## Rerankers
 

--- a/docs/user_guide/04_vectorizers.ipynb
+++ b/docs/user_guide/04_vectorizers.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# Create Embeddings with Vectorizers\n",
         "\n",
-        "This guide demonstrates how to create embeddings using RedisVL's built-in text vectorizers. RedisVL supports multiple embedding providers: OpenAI, HuggingFace, Ollama, Vertex AI, Cohere, Mistral AI, Amazon Bedrock, VoyageAI, and custom vectorizers.\n",
+        "This guide demonstrates how to create embeddings using RedisVL's built-in text vectorizers. RedisVL supports multiple embedding providers: OpenAI, HuggingFace, Ollama, Google (Vertex AI and the Gemini Developer API), Cohere, Mistral AI, Amazon Bedrock, VoyageAI, and custom vectorizers.\n",
         "\n",
         "## Prerequisites\n",
         "\n",
@@ -360,6 +360,8 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "> **⚠️ Deprecated.** `VertexAIVectorizer` uses Google's Vertex AI model-garden SDK, which Google has deprecated with a scheduled removal. For text embeddings use the **Google Gen AI** vectorizer shown in the next section (`GoogleGenAIVectorizer`) on the supported `google-genai` SDK. Multimodal (image/video) migration is tracked in [issue #620](https://github.com/redis/redis-vl-python/issues/620).\n",
+        "\n",
         "### VertexAI\n",
         "\n",
         "[VertexAI](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings) is GCP's fully-featured AI platform including a number of pretrained LLMs. RedisVL supports using VertexAI to create embeddings from these models. To use VertexAI, you will first need to install the ``google-cloud-aiplatform`` library.\n",
@@ -400,6 +402,64 @@
         "# embed a sentence\n",
         "test = vtx.embed(\"This is a test sentence.\")\n",
         "test[:10]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Google Gen AI\n",
+        "\n",
+        "The `GoogleGenAIVectorizer` uses Google's [`google-genai`](https://pypi.org/project/google-genai/) SDK — the supported replacement for the deprecated Vertex AI model-garden SDK. It reaches **both** Google embedding backends from a single client:\n",
+        "\n",
+        "- **Vertex AI / Gemini Enterprise** — GCP project auth (`project_id` + `location`, credentials via ADC).\n",
+        "- **Gemini Developer API** — a single `api_key`.\n",
+        "\n",
+        "Install it with `pip install redisvl[google-genai]`.\n",
+        "\n",
+        "**Migrating from `VertexAIVectorizer`:**\n",
+        "\n",
+        "| | `VertexAIVectorizer` (deprecated) | `GoogleGenAIVectorizer` |\n",
+        "|---|---|---|\n",
+        "| SDK | `google-cloud-aiplatform` (deprecated) | `google-genai` (supported) |\n",
+        "| Default model | `textembedding-gecko` (768 dims) | `gemini-embedding-001` (3072 dims) |\n",
+        "| Backends | Vertex AI only | Vertex AI **and** Gemini Developer API |\n",
+        "| Async | no | yes (`aembed`, `aembed_many`) |\n",
+        "\n",
+        "Because the default model and dimensions differ, embeddings are **not** interchangeable — reindex when you switch. When you request a reduced `output_dimensionality`, the vectorizer L2-normalizes the result so it stays valid for Redis COSINE / inner-product search.\n",
+        "\n",
+        "**Set one of the following:**\n",
+        "\n",
+        "```\n",
+        "# Gemini Developer API\n",
+        "GEMINI_API_KEY=<your gemini api key>\n",
+        "\n",
+        "# or Vertex AI\n",
+        "GOOGLE_CLOUD_PROJECT=<your gcp project id>\n",
+        "GOOGLE_CLOUD_LOCATION=<your gcp region>\n",
+        "GOOGLE_APPLICATION_CREDENTIALS=<path to your gcp JSON creds>\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# NBVAL_SKIP  (docs example; not executed in CI so notebook validation makes no API calls)\n",
+        "from redisvl.utils.vectorize import GoogleGenAIVectorizer\n",
+        "\n",
+        "# Auto-detects the backend: GEMINI_API_KEY -> Gemini, else GCP project/location -> Vertex AI.\n",
+        "# Guarded so this notebook still runs when Google credentials aren't configured.\n",
+        "try:\n",
+        "    genai_vectorizer = GoogleGenAIVectorizer(model=\"gemini-embedding-001\")\n",
+        "    print(f\"backend={genai_vectorizer.backend}, dims={genai_vectorizer.dims}\")\n",
+        "    genai_test = genai_vectorizer.embed(\"This is a test sentence.\")\n",
+        "    print(genai_test[:10])\n",
+        "except (ImportError, ValueError) as e:\n",
+        "    print(f\"Skipping GoogleGenAIVectorizer demo: {e}\")\n",
+        "    genai_vectorizer = None\n"
       ]
     },
     {

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -27,7 +27,8 @@ $ pip install redisvl[cohere]              # Cohere embeddings and reranking
 $ pip install redisvl[mistralai]           # Mistral AI embeddings
 $ pip install redisvl[voyageai]            # Voyage AI embeddings and reranking
 $ pip install redisvl[sentence-transformers]  # HuggingFace local embeddings
-$ pip install redisvl[vertexai]            # Google Vertex AI embeddings
+$ pip install redisvl[google-genai]        # Google embeddings (Vertex AI + Gemini API)
+$ pip install redisvl[vertexai]            # Google Vertex AI embeddings (legacy; deprecated, multimodal only)
 $ pip install redisvl[bedrock]             # AWS Bedrock embeddings
 
 # Other optional features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,19 @@ cohere = ["cohere>=4.44"]
 voyageai = ["voyageai>=0.2.2"]
 sentence-transformers = ["sentence-transformers>=3.4.0,<4"]
 langcache = ["langcache>=0.11.0"]
+# Legacy Google backend for the deprecated VertexAIVectorizer. The <2.0.0 cap is
+# intentional: Google's model-garden modules (vertexai.language_models /
+# vertexai.vision_models) that this vectorizer imports are deprecated with a
+# scheduled removal. They still ship in the 1.x line (latest 1.162.0); the 2.0.0
+# release that drops them is yanked on PyPI. Keep the cap so the deprecated class
+# (and its multimodal path, which has no google-genai replacement yet) keeps
+# importing. New text embeddings should use the `google-genai` extra below.
 vertexai = [
     "google-cloud-aiplatform>=1.26,<2.0.0",
     "protobuf>=5.28.0,<6.0.0",
 ]
+# Modern Google backend (Vertex AI + Gemini Developer API) for GoogleGenAIVectorizer.
+google-genai = ["google-genai>=1.0.0"]
 bedrock = [
     "boto3>=1.36.0,<2",
     "urllib3<2.2.0",
@@ -67,6 +76,7 @@ all = [
     "langcache>=0.11.0",
     "google-cloud-aiplatform>=1.26,<2.0.0",
     "protobuf>=5.28.0,<6.0.0",
+    "google-genai>=1.0.0",
     "boto3>=1.36.0,<2",
     "urllib3<2.2.0",
     "pillow>=11.3.0",

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -203,7 +203,15 @@ def deprecated_class(name: str | None = None, replacement: str | None = None):
 
         @wraps(original_init)
         def new_init(self, *args, **kwargs):
-            warn(warning_message, category=DeprecationWarning, stacklevel=2)
+            # Emit only once per instance. When a deprecated subclass wraps a
+            # deprecated parent, both __init__ wrappers run via super().__init__;
+            # the sentinel keeps that to a single warning.
+            if not getattr(self, "_deprecation_warned", False):
+                warn(warning_message, category=DeprecationWarning, stacklevel=2)
+                try:
+                    object.__setattr__(self, "_deprecation_warned", True)
+                except Exception:
+                    pass
             original_init(self, *args, **kwargs)
 
         cls.__init__ = new_init

--- a/redisvl/utils/vectorize/__init__.py
+++ b/redisvl/utils/vectorize/__init__.py
@@ -2,6 +2,7 @@ from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.utils.vectorize.base import BaseVectorizer, Vectorizers
 from redisvl.utils.vectorize.bedrock import BedrockVectorizer
 from redisvl.utils.vectorize.custom import CustomVectorizer
+from redisvl.utils.vectorize.googlegenai import GoogleGenAIVectorizer
 from redisvl.utils.vectorize.text.azureopenai import AzureOpenAITextVectorizer
 from redisvl.utils.vectorize.text.bedrock import BedrockTextVectorizer
 from redisvl.utils.vectorize.text.cohere import CohereTextVectorizer
@@ -20,6 +21,7 @@ __all__ = [
     "CohereTextVectorizer",
     "HFTextVectorizer",
     "OpenAITextVectorizer",
+    "GoogleGenAIVectorizer",
     "VertexAIVectorizer",
     "VertexAITextVectorizer",
     "AzureOpenAITextVectorizer",
@@ -61,6 +63,8 @@ def vectorizer_from_dict(
         return OllamaTextVectorizer(**args)
     elif vectorizer_type == Vectorizers.vertexai:
         return VertexAIVectorizer(**args)
+    elif vectorizer_type == Vectorizers.google_genai:
+        return GoogleGenAIVectorizer(**args)
     elif vectorizer_type == Vectorizers.voyageai:
         return VoyageAIVectorizer(**args)
     else:

--- a/redisvl/utils/vectorize/base.py
+++ b/redisvl/utils/vectorize/base.py
@@ -28,6 +28,7 @@ class Vectorizers(Enum):
     mistral = "mistral"
     ollama = "ollama"
     vertexai = "vertexai"
+    google_genai = "google_genai"
     hf = "hf"
     voyageai = "voyageai"
 

--- a/redisvl/utils/vectorize/googlegenai.py
+++ b/redisvl/utils/vectorize/googlegenai.py
@@ -1,0 +1,390 @@
+import os
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from pydantic import ConfigDict
+from tenacity import (
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+
+from redisvl.utils.vectorize.base import BaseVectorizer
+
+if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+
+# ignore that google.genai isn't imported at module level
+# mypy: disable-error-code="name-defined"
+
+
+class GoogleGenAIVectorizer(BaseVectorizer):
+    """The GoogleGenAIVectorizer creates embeddings with Google's `google-genai`
+    SDK, the supported replacement for the deprecated Vertex AI model-garden SDK
+    used by :class:`VertexAIVectorizer`.
+
+    One client, two backends. `google-genai` reaches both of Google's embedding
+    backends; this vectorizer auto-selects one from your config/environment (or an
+    explicit override):
+
+    - **Vertex AI / Gemini Enterprise** (GCP project auth) — for existing Vertex users.
+    - **Gemini Developer API** (a single API key) — the simplest way to get started.
+
+    Credentials are resolved in this order (explicit beats ambient):
+
+    1. Explicit override — ``api_config={"backend": "vertex" | "gemini"}``.
+    2. Explicit creds in ``api_config`` — ``api_key`` selects Gemini; ``project_id``
+       (+ ``location``) selects Vertex.
+    3. Environment — a project (``GOOGLE_CLOUD_PROJECT`` | ``GCP_PROJECT_ID`` with
+       ``GOOGLE_CLOUD_LOCATION`` | ``GCP_LOCATION`` and Application Default
+       Credentials via ``GOOGLE_APPLICATION_CREDENTIALS``) selects Vertex; otherwise
+       ``GEMINI_API_KEY`` | ``GOOGLE_API_KEY`` selects Gemini. If both a project and a
+       key are present, Vertex wins.
+
+    Install the client with ``pip install redisvl[google-genai]``.
+
+    .. note::
+        The default model ``gemini-embedding-001`` returns **3072-dimensional**
+        vectors (≈4× the width of the legacy ``textembedding-gecko``, so ≈4× the
+        index memory). When you request a reduced ``output_dimensionality`` the API
+        returns **un-normalized** vectors; this vectorizer L2-normalizes them so they
+        are valid for Redis COSINE / inner-product search. Embeddings from different
+        models (or dimensions) are not interchangeable — reindex when you change them.
+
+    .. code-block:: python
+
+        # Vertex AI backend
+        from redisvl.utils.vectorize import GoogleGenAIVectorizer
+
+        vectorizer = GoogleGenAIVectorizer(
+            model="gemini-embedding-001",
+            api_config={
+                "project_id": "your-gcp-project",  # or set GOOGLE_CLOUD_PROJECT
+                "location": "us-central1",         # or set GOOGLE_CLOUD_LOCATION
+            },
+        )
+        embedding = vectorizer.embed("Hello, world!")
+
+        # Gemini Developer API backend
+        vectorizer = GoogleGenAIVectorizer(
+            model="gemini-embedding-001",
+            api_config={"api_key": "your-gemini-api-key"},  # or set GEMINI_API_KEY
+        )
+
+        # Reduced dimensions (returned normalized) + caching
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+
+        vectorizer = GoogleGenAIVectorizer(
+            model="gemini-embedding-001",
+            output_dimensionality=768,
+            cache=EmbeddingsCache(name="genai_embeddings_cache"),
+        )
+
+        # Asynchronous batch embedding
+        embeddings = await vectorizer.aembed_many(
+            ["Hello, world!", "How are you?"], batch_size=2
+        )
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __init__(
+        self,
+        model: str = "gemini-embedding-001",
+        api_config: dict[str, Any] | None = None,
+        dtype: str = "float32",
+        cache: "EmbeddingsCache | None" = None,
+        task_type: str | None = None,
+        output_dimensionality: int | None = None,
+        **kwargs,
+    ):
+        """Initialize the Google GenAI vectorizer.
+
+        Args:
+            model (str): The embedding model to use. Defaults to
+                'gemini-embedding-001', which works on both backends.
+            api_config (Optional[Dict]): Auth/client configuration. Recognized keys:
+                ``backend`` ("vertex"|"gemini"), ``project_id``, ``location``,
+                ``credentials`` (Vertex), and ``api_key`` (Gemini). Model-behavior
+                options are the ``task_type``/``output_dimensionality`` arguments
+                below, not ``api_config`` keys. Defaults to None.
+            dtype (str): The default datatype to use when embedding text as byte
+                arrays. Used when setting ``as_buffer=True``. Defaults to 'float32'.
+            cache (Optional[EmbeddingsCache]): Optional cache for repeated inputs.
+            task_type (Optional[str]): Default embedding task type (e.g.
+                'RETRIEVAL_DOCUMENT', 'RETRIEVAL_QUERY'). Overridable per call.
+            output_dimensionality (Optional[int]): Truncate embeddings to this many
+                dimensions. Truncated vectors are L2-normalized. Overridable per call.
+            **kwargs: Additional arguments forwarded to ``google.genai.Client``
+                (e.g. ``http_options``).
+
+        Raises:
+            ImportError: If the google-genai library is not installed.
+            ValueError: If a backend cannot be resolved, or an invalid dtype is given.
+        """
+        super().__init__(model=model, dtype=dtype, cache=cache)
+        self._setup(api_config, task_type, output_dimensionality, **kwargs)
+
+    def _setup(
+        self,
+        api_config: dict[str, Any] | None,
+        task_type: str | None,
+        output_dimensionality: int | None,
+        **kwargs,
+    ):
+        """Build the default embed config, initialize the client, and set dims."""
+        # Default embed config is set BEFORE _set_model_dims so the dimension-probe
+        # embed uses the same config (e.g. output_dimensionality) as real calls.
+        self._embed_config: dict[str, Any] = {}
+        if task_type is not None:
+            self._embed_config["task_type"] = task_type
+        if output_dimensionality is not None:
+            self._embed_config["output_dimensionality"] = output_dimensionality
+
+        self._initialize_client(api_config, **kwargs)
+        self.dims = self._set_model_dims()
+
+    def _initialize_client(self, api_config: dict[str, Any] | None, **kwargs):
+        """Resolve the backend and construct a single google-genai client.
+
+        Raises:
+            ImportError: If the google-genai library is not installed.
+            ValueError: If no backend can be resolved from config or environment.
+        """
+        # Copy so we never mutate the caller's dict.
+        api_config = dict(api_config or {})
+
+        try:
+            from google import genai
+            from google.genai.types import EmbedContentConfig
+        except ImportError:
+            raise ImportError(
+                "GoogleGenAIVectorizer requires the google-genai library. "
+                "Please install with `pip install redisvl[google-genai]`"
+            )
+
+        self._config_cls = EmbedContentConfig
+        backend = self._resolve_backend(api_config)
+
+        if backend == "vertex":
+            project = (
+                api_config.get("project_id")
+                or os.getenv("GOOGLE_CLOUD_PROJECT")
+                or os.getenv("GCP_PROJECT_ID")
+            )
+            location = (
+                api_config.get("location")
+                or os.getenv("GOOGLE_CLOUD_LOCATION")
+                or os.getenv("GCP_LOCATION")
+            )
+            if not location:
+                raise ValueError(
+                    "Vertex AI backend selected but no location was provided. "
+                    "Set api_config['location'] or the GOOGLE_CLOUD_LOCATION "
+                    "(or GCP_LOCATION) environment variable."
+                )
+            self._client = genai.Client(
+                vertexai=True,
+                project=project,
+                location=location,
+                credentials=api_config.get("credentials"),
+                **kwargs,
+            )
+        else:
+            api_key = (
+                api_config.get("api_key")
+                or os.getenv("GEMINI_API_KEY")
+                or os.getenv("GOOGLE_API_KEY")
+            )
+            self._client = genai.Client(api_key=api_key, **kwargs)
+
+        self._backend = backend
+
+    @staticmethod
+    def _resolve_backend(api_config: dict[str, Any]) -> str:
+        """Return 'vertex' or 'gemini' using explicit-beats-ambient precedence."""
+        # 1. Explicit override.
+        explicit = api_config.get("backend")
+        if explicit is not None:
+            if explicit not in ("vertex", "gemini"):
+                raise ValueError(
+                    f"Invalid api_config['backend']: {explicit!r}. "
+                    "Must be 'vertex' or 'gemini'."
+                )
+            return explicit
+        if "vertexai" in api_config:
+            return "vertex" if api_config["vertexai"] else "gemini"
+
+        # 2. Explicit credentials in api_config.
+        if api_config.get("api_key"):
+            return "gemini"
+        if api_config.get("project_id"):
+            return "vertex"
+
+        # 3. Ambient environment (project beats key).
+        if os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("GCP_PROJECT_ID"):
+            return "vertex"
+        if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
+            return "gemini"
+
+        raise ValueError(
+            "Could not resolve a Google backend. Provide Vertex AI config "
+            "(api_config={'project_id': ..., 'location': ...} or set "
+            "GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION [or GCP_PROJECT_ID/GCP_LOCATION] "
+            "with Application Default Credentials), or a Gemini Developer API key "
+            "(api_config={'api_key': ...} or set GEMINI_API_KEY/GOOGLE_API_KEY)."
+        )
+
+    @property
+    def backend(self) -> str:
+        """The resolved backend: 'vertex' or 'gemini'."""
+        return self._backend
+
+    def _set_model_dims(self) -> int:
+        """Determine embedding dimensionality via a single probe embed."""
+        try:
+            embedding = self._embed("dimension check")
+            return len(embedding)
+        except (KeyError, IndexError, AttributeError) as e:
+            raise ValueError(f"Unexpected response from the Google GenAI API: {e}")
+        except Exception as e:  # pylint: disable=broad-except
+            # Avoid interpolating provider/transport errors, which can embed
+            # credentials, into the message. Chain the original for debugging.
+            raise ValueError(
+                "Error setting embedding model dimensions with the Google GenAI API. "
+                "Verify the model name, backend selection, and credentials."
+            ) from e
+
+    def _build_config(self, extra: dict[str, Any]) -> tuple[Any, bool]:
+        """Merge stored defaults with per-call kwargs into an EmbedContentConfig.
+
+        Returns the config (or None) and whether results should be normalized
+        (true whenever output_dimensionality is requested).
+        """
+        merged = {**self._embed_config, **extra}
+        normalize = merged.get("output_dimensionality") is not None
+        config = self._config_cls(**merged) if merged else None
+        return config, normalize
+
+    @staticmethod
+    def _embeddings_from_response(response: Any, expected: int) -> list:
+        """Return the response embeddings, guarding against None / count mismatch."""
+        embeddings = response.embeddings
+        if not embeddings or len(embeddings) != expected:
+            count = 0 if not embeddings else len(embeddings)
+            raise ValueError(
+                f"Google GenAI API returned {count} embedding(s) for {expected} "
+                "input(s)."
+            )
+        return embeddings
+
+    @staticmethod
+    def _postprocess(values: list[float] | None, normalize: bool) -> list[float]:
+        """Validate and optionally L2-normalize a returned embedding."""
+        if values is None:
+            raise ValueError("No embedding returned from the Google GenAI API.")
+        if normalize:
+            arr = np.asarray(values, dtype=np.float32)
+            norm = float(np.linalg.norm(arr))
+            if norm > 0:
+                return (arr / norm).tolist()
+        return list(values)
+
+    @staticmethod
+    def _validate_many(contents: list[str]) -> None:
+        """Validate batch input without masking the validation error."""
+        if not isinstance(contents, list):
+            raise TypeError(
+                f"Input contents must be a list of strings to embed, got {type(contents)}"
+            )
+        if not all(isinstance(c, str) for c in contents):
+            raise TypeError("Input contents must be a list of strings to embed.")
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
+    )
+    def _embed(self, content: str, **kwargs) -> list[float]:
+        """Generate a vector embedding for a single string."""
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Input content must be a string to embed, got {type(content)}"
+            )
+        config, normalize = self._build_config(kwargs)
+        response = self._client.models.embed_content(
+            model=self.model, contents=content, config=config
+        )
+        embeddings = self._embeddings_from_response(response, 1)
+        return self._postprocess(embeddings[0].values, normalize)
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
+    )
+    def _embed_many(
+        self, contents: list[str], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
+        """Generate vector embeddings for a batch of strings."""
+        self._validate_many(contents)
+        config, normalize = self._build_config(kwargs)
+        embeddings: list[list[float]] = []
+        for batch in self.batchify(contents, batch_size):
+            response = self._client.models.embed_content(
+                model=self.model, contents=batch, config=config
+            )
+            batch_embeddings = self._embeddings_from_response(response, len(batch))
+            embeddings.extend(
+                self._postprocess(e.values, normalize) for e in batch_embeddings
+            )
+        return embeddings
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
+    )
+    async def _aembed(self, content: str, **kwargs) -> list[float]:
+        """Asynchronously generate a vector embedding for a single string."""
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Input content must be a string to embed, got {type(content)}"
+            )
+        config, normalize = self._build_config(kwargs)
+        response = await self._client.aio.models.embed_content(
+            model=self.model, contents=content, config=config
+        )
+        embeddings = self._embeddings_from_response(response, 1)
+        return self._postprocess(embeddings[0].values, normalize)
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        retry=retry_if_not_exception_type(TypeError),
+        reraise=True,
+    )
+    async def _aembed_many(
+        self, contents: list[str], batch_size: int = 10, **kwargs
+    ) -> list[list[float]]:
+        """Asynchronously generate vector embeddings for a batch of strings."""
+        self._validate_many(contents)
+        config, normalize = self._build_config(kwargs)
+        embeddings: list[list[float]] = []
+        for batch in self.batchify(contents, batch_size):
+            response = await self._client.aio.models.embed_content(
+                model=self.model, contents=batch, config=config
+            )
+            batch_embeddings = self._embeddings_from_response(response, len(batch))
+            embeddings.extend(
+                self._postprocess(e.values, normalize) for e in batch_embeddings
+            )
+        return embeddings
+
+    @property
+    def type(self) -> str:
+        return "google_genai"

--- a/redisvl/utils/vectorize/googlegenai.py
+++ b/redisvl/utils/vectorize/googlegenai.py
@@ -112,8 +112,9 @@ class GoogleGenAIVectorizer(BaseVectorizer):
             task_type (Optional[str]): Default embedding task type (e.g.
                 'RETRIEVAL_DOCUMENT', 'RETRIEVAL_QUERY'). Overridable per call.
             output_dimensionality (Optional[int]): Request shorter (Matryoshka)
-                embeddings of this width. Sets ``dims`` accordingly. Note Google does
-                not re-normalize reduced vectors. Overridable per call.
+                embeddings of this width; sets ``dims`` accordingly. Fixed for the
+                vectorizer's lifetime (cannot be overridden per call). Note Google does
+                not re-normalize reduced vectors.
             **kwargs: Additional arguments forwarded to ``google.genai.Client``
                 (e.g. ``http_options``).
 
@@ -255,7 +256,17 @@ class GoogleGenAIVectorizer(BaseVectorizer):
             ) from e
 
     def _build_config(self, extra: dict[str, Any]) -> Any:
-        """Merge stored config defaults with per-call kwargs into an EmbedContentConfig."""
+        """Merge stored config defaults with per-call kwargs into an EmbedContentConfig.
+
+        ``output_dimensionality`` is fixed at construction (it determines ``self.dims``),
+        so it cannot be overridden per call — that would desync returned embeddings from
+        the index's vector width. Other fields (e.g. ``task_type``) may vary per call.
+        """
+        if "output_dimensionality" in extra:
+            raise TypeError(
+                "output_dimensionality cannot be overridden per call; set it on the "
+                "GoogleGenAIVectorizer(...) constructor instead (it determines dims)."
+            )
         merged = {**self._embed_config, **extra}
         return self._config_cls(**merged) if merged else None
 

--- a/redisvl/utils/vectorize/googlegenai.py
+++ b/redisvl/utils/vectorize/googlegenai.py
@@ -1,7 +1,6 @@
 import os
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
 from pydantic import ConfigDict
 from tenacity import (
     retry,
@@ -14,9 +13,6 @@ from redisvl.utils.vectorize.base import BaseVectorizer
 
 if TYPE_CHECKING:
     from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
-
-# ignore that google.genai isn't imported at module level
-# mypy: disable-error-code="name-defined"
 
 
 class GoogleGenAIVectorizer(BaseVectorizer):
@@ -47,10 +43,11 @@ class GoogleGenAIVectorizer(BaseVectorizer):
     .. note::
         The default model ``gemini-embedding-001`` returns **3072-dimensional**
         vectors (≈4× the width of the legacy ``textembedding-gecko``, so ≈4× the
-        index memory). When you request a reduced ``output_dimensionality`` the API
-        returns **un-normalized** vectors; this vectorizer L2-normalizes them so they
-        are valid for Redis COSINE / inner-product search. Embeddings from different
-        models (or dimensions) are not interchangeable — reindex when you change them.
+        index memory). A reduced ``output_dimensionality`` returns shorter vectors that
+        Google does **not** re-normalize; this is invisible under the COSINE metric
+        (scale-invariant) but matters for inner-product / L2 — normalize yourself if your
+        index needs it. Embeddings from different models (or dimensions) are not
+        interchangeable — reindex when you change them.
 
     .. code-block:: python
 
@@ -72,7 +69,7 @@ class GoogleGenAIVectorizer(BaseVectorizer):
             api_config={"api_key": "your-gemini-api-key"},  # or set GEMINI_API_KEY
         )
 
-        # Reduced dimensions (returned normalized) + caching
+        # Reduced dimensions (Matryoshka) + caching
         from redisvl.extensions.cache.embeddings import EmbeddingsCache
 
         vectorizer = GoogleGenAIVectorizer(
@@ -114,8 +111,9 @@ class GoogleGenAIVectorizer(BaseVectorizer):
             cache (Optional[EmbeddingsCache]): Optional cache for repeated inputs.
             task_type (Optional[str]): Default embedding task type (e.g.
                 'RETRIEVAL_DOCUMENT', 'RETRIEVAL_QUERY'). Overridable per call.
-            output_dimensionality (Optional[int]): Truncate embeddings to this many
-                dimensions. Truncated vectors are L2-normalized. Overridable per call.
+            output_dimensionality (Optional[int]): Request shorter (Matryoshka)
+                embeddings of this width. Sets ``dims`` accordingly. Note Google does
+                not re-normalize reduced vectors. Overridable per call.
             **kwargs: Additional arguments forwarded to ``google.genai.Client``
                 (e.g. ``http_options``).
 
@@ -256,16 +254,10 @@ class GoogleGenAIVectorizer(BaseVectorizer):
                 "Verify the model name, backend selection, and credentials."
             ) from e
 
-    def _build_config(self, extra: dict[str, Any]) -> tuple[Any, bool]:
-        """Merge stored defaults with per-call kwargs into an EmbedContentConfig.
-
-        Returns the config (or None) and whether results should be normalized
-        (true whenever output_dimensionality is requested).
-        """
+    def _build_config(self, extra: dict[str, Any]) -> Any:
+        """Merge stored config defaults with per-call kwargs into an EmbedContentConfig."""
         merged = {**self._embed_config, **extra}
-        normalize = merged.get("output_dimensionality") is not None
-        config = self._config_cls(**merged) if merged else None
-        return config, normalize
+        return self._config_cls(**merged) if merged else None
 
     @staticmethod
     def _embeddings_from_response(response: Any, expected: int) -> list:
@@ -280,16 +272,11 @@ class GoogleGenAIVectorizer(BaseVectorizer):
         return embeddings
 
     @staticmethod
-    def _postprocess(values: list[float] | None, normalize: bool) -> list[float]:
-        """Validate and optionally L2-normalize a returned embedding."""
-        if values is None:
+    def _values(embedding: Any) -> list[float]:
+        """Return an embedding's raw values, guarding against a null payload."""
+        if embedding.values is None:
             raise ValueError("No embedding returned from the Google GenAI API.")
-        if normalize:
-            arr = np.asarray(values, dtype=np.float32)
-            norm = float(np.linalg.norm(arr))
-            if norm > 0:
-                return (arr / norm).tolist()
-        return list(values)
+        return list(embedding.values)
 
     @staticmethod
     def _validate_many(contents: list[str]) -> None:
@@ -313,12 +300,12 @@ class GoogleGenAIVectorizer(BaseVectorizer):
             raise TypeError(
                 f"Input content must be a string to embed, got {type(content)}"
             )
-        config, normalize = self._build_config(kwargs)
+        config = self._build_config(kwargs)
         response = self._client.models.embed_content(
             model=self.model, contents=content, config=config
         )
         embeddings = self._embeddings_from_response(response, 1)
-        return self._postprocess(embeddings[0].values, normalize)
+        return self._values(embeddings[0])
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
@@ -331,16 +318,14 @@ class GoogleGenAIVectorizer(BaseVectorizer):
     ) -> list[list[float]]:
         """Generate vector embeddings for a batch of strings."""
         self._validate_many(contents)
-        config, normalize = self._build_config(kwargs)
+        config = self._build_config(kwargs)
         embeddings: list[list[float]] = []
         for batch in self.batchify(contents, batch_size):
             response = self._client.models.embed_content(
                 model=self.model, contents=batch, config=config
             )
             batch_embeddings = self._embeddings_from_response(response, len(batch))
-            embeddings.extend(
-                self._postprocess(e.values, normalize) for e in batch_embeddings
-            )
+            embeddings.extend(self._values(e) for e in batch_embeddings)
         return embeddings
 
     @retry(
@@ -355,12 +340,12 @@ class GoogleGenAIVectorizer(BaseVectorizer):
             raise TypeError(
                 f"Input content must be a string to embed, got {type(content)}"
             )
-        config, normalize = self._build_config(kwargs)
+        config = self._build_config(kwargs)
         response = await self._client.aio.models.embed_content(
             model=self.model, contents=content, config=config
         )
         embeddings = self._embeddings_from_response(response, 1)
-        return self._postprocess(embeddings[0].values, normalize)
+        return self._values(embeddings[0])
 
     @retry(
         wait=wait_random_exponential(min=1, max=60),
@@ -373,16 +358,14 @@ class GoogleGenAIVectorizer(BaseVectorizer):
     ) -> list[list[float]]:
         """Asynchronously generate vector embeddings for a batch of strings."""
         self._validate_many(contents)
-        config, normalize = self._build_config(kwargs)
+        config = self._build_config(kwargs)
         embeddings: list[list[float]] = []
         for batch in self.batchify(contents, batch_size):
             response = await self._client.aio.models.embed_content(
                 model=self.model, contents=batch, config=config
             )
             batch_embeddings = self._embeddings_from_response(response, len(batch))
-            embeddings.extend(
-                self._postprocess(e.values, normalize) for e in batch_embeddings
-            )
+            embeddings.extend(self._values(e) for e in batch_embeddings)
         return embeddings
 
     @property

--- a/redisvl/utils/vectorize/text/vertexai.py
+++ b/redisvl/utils/vectorize/text/vertexai.py
@@ -5,7 +5,8 @@ from redisvl.utils.vectorize.vertexai import VertexAIVectorizer
 
 
 @deprecated_class(
-    name="VertexAITextVectorizer", replacement="Use VertexAIVectorizer instead."
+    name="VertexAITextVectorizer",
+    replacement="Use GoogleGenAIVectorizer instead.",
 )
 class VertexAITextVectorizer(VertexAIVectorizer):
     """A backwards-compatible alias for VertexAIVectorizer."""

--- a/redisvl/utils/vectorize/vertexai.py
+++ b/redisvl/utils/vectorize/vertexai.py
@@ -9,9 +9,21 @@ from tenacity.retry import retry_if_not_exception_type
 if TYPE_CHECKING:
     from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
 
+from redisvl.utils.utils import deprecated_class
 from redisvl.utils.vectorize.base import BaseVectorizer
 
+_VERTEXAI_DEPRECATION = (
+    "Use GoogleGenAIVectorizer for text embeddings — it runs on the supported "
+    "google-genai SDK. Note the default model changes (textembedding-gecko, 768 "
+    "dims -> gemini-embedding-001, 3072 dims), so vectors are not interchangeable; "
+    "reindex when you switch. This class uses Google's Vertex AI model-garden SDK, "
+    "which is deprecated with a scheduled removal (it still works today but is on a "
+    "clock). Multimodal (image/video) migration is tracked in "
+    "https://github.com/redis/redis-vl-python/issues/620."
+)
 
+
+@deprecated_class(name="VertexAIVectorizer", replacement=_VERTEXAI_DEPRECATION)
 class VertexAIVectorizer(BaseVectorizer):
     """The VertexAIVectorizer uses Google's VertexAI embedding model
     API to create embeddings.

--- a/tests/integration/test_vectorizers.py
+++ b/tests/integration/test_vectorizers.py
@@ -11,6 +11,7 @@ from redisvl.utils.vectorize import (
     BedrockVectorizer,
     CohereTextVectorizer,
     CustomVectorizer,
+    GoogleGenAIVectorizer,
     MistralAITextVectorizer,
     OpenAITextVectorizer,
     VertexAIVectorizer,
@@ -45,6 +46,7 @@ def embeddings_cache(client):
 _vectorizer_params = [
     OpenAITextVectorizer,
     VertexAIVectorizer,
+    GoogleGenAIVectorizer,
     CohereTextVectorizer,
     AzureOpenAITextVectorizer,
     BedrockVectorizer,
@@ -63,6 +65,15 @@ def vectorizer(request):
     elif request.param == OpenAITextVectorizer:
         return request.param()
     elif request.param == VertexAIVectorizer:
+        return request.param()
+    elif request.param == GoogleGenAIVectorizer:
+        # Prefer the Gemini Developer API key when present so this fixture
+        # exercises the Gemini backend. The dtype-param tests below construct
+        # GoogleGenAIVectorizer() with no config, exercising env auto-detect
+        # (Vertex when GCP creds are set) — so both backends get covered in CI.
+        api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        if api_key:
+            return request.param(api_config={"api_key": api_key})
         return request.param()
     elif request.param == CohereTextVectorizer:
         return request.param()
@@ -426,6 +437,7 @@ _dtype_params = [
     MistralAITextVectorizer,
     OpenAITextVectorizer,
     VertexAIVectorizer,
+    GoogleGenAIVectorizer,
     VoyageAIVectorizer,
 ]
 
@@ -484,6 +496,7 @@ _non_supported_dtype_params = [
     MistralAITextVectorizer,
     OpenAITextVectorizer,
     VertexAIVectorizer,
+    GoogleGenAIVectorizer,
     VoyageAIVectorizer,
 ]
 

--- a/tests/unit/test_google_genai_vectorizer.py
+++ b/tests/unit/test_google_genai_vectorizer.py
@@ -1,0 +1,445 @@
+import builtins
+import math
+import sys
+import types
+import warnings
+
+import pytest
+
+from redisvl.utils.vectorize.base import BaseVectorizer
+from redisvl.utils.vectorize.googlegenai import GoogleGenAIVectorizer
+
+# Environment variables that would otherwise steer backend auto-detection. CI's
+# `make test` job exports GCP_* and tests run under xdist, so scrub them and let
+# each test set only what it exercises.
+_GOOGLE_ENV_VARS = (
+    "GCP_PROJECT_ID",
+    "GCP_LOCATION",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_LOCATION",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_GENAI_USE_VERTEXAI",
+)
+
+
+def _vec(content: str, dim):
+    """Fake embedding: reduced-dim vectors are intentionally NON-normalized so
+    tests can verify the vectorizer normalizes them."""
+    if dim:
+        return [float(i + 1) for i in range(dim)]
+    base = float(len(content))
+    return [base, base + 1.0, base + 2.0]
+
+
+class FakeContentEmbedding:
+    def __init__(self, values):
+        self.values = values
+
+
+class FakeEmbedResponse:
+    def __init__(self, embeddings):
+        self.embeddings = embeddings
+
+
+class FakeEmbedContentConfig:
+    _allowed = {
+        "task_type",
+        "output_dimensionality",
+        "title",
+        "mime_type",
+        "auto_truncate",
+    }
+
+    def __init__(self, **kwargs):
+        unknown = set(kwargs) - self._allowed
+        if unknown:
+            raise TypeError(f"Unexpected EmbedContentConfig fields: {unknown}")
+        for field in self._allowed:
+            setattr(self, field, kwargs.get(field))
+
+
+def _response_for(contents, config):
+    dim = getattr(config, "output_dimensionality", None) if config else None
+    items = [contents] if isinstance(contents, str) else list(contents)
+    return FakeEmbedResponse([FakeContentEmbedding(_vec(c, dim)) for c in items])
+
+
+class FakeModels:
+    def __init__(self, client):
+        self._client = client
+
+    def embed_content(self, *, model, contents, config=None):
+        self._client.calls.append(
+            {"model": model, "contents": contents, "config": config, "async": False}
+        )
+        if self._client.raise_exc is not None:
+            raise self._client.raise_exc
+        return _response_for(contents, config)
+
+
+class FakeAioModels:
+    def __init__(self, client):
+        self._client = client
+
+    async def embed_content(self, *, model, contents, config=None):
+        self._client.calls.append(
+            {"model": model, "contents": contents, "config": config, "async": True}
+        )
+        if self._client.raise_exc is not None:
+            raise self._client.raise_exc
+        return _response_for(contents, config)
+
+
+class FakeAio:
+    def __init__(self, client):
+        self.models = FakeAioModels(client)
+
+
+class FakeClient:
+    instances: list = []
+    # Set on the class to force a failure during __init__'s dimension probe.
+    raise_exc_on_init = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls: list = []
+        self.raise_exc = self.__class__.raise_exc_on_init
+        self.models = FakeModels(self)
+        self.aio = FakeAio(self)
+        FakeClient.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_google_env(monkeypatch):
+    for var in _GOOGLE_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def fake_genai(monkeypatch):
+    FakeClient.instances = []
+    FakeClient.raise_exc_on_init = None
+
+    genai_mod = types.ModuleType("google.genai")
+    types_mod = types.ModuleType("google.genai.types")
+    types_mod.EmbedContentConfig = FakeEmbedContentConfig
+    genai_mod.Client = FakeClient
+    genai_mod.types = types_mod
+
+    import google
+
+    monkeypatch.setattr(google, "genai", genai_mod, raising=False)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.genai.types", types_mod)
+    return genai_mod
+
+
+# --------------------------------------------------------------------------- #
+# Backend resolution                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_init_vertex_backend_from_api_config(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(
+        api_config={"project_id": "proj", "location": "us-central1"}
+    )
+    client = FakeClient.instances[0]
+    assert vectorizer.backend == "vertex"
+    assert vectorizer.type == "google_genai"
+    assert vectorizer.dims == 3
+    assert client.kwargs["vertexai"] is True
+    assert client.kwargs["project"] == "proj"
+    assert client.kwargs["location"] == "us-central1"
+
+
+def test_init_gemini_backend_from_api_config(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "secret-key"})
+    client = FakeClient.instances[0]
+    assert vectorizer.backend == "gemini"
+    assert client.kwargs.get("api_key") == "secret-key"
+    assert "vertexai" not in client.kwargs
+
+
+def test_explicit_backend_override_beats_creds(fake_genai):
+    # project present, but explicitly force gemini
+    vectorizer = GoogleGenAIVectorizer(
+        api_config={"backend": "gemini", "project_id": "proj", "api_key": "k"}
+    )
+    assert vectorizer.backend == "gemini"
+
+
+def test_explicit_api_key_beats_ambient_project(fake_genai, monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "amb-proj")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    assert vectorizer.backend == "gemini"
+
+
+def test_env_project_selects_vertex(fake_genai, monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "p")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+    vectorizer = GoogleGenAIVectorizer()
+    assert vectorizer.backend == "vertex"
+    assert FakeClient.instances[0].kwargs["project"] == "p"
+
+
+def test_env_key_selects_gemini(fake_genai, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    vectorizer = GoogleGenAIVectorizer()
+    assert vectorizer.backend == "gemini"
+
+
+def test_both_env_creds_vertex_wins(fake_genai, monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "p")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    vectorizer = GoogleGenAIVectorizer()
+    assert vectorizer.backend == "vertex"
+
+
+def test_legacy_gcp_env_vars_supported(fake_genai, monkeypatch):
+    monkeypatch.setenv("GCP_PROJECT_ID", "p")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+    vectorizer = GoogleGenAIVectorizer()
+    assert vectorizer.backend == "vertex"
+    assert FakeClient.instances[0].kwargs["location"] == "us-central1"
+
+
+def test_vertex_missing_location_raises(fake_genai):
+    with pytest.raises(ValueError, match="location"):
+        GoogleGenAIVectorizer(api_config={"project_id": "p"})
+
+
+def test_no_credentials_raises(fake_genai):
+    with pytest.raises(ValueError, match="Could not resolve a Google backend"):
+        GoogleGenAIVectorizer()
+
+
+def test_invalid_backend_value_raises(fake_genai):
+    with pytest.raises(ValueError, match="Must be 'vertex' or 'gemini'"):
+        GoogleGenAIVectorizer(api_config={"backend": "bogus"})
+
+
+def test_api_config_not_mutated(fake_genai):
+    api_config = {"api_key": "k"}
+    GoogleGenAIVectorizer(api_config=api_config)
+    assert api_config == {"api_key": "k"}
+
+
+# --------------------------------------------------------------------------- #
+# Embedding                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_embed_forwards_model_and_returns_values(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(
+        model="gemini-embedding-001", api_config={"api_key": "k"}
+    )
+    result = vectorizer.embed("hello world")
+    client = FakeClient.instances[0]
+    assert result == _vec("hello world", None)
+    assert client.calls[-1]["model"] == "gemini-embedding-001"
+    assert client.calls[-1]["contents"] == "hello world"
+
+
+def test_embed_many_batches_and_preserves_order(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    result = vectorizer.embed_many(["a", "bb", "ccc", "dddd"], batch_size=2)
+    assert result == [
+        _vec("a", None),
+        _vec("bb", None),
+        _vec("ccc", None),
+        _vec("dddd", None),
+    ]
+    client = FakeClient.instances[0]
+    # calls[0] is the dimension probe; the rest are the batches.
+    assert [c["contents"] for c in client.calls[1:]] == [["a", "bb"], ["ccc", "dddd"]]
+
+
+def test_embed_many_empty_makes_no_api_calls(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    client = FakeClient.instances[0]
+    calls_after_init = len(client.calls)
+    assert vectorizer.embed_many([]) == []
+    assert len(client.calls) == calls_after_init
+
+
+@pytest.mark.asyncio
+async def test_aembed_uses_async_client(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    result = await vectorizer.aembed("hello async")
+    client = FakeClient.instances[0]
+    assert result == _vec("hello async", None)
+    assert client.calls[-1]["async"] is True
+
+
+@pytest.mark.asyncio
+async def test_aembed_many_uses_async_client(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    result = await vectorizer.aembed_many(["a", "bb", "ccc"], batch_size=2)
+    assert result == [_vec("a", None), _vec("bb", None), _vec("ccc", None)]
+    client = FakeClient.instances[0]
+    assert [c["contents"] for c in client.calls if c["async"]] == [
+        ["a", "bb"],
+        ["ccc"],
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Dimensions, normalization, config passthrough                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_output_dimensionality_sets_dims_and_normalizes(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(
+        api_config={"api_key": "k"}, output_dimensionality=6
+    )
+    assert vectorizer.dims == 6
+    result = vectorizer.embed("hello")
+    assert len(result) == 6
+    assert math.isclose(sum(v * v for v in result), 1.0, rel_tol=1e-6)
+
+
+def test_per_call_output_dimensionality_overrides_default(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    assert vectorizer.dims == 3  # default probe, no reduction
+    result = vectorizer.embed("hello", output_dimensionality=5)
+    assert len(result) == 5
+    assert math.isclose(sum(v * v for v in result), 1.0, rel_tol=1e-6)
+
+
+def test_task_type_passthrough_per_call(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    vectorizer.embed("hello", task_type="RETRIEVAL_QUERY")
+    config = FakeClient.instances[0].calls[-1]["config"]
+    assert config.task_type == "RETRIEVAL_QUERY"
+
+
+def test_task_type_default_applied_to_every_call(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(
+        api_config={"api_key": "k"}, task_type="RETRIEVAL_DOCUMENT"
+    )
+    vectorizer.embed("hello")
+    config = FakeClient.instances[0].calls[-1]["config"]
+    assert config.task_type == "RETRIEVAL_DOCUMENT"
+
+
+# --------------------------------------------------------------------------- #
+# Input validation and errors                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_rejects_invalid_single_content(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    with pytest.raises(TypeError):
+        vectorizer.embed(42)
+
+
+def test_rejects_invalid_many_contents(fake_genai):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    with pytest.raises(TypeError):
+        vectorizer.embed_many("not a list")
+    with pytest.raises(TypeError):
+        vectorizer.embed_many(["valid", 42])
+
+
+def test_invalid_dtype_uses_base_validation(fake_genai):
+    with pytest.raises(ValueError, match="Invalid data type"):
+        GoogleGenAIVectorizer(api_config={"api_key": "k"}, dtype="float25")
+
+
+def test_missing_dependency_raises_import_error(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "google" and "genai" in (fromlist or ()):
+            raise ImportError("no genai")
+        if name == "google.genai":
+            raise ImportError("no genai")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.delitem(sys.modules, "google.genai", raising=False)
+    monkeypatch.delitem(sys.modules, "google.genai.types", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+
+    with pytest.raises(ImportError, match=r"pip install redisvl\[google-genai\]"):
+        GoogleGenAIVectorizer()
+
+
+def test_transient_error_is_retried(fake_genai, monkeypatch):
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    monkeypatch.setattr(GoogleGenAIVectorizer._embed.retry, "sleep", lambda _: None)
+    client = FakeClient.instances[0]
+    client.raise_exc = RuntimeError("transient 503")
+    calls_before = len(client.calls)
+
+    with pytest.raises(RuntimeError, match="transient 503"):
+        vectorizer.embed("hello")
+
+    assert len(client.calls) - calls_before == 6
+
+
+@pytest.mark.asyncio
+async def test_async_transient_error_is_retried(fake_genai, monkeypatch):
+    async def _no_sleep(_):
+        return None
+
+    vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
+    monkeypatch.setattr(GoogleGenAIVectorizer._aembed.retry, "sleep", _no_sleep)
+    client = FakeClient.instances[0]
+    client.raise_exc = RuntimeError("transient 503")
+    calls_before = len(client.calls)
+
+    with pytest.raises(RuntimeError, match="transient 503"):
+        await vectorizer.aembed("hello")
+
+    assert len(client.calls) - calls_before == 6
+
+
+def test_credentials_never_appear_in_raised_error(fake_genai, monkeypatch):
+    # Force the dimension probe to fail with an error that echoes the api key.
+    secret = "super-secret-key-12345"
+    monkeypatch.setattr(
+        FakeClient,
+        "raise_exc_on_init",
+        RuntimeError(f"HTTP 401 for key={secret}"),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        GoogleGenAIVectorizer(api_config={"api_key": secret})
+    assert secret not in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------- #
+# Wiring                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_vectorizer_from_dict_supports_google_genai(fake_genai, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    from redisvl.utils.vectorize import vectorizer_from_dict
+
+    vectorizer = vectorizer_from_dict(
+        {"type": "google_genai", "model": "gemini-embedding-001", "dtype": "float64"}
+    )
+    assert isinstance(vectorizer, GoogleGenAIVectorizer)
+    assert vectorizer.model == "gemini-embedding-001"
+    assert vectorizer.dtype == "float64"
+    assert vectorizer.backend == "gemini"
+
+
+def test_enum_and_public_export():
+    from redisvl.utils.vectorize.base import Vectorizers
+
+    assert Vectorizers("google_genai") == Vectorizers.google_genai
+
+    import redisvl.utils.vectorize as vectorize
+
+    assert vectorize.GoogleGenAIVectorizer is GoogleGenAIVectorizer
+
+
+def test_uses_base_public_batch_embedding_methods():
+    assert GoogleGenAIVectorizer.embed_many is BaseVectorizer.embed_many
+    assert GoogleGenAIVectorizer.aembed_many is BaseVectorizer.aembed_many

--- a/tests/unit/test_google_genai_vectorizer.py
+++ b/tests/unit/test_google_genai_vectorizer.py
@@ -300,11 +300,12 @@ def test_output_dimensionality_sets_dims(fake_genai):
     assert result == _vec("hello", 6)
 
 
-def test_per_call_output_dimensionality_overrides_default(fake_genai):
+def test_per_call_output_dimensionality_is_rejected(fake_genai):
+    # output_dimensionality determines dims, so it is fixed at construction and must
+    # not be overridable per call (that would desync from the index vector width).
     vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
-    assert vectorizer.dims == 3  # default probe, no reduction
-    result = vectorizer.embed("hello", output_dimensionality=5)
-    assert result == _vec("hello", 5)
+    with pytest.raises(TypeError, match="output_dimensionality"):
+        vectorizer.embed("hello", output_dimensionality=5)
 
 
 def test_task_type_passthrough_per_call(fake_genai):

--- a/tests/unit/test_google_genai_vectorizer.py
+++ b/tests/unit/test_google_genai_vectorizer.py
@@ -1,8 +1,6 @@
 import builtins
-import math
 import sys
 import types
-import warnings
 
 import pytest
 
@@ -292,22 +290,21 @@ async def test_aembed_many_uses_async_client(fake_genai):
 # --------------------------------------------------------------------------- #
 
 
-def test_output_dimensionality_sets_dims_and_normalizes(fake_genai):
+def test_output_dimensionality_sets_dims(fake_genai):
     vectorizer = GoogleGenAIVectorizer(
         api_config={"api_key": "k"}, output_dimensionality=6
     )
     assert vectorizer.dims == 6
     result = vectorizer.embed("hello")
-    assert len(result) == 6
-    assert math.isclose(sum(v * v for v in result), 1.0, rel_tol=1e-6)
+    # Raw provider values are returned as-is (no normalization).
+    assert result == _vec("hello", 6)
 
 
 def test_per_call_output_dimensionality_overrides_default(fake_genai):
     vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "k"})
     assert vectorizer.dims == 3  # default probe, no reduction
     result = vectorizer.embed("hello", output_dimensionality=5)
-    assert len(result) == 5
-    assert math.isclose(sum(v * v for v in result), 1.0, rel_tol=1e-6)
+    assert result == _vec("hello", 5)
 
 
 def test_task_type_passthrough_per_call(fake_genai):

--- a/tests/unit/test_vertexai_deprecation.py
+++ b/tests/unit/test_vertexai_deprecation.py
@@ -1,0 +1,76 @@
+"""Offline tests for the VertexAIVectorizer deprecation (issue #620).
+
+These use a fake `vertexai` module so they run without google-cloud-aiplatform
+or live GCP credentials.
+"""
+
+import sys
+import types
+import warnings
+
+import pytest
+
+
+@pytest.fixture
+def fake_vertexai(monkeypatch):
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+
+    vertexai_mod = types.ModuleType("vertexai")
+
+    def init(**kwargs):
+        return None
+
+    vertexai_mod.init = init
+
+    lang_mod = types.ModuleType("vertexai.language_models")
+
+    class _FakeEmbedding:
+        def __init__(self, values):
+            self.values = values
+
+    class FakeTextEmbeddingModel:
+        @classmethod
+        def from_pretrained(cls, model):
+            return cls()
+
+        def get_embeddings(self, contents, **kwargs):
+            items = contents if isinstance(contents, list) else [contents]
+            return [_FakeEmbedding([0.1, 0.2, 0.3]) for _ in items]
+
+    lang_mod.TextEmbeddingModel = FakeTextEmbeddingModel
+    vertexai_mod.language_models = lang_mod
+
+    monkeypatch.setitem(sys.modules, "vertexai", vertexai_mod)
+    monkeypatch.setitem(sys.modules, "vertexai.language_models", lang_mod)
+    return vertexai_mod
+
+
+def _deprecation_warnings(records):
+    return [w for w in records if issubclass(w.category, DeprecationWarning)]
+
+
+def test_vertexai_vectorizer_warns_once(fake_vertexai):
+    from redisvl.utils.vectorize.vertexai import VertexAIVectorizer
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        VertexAIVectorizer(model="textembedding-gecko")
+
+    dep = _deprecation_warnings(rec)
+    assert len(dep) == 1
+    assert "GoogleGenAIVectorizer" in str(dep[0].message)
+
+
+def test_vertexai_text_vectorizer_warns_once(fake_vertexai):
+    """The already-deprecated alias subclasses the now-deprecated parent; the
+    idempotency sentinel keeps that to a single warning."""
+    from redisvl.utils.vectorize.text.vertexai import VertexAITextVectorizer
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        VertexAITextVectorizer(model="textembedding-gecko")
+
+    dep = _deprecation_warnings(rec)
+    assert len(dep) == 1
+    assert "GoogleGenAIVectorizer" in str(dep[0].message)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -4854,7 +4854,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },
@@ -4874,6 +4874,7 @@ all = [
     { name = "cohere" },
     { name = "google-cloud-aiplatform", version = "1.148.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "google-cloud-aiplatform", version = "1.154.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "google-genai" },
     { name = "langcache" },
     { name = "mistralai" },
     { name = "ollama" },
@@ -4891,6 +4892,9 @@ bedrock = [
 ]
 cohere = [
     { name = "cohere" },
+]
+google-genai = [
+    { name = "google-genai" },
 ]
 langcache = [
     { name = "langcache" },
@@ -4967,6 +4971,8 @@ requires-dist = [
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'all'", specifier = ">=1.26,<2.0.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertexai'", specifier = ">=1.26,<2.0.0" },
+    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0.0" },
+    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.0.0" },
     { name = "jsonpath-ng", specifier = ">=1.5.0" },
     { name = "langcache", marker = "extra == 'all'", specifier = ">=0.11.0" },
     { name = "langcache", marker = "extra == 'langcache'", specifier = ">=0.11.0" },
@@ -4997,7 +5003,7 @@ requires-dist = [
     { name = "voyageai", marker = "extra == 'all'", specifier = ">=0.2.2" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = ">=0.2.2" },
 ]
-provides-extras = ["mcp", "mistralai", "openai", "cohere", "voyageai", "sentence-transformers", "langcache", "vertexai", "bedrock", "pillow", "sql-redis", "all", "ollama"]
+provides-extras = ["mcp", "mistralai", "openai", "cohere", "voyageai", "sentence-transformers", "langcache", "vertexai", "google-genai", "bedrock", "pillow", "sql-redis", "all", "ollama"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Why

`VertexAIVectorizer` builds embeddings through Google's Vertex AI **model-garden** SDK (`TextEmbeddingModel` from `vertexai.language_models`, `MultiModalEmbeddingModel` from `vertexai.vision_models`). Google deprecated those modules on 2025-06-24 with a stated removal date of 2026-06-24, so today every `VertexAIVectorizer()` init prints:

```
UserWarning: This feature is deprecated as of June 24, 2025 and will be removed on June 24, 2026.
```

To be precise about the state of the world (verified against PyPI, not just the docs): the modules are **not yet hard-removed** — `google-cloud-aiplatform==1.162.0` still imports and runs them, and the `2.0.0` that would drop them is **yanked**. So the old path *works today but is living on borrowed time*: noisy, on a removal clock, and on an SDK Google has stopped investing in for gen-AI.

The replacement Google points to is [`google-genai`](https://pypi.org/project/google-genai/). Moving to it silences the warning, runs on the supported SDK, unlocks the Gemini Developer API and real async, and sheds the ~200 MB memory overhead of `google-cloud-aiplatform` ([python-aiplatform#6191](https://github.com/googleapis/python-aiplatform/issues/6191)).

Closes #620 (text embeddings; see *Caveats* for multimodal).

## The mental model

Three ideas carry the whole change:

**1. One client, two backends.** `google-genai` unifies what used to be two SDKs. The only difference between enterprise Vertex AI and the consumer Gemini API is how you build the client; after that, `embed_content` is identical (and `client.aio` gives real async for free):

```python
from redisvl.utils.vectorize import GoogleGenAIVectorizer

# Vertex AI (GCP project auth)
vectorizer = GoogleGenAIVectorizer(
    model="gemini-embedding-001",
    api_config={"project_id": "your-gcp-project", "location": "us-central1"},
)

# Gemini Developer API (single key)
vectorizer = GoogleGenAIVectorizer(api_config={"api_key": "..."})  # or set GEMINI_API_KEY

embedding = vectorizer.embed("Hello, world!")
embeddings = await vectorizer.aembed_many(["a", "b"], batch_size=2)
```

**2. Explicit beats ambient.** Auth can come from `api_config` or the environment, and real deployments often have *both* a `GOOGLE_CLOUD_PROJECT` and a stray `GOOGLE_API_KEY` lying around. So backend selection is deterministic and documented — explicit override → explicit `api_config` creds → environment — rather than "guess from whatever's set":

```python
# Force a backend regardless of ambient env:
GoogleGenAIVectorizer(api_config={"backend": "gemini", "api_key": "..."})
vectorizer.backend  # -> "gemini"  (resolved backend is observable)
```

If both a project and a key are resolvable from the environment, Vertex wins; if neither is, you get a `ValueError` that names both option sets.

**3. Errors must retry, and must not leak.** Transient API errors propagate into the tenacity `@retry` (the old vectorizer wrapped everything in `ValueError`, which its own retry filter then excluded — so it never actually retried). Input-type errors fail fast as `TypeError`. And because the Gemini key rides in a request header that transport errors can echo, we never interpolate a raw provider exception into a message on a key-bearing path.

Embeddings are returned exactly as the provider produces them — no post-processing — matching every other vectorizer in the library. `output_dimensionality` is an optional passthrough for Google's Matryoshka reduction (shorter vectors, ~4× less index memory) that also sets `dims` correctly and is fixed for the vectorizer's lifetime:

```python
v = GoogleGenAIVectorizer(output_dimensionality=768)
v.dims  # 768
```

(Note: Google does not re-normalize reduced-dim vectors. That's invisible under the COSINE metric, which is scale-invariant, and left to the caller for inner-product / L2 — we don't silently mutate provider output.)

## What changed

- **New** [`redisvl/utils/vectorize/googlegenai.py`](redisvl/utils/vectorize/googlegenai.py) — `GoogleGenAIVectorizer` (both backends, sync + async, caching, secrets-safe errors). Registered in the `Vectorizers` enum and `vectorizer_from_dict`.
- **Deprecation** — `VertexAIVectorizer` now emits a *teaching* `DeprecationWarning` (names the new class, gives the model/dim mapping, links #620). `deprecated_class` is now idempotent per instance, so the already-deprecated `VertexAITextVectorizer` alias (which subclasses it) warns exactly **once**.
- **Dependencies** — new `google-genai` extra (`pip install redisvl[google-genai]`), added to `all`. The legacy `vertexai` extra is unchanged, but its `<2.0.0` cap is now **documented** as intentional (it keeps the still-working 1.x line that ships the deprecated modules, incl. the multimodal path).
- **Tests** — offline unit tests (fake `google.genai` module + an autouse env-scrub fixture, since CI's `make test` exports `GCP_*` and would otherwise skew backend detection) covering backend resolution, both embed paths, async, retry, the secrets-never-leak guarantee, and the single-deprecation-warning behavior; integration params wired for both backends.
- **Docs** — API reference, the vectorizers user-guide notebook, `installation.md`, and `utilities.md`.
- **CI** — the existing `GEMINI_API_KEY` secret is wired into the fork-guarded `service-tests` job only.

## Caveats & future steps

- **Text embeddings only.** Multimodal (image/video) is still public preview on `google-genai`; `VertexAIVectorizer` remains the (deprecated) path for it, and its migration is tracked in #620. The new class lives at the package root with a backend-neutral name precisely so multimodal can be added later without a rename.
- **The old class still works** — deprecate-now / remove-next-major. No user is broken by this PR.
- **Notebook validation & live APIs (out of scope here).** The new notebook cell is marked `# NBVAL_SKIP`, matching the existing precedent in `13_langcache`, so it adds no API calls to notebook validation. However, several *existing* cells in `04_vectorizers.ipynb` (and `03`, `06`) already make live provider API calls under `--nbval-lax`. Making notebook validation credential-free across the board is a worthwhile, separate cleanup.
- **`google-genai` version floor** is pinned `>=1.0.0`; worth confirming the earliest release that exposes `embed_content` + `.aio` + `EmbedContentConfig` before merge.

## Verification

- `make format` clean; `mypy redisvl` clean; pre-commit hooks pass.
- New unit tests pass; full offline unit suite green.
- `python -m tests.test_imports redisvl` passes with `google-genai` **not** installed (lazy import).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches embedding/auth paths and default model/dimension changes (reindex required); legacy Vertex remains for multimodal until a follow-up.
> 
> **Overview**
> Adds **`GoogleGenAIVectorizer`** on the supported `google-genai` SDK for text embeddings, with auto-selection of **Vertex AI** (project/location/ADC) or the **Gemini Developer API** (`GEMINI_API_KEY`), plus sync/async batching, retries, and safer error messages that avoid leaking credentials.
> 
> **`VertexAIVectorizer`** and **`VertexAITextVectorizer`** are now deprecated in favor of the new class; **`deprecated_class`** warns only once per instance so subclass chains do not double-warn. Wiring includes a new **`google_genai`** `Vectorizers` enum value, **`vectorizer_from_dict`**, optional extra **`redisvl[google-genai]`** (and **`all`**), **`GEMINI_API_KEY`** in service CI, docs/notebook migration guidance, and unit + integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c543fbd7ec90fb95cba6a2809be9b84b6fcbb61e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->