### PR TITLE
fix: negate the day range in Timestamp != date filters

### DIFF
--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -803,13 +803,22 @@ class Timestamp(Num):
             self: The filter object for method chaining
         """
         if self._is_date(other):
-            # For date objects, exclude the entire day
+            # For date objects, exclude the entire day by negating exactly the
+            # range that __eq__ matches.
             if isinstance(other, str):
                 other = datetime.datetime.strptime(other, "%Y-%m-%d").date()
             assert isinstance(other, datetime.date)  # validate for mypy
-            start = datetime.datetime.combine(other, datetime.time.min)
-            end = datetime.datetime.combine(other, datetime.time.max)
-            return self.between(start, end)
+            start = datetime.datetime.combine(other, datetime.time.min).astimezone(
+                datetime.timezone.utc
+            )
+            end = datetime.datetime.combine(other, datetime.time.max).astimezone(
+                datetime.timezone.utc
+            )
+            start_ts = self._convert_to_timestamp(start)
+            end_ts = self._convert_to_timestamp(end, end_date=True)
+            return FilterExpression(
+                self.OPERATOR_MAP[FilterOperator.NE] % (self._field, start_ts, end_ts)
+            )
 
         timestamp = self._convert_to_timestamp(other)
         self._set_value(timestamp, self.SUPPORTED_TYPES, FilterOperator.NE)

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -412,6 +412,26 @@ def test_timestamp_date():
     assert str(ts) == f"@created_at:[{expected_ts_start} {expected_ts_end}]"
 
 
+def test_timestamp_not_equal_date():
+    """Test Timestamp != with date objects (should exclude the full day)."""
+    d = date(2023, 3, 17)
+    ts = Timestamp("created_at") != d
+
+    expected_ts_start = (
+        datetime.combine(d, time.min).astimezone(timezone.utc).timestamp()
+    )
+    expected_ts_end = datetime.combine(d, time.max).astimezone(timezone.utc).timestamp()
+
+    assert str(ts) == f"(-@created_at:[{expected_ts_start} {expected_ts_end}])"
+
+    # != must be the exact negation of == for the same date
+    eq = Timestamp("created_at") == d
+    assert str(ts) == f"(-{eq!s})"
+
+    # A date-only ISO string takes the same path as a date object
+    assert str(Timestamp("created_at") != "2023-03-17") == str(ts)
+
+
 def test_timestamp_iso_string():
     """Test Timestamp filter with ISO format strings."""
     # Date-only ISO string


### PR DESCRIPTION
## What this fixes

`Timestamp.__ne__`'s docstring promises: *"For date objects (without time), this excludes the entire day."* The implementation called `self.between(start, end)` — the **same positive range construction as `__eq__`** — so the filter matched the entire day instead:

```python
Timestamp("created_at") == date(2023, 3, 17)   # @created_at:[1679029200.0 1679115599.999999]
Timestamp("created_at") != date(2023, 3, 17)   # @created_at:[1679011200.0 1679097599.999999]  ← positive range!
```

Silent inverted filtering: `!=` with a date returns exactly the rows the caller asked to exclude, with no error or warning. The non-date path of the same method already negates correctly via `FilterOperator.NE` (`(-@created_at:[v v])`), as do the `NE` forms of `Tag`, `Text`, `Num`, and `Geo` — the date branch was the one exception.

There was a second, smaller asymmetry hiding in the same branch: `__eq__` computes its day bounds with `.astimezone(timezone.utc)` while `__ne__` used bare `datetime.combine`, so the two methods disagreed about where the day starts on machines whose local timezone isn't UTC.

## The fix

Compute the day bounds exactly as `__eq__` does (including the `astimezone` conversion), convert with `_convert_to_timestamp` exactly as `between()` does, and emit through the existing `OPERATOR_MAP[FilterOperator.NE]` template. The invariant this establishes: **`str(ts != d)` is byte-for-byte `f"(-{ts == d})"`** on any machine, for both `date` objects and date-only ISO strings (`"2023-03-17"`), which take the same branch. The datetime/unix path is untouched.

## Tests

Added `test_timestamp_not_equal_date`, which asserts the negated-range form, the exact-negation-of-`__eq__` invariant, and the ISO-string path. The existing suite covered `!=` only with a `datetime` (the non-date path), which is why this never failed. The new test fails on current `main` and passes with the fix.

`tests/unit/test_filter.py`: 63/63 pass. Full `tests/unit`: 1168 passed, 1 skipped — with 6 errors identical on unmodified `main` in my environment (Docker-dependent CLI fixtures; no daemon locally). `black`, `isort`, and `mypy` clean.

## Notes

- Bug-fix, so this should carry the **`auto:patch`** label per CONTRIBUTING — I can't set labels as an outside contributor.
- Found by reading `filter.py` while working on #654 (exception docs, still open) — happy to rebase either PR if they land in either order; they don't overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query semantics for a previously broken filter path; callers relying on the old (incorrect) behavior would see different results, but the fix aligns with documented behavior and other filter types.
> 
> **Overview**
> Fixes **`Timestamp != date`** (and date-only ISO strings) so they **exclude** the full day instead of matching it. The date branch no longer calls `between()`; it builds the same UTC day bounds as **`==`**, converts them with `_convert_to_timestamp`, and emits a negated Redis range via **`FilterOperator.NE`**—so `str(ts != d)` matches `(-{ts == d})`.
> 
> Adds **`test_timestamp_not_equal_date`** to lock in the negated query shape, the `==` / `!=` pairing, and the ISO-string path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1157c08941ed77839ad7925b464d3a56bee77594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->