### PR TITLE
docs: add exception reference and error handling guide

### DIFF
--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -1,0 +1,200 @@
+***********
+Exceptions
+***********
+
+RedisVL defines its custom exceptions in ``redisvl.exceptions``. Every one of them
+inherits from :class:`RedisVLError`, so catching that single base class is enough to
+handle any error the library raises on its own behalf. Catch the more specific
+subclasses when you want to react differently to, for example, a schema validation
+failure than to a Redis connection problem.
+
+.. code-block:: text
+
+    Exception
+    └── RedisVLError
+        ├── RedisSearchError
+        ├── SchemaValidationError
+        ├── QueryValidationError
+        └── RedisModuleVersionError
+
+.. note::
+
+   Exceptions raised by the underlying ``redis-py`` client, such as
+   ``redis.exceptions.ConnectionError``, are not part of this hierarchy. Where
+   RedisVL performs an index or search operation on your behalf it wraps those
+   errors in a :class:`RedisSearchError` and chains the original exception, so the
+   underlying cause is still available on ``__cause__``.
+
+
+When each error is raised
+=========================
+
+.. list-table::
+   :widths: 28 42 30
+   :header-rows: 1
+
+   * - Exception
+     - Raised when
+     - Typical entry points
+   * - :class:`SchemaValidationError`
+     - An object does not match the index schema. Only raised when the index was
+       created with ``validate_on_load=True``.
+     - ``load()``
+   * - :class:`QueryValidationError`
+     - A query is not valid for the index it targets, for example setting
+       ``ef_runtime`` on a vector field that uses the ``flat`` algorithm.
+     - ``query()``
+   * - :class:`RedisSearchError`
+     - An index or search operation fails, including errors returned by Redis
+       itself.
+     - ``create()``, ``delete()``, ``search()``, ``aggregate()``
+   * - :class:`RedisModuleVersionError`
+     - The connected Redis or Redis Search version does not support a requested
+       feature, such as an ``svs-vamana`` vector field.
+     - ``create()``
+   * - :class:`RedisVLError`
+     - A load operation fails for a reason not covered by a more specific error.
+       Also the base class for everything above.
+     - ``load()``
+
+All of the above apply equally to :class:`~redisvl.index.SearchIndex` and
+:class:`~redisvl.index.AsyncSearchIndex`.
+
+
+Handling errors
+===============
+
+Validating data on load
+-----------------------
+
+Schema validation is off by default. Pass ``validate_on_load=True`` to have RedisVL
+check each object against the index schema before writing it, and raise
+:class:`SchemaValidationError` on the first object that does not match.
+
+.. code-block:: python
+
+    from redisvl.index import SearchIndex
+    from redisvl.exceptions import SchemaValidationError
+
+    index = SearchIndex.from_yaml(
+        "schema.yaml",
+        redis_url="redis://localhost:6379",
+        validate_on_load=True,
+    )
+
+    try:
+        index.load(data)
+    except SchemaValidationError as e:
+        # The message identifies the offending object by its position in the
+        # input and describes which field failed and why.
+        print(f"Invalid record: {e}")
+
+The error message reports the index of the object within the batch you passed, so a
+failure part way through a large load still points at a specific record.
+
+Handling query failures
+-----------------------
+
+:class:`QueryValidationError` signals a query that cannot run against this index. It
+is a programming error rather than a transient one, so it is usually worth failing
+loudly instead of retrying.
+
+.. code-block:: python
+
+    from redisvl.query import VectorQuery
+    from redisvl.exceptions import QueryValidationError
+
+    query = VectorQuery(
+        vector=[0.1, 0.2, 0.3],
+        vector_field_name="embedding",
+        return_fields=["title"],
+        ef_runtime=50,  # only supported by the 'hnsw' algorithm
+    )
+
+    try:
+        results = index.query(query)
+    except QueryValidationError as e:
+        print(f"Query rejected: {e}")
+
+Separating configuration problems from Redis problems
+-----------------------------------------------------
+
+:class:`RedisModuleVersionError` is a subclass of :class:`RedisVLError`, not of
+:class:`RedisSearchError`, so ordering the ``except`` clauses lets you distinguish an
+unsupported feature from a genuine Redis failure.
+
+.. code-block:: python
+
+    from redisvl.exceptions import RedisModuleVersionError, RedisSearchError
+
+    try:
+        index.create(overwrite=True)
+    except RedisModuleVersionError as e:
+        # The deployment does not support the requested feature, for example an
+        # 'svs-vamana' field on a Redis version without a new enough Redis Search.
+        print(f"Unsupported by this Redis deployment: {e}")
+    except RedisSearchError as e:
+        # Something went wrong talking to Redis, or the index definition was
+        # rejected. The original redis-py exception is available as e.__cause__.
+        print(f"Index creation failed: {e}")
+
+Catching everything
+-------------------
+
+When the calling code only needs to know that the operation failed, catch the base
+class.
+
+.. code-block:: python
+
+    from redisvl.exceptions import RedisVLError
+
+    try:
+        index.load(data)
+        results = index.query(query)
+    except RedisVLError as e:
+        logger.error("RedisVL operation failed: %s", e)
+        raise
+
+Because RedisVL chains the underlying exception when it wraps one, ``e.__cause__``
+still holds the original ``redis-py`` error where there was one.
+
+
+Exception classes
+=================
+
+.. currentmodule:: redisvl.exceptions
+
+RedisVLError
+------------
+
+.. autoclass:: RedisVLError
+   :members:
+   :show-inheritance:
+
+RedisSearchError
+----------------
+
+.. autoclass:: RedisSearchError
+   :members:
+   :show-inheritance:
+
+SchemaValidationError
+---------------------
+
+.. autoclass:: SchemaValidationError
+   :members:
+   :show-inheritance:
+
+QueryValidationError
+--------------------
+
+.. autoclass:: QueryValidationError
+   :members:
+   :show-inheritance:
+
+RedisModuleVersionError
+-----------------------
+
+.. autoclass:: RedisModuleVersionError
+   :members:
+   :show-inheritance:

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -2,11 +2,15 @@
 Exceptions
 ***********
 
+.. currentmodule:: redisvl.exceptions
+
 RedisVL defines its custom exceptions in ``redisvl.exceptions``. Every one of them
 inherits from :class:`RedisVLError`, so catching that single base class is enough to
-handle any error the library raises on its own behalf. Catch the more specific
-subclasses when you want to react differently to, for example, a schema validation
-failure than to a Redis connection problem.
+handle any error the core index and query APIs raise on their own behalf. Catch the
+more specific subclasses when you want to react differently to, for example, a
+schema validation failure than to a Redis connection problem. (The MCP integration
+defines its own ``redisvl.mcp.errors.RedisVLMCPError``, which is outside this
+hierarchy.)
 
 .. code-block:: text
 
@@ -23,7 +27,10 @@ failure than to a Redis connection problem.
    ``redis.exceptions.ConnectionError``, are not part of this hierarchy. Where
    RedisVL performs an index or search operation on your behalf it wraps those
    errors in a :class:`RedisSearchError` and chains the original exception, so the
-   underlying cause is still available on ``__cause__``.
+   underlying cause is still available on ``__cause__``. Constructor and argument
+   validation raises standard Python exceptions instead: for example,
+   ``VectorQuery(..., ef_runtime=-1)`` raises ``ValueError`` at construction time,
+   before any ``try`` block around the query run is entered.
 
 
 When each error is raised
@@ -161,8 +168,6 @@ still holds the original ``redis-py`` error where there was one.
 
 Exception classes
 =================
-
-.. currentmodule:: redisvl.exceptions
 
 RedisVLError
 ------------

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,5 +24,6 @@ cache
 message_history
 router
 cli
+exceptions
 ```
 


### PR DESCRIPTION
Fixes #496

Adds `docs/api/exceptions.rst` and links it from the API toctree, so the exception hierarchy has one discoverable home.

## What's on the page

- **The hierarchy** — all five classes in `redisvl.exceptions`, and a note that `redis-py` exceptions such as `redis.exceptions.ConnectionError` are *not* part of it. RedisVL wraps those and chains the original with `raise ... from e`, so `__cause__` still holds it. That seemed like the detail most likely to trip someone writing an `except` clause.
- **A table** mapping each exception to the operations that raise it, e.g. `SchemaValidationError` → `load()`, `RedisSearchError` → `create()` / `delete()` / `search()` / `aggregate()`.
- **Four `try`/`except` examples**, including the two the issue asks for.
- **Autodoc reference** for each class, following the `:members:` / `:show-inheritance:` pattern used in `schema.rst`.

## Examples are drawn from real raise sites

Rather than writing plausible-looking snippets, I traced each exception to where it is actually raised so the examples match current behaviour:

| Exception | Verified raise site | What the example shows |
| --- | --- | --- |
| `SchemaValidationError` | `storage.py` `_preprocess_and_validate_objects` | `validate_on_load=True`, since validation is off by default and the error cannot otherwise occur |
| `QueryValidationError` | `index.py` `_validate_query` | `ef_runtime` on a `flat` vector field — the concrete case that method rejects |
| `RedisSearchError` | `create`, `delete`, `search`, `aggregate` | wrapping a Redis-side failure |
| `RedisModuleVersionError` | `_check_svs_support`, reached from `create()` | ordering `except` clauses, since it subclasses `RedisVLError` and *not* `RedisSearchError` |

The `from_yaml(..., validate_on_load=True)` form matches the example already in the `SearchIndex` docstring.

## Definition of Done

- **Exception docs present and discoverable** — `docs/_build/html/api/exceptions.html` renders, all five classes appear with their docstrings, `RedisModuleVersionError.for_svs_vamana` is documented, and the page is linked from the API index as "Exceptions".
- **`make docs-build` passes** — exit 0. The build reports 11 warnings; all 11 are pre-existing and point at `query.py` / `aggregate.py` docstrings inherited from redis-py, `index.md` heading levels, and the MCP how-to cross-references. None reference `exceptions.rst`.
- **Examples align with current exception classes** — per the table above.

`codespell` is clean on both files. No Python changed, so no behaviour change.

## Notes

- Docs-only, so this needs the **`auto:documentation`** label per CONTRIBUTING. I can't set labels as an outside contributor — could a maintainer add it?
- I deliberately left `uv.lock` out. Running `make docs-build` with a recent `uv` rewrites it to lockfile revision 3 (a ~250 line diff) which has nothing to do with this change.
- If #608 (Sphinx → mkdocs) lands first, this page is a single autodoc file and cheap to port; happy to do that conversion if you'd prefer to wait for it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Adds a dedicated **Exceptions** API page and links it from the API toctree so `redisvl.exceptions` is easy to find.
> 
> The new `exceptions.rst` documents the five-class hierarchy under `RedisVLError`, clarifies that `redis-py` errors are wrapped as `RedisSearchError` with chaining on `__cause__`, and includes a table mapping each exception to typical entry points (`load()`, `query()`, `create()`, etc.). It also provides four `try`/`except` patterns (schema validation on load, query validation, version vs Redis failures, and catching `RedisVLError`) plus autoclass reference blocks matching the style used elsewhere in the API docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891bfe9fbf4010153b6e6cb8c9d5f7a766ff6f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->