### PR TITLE
fix: prevent SearchIndex/AsyncSearchIndex finalizer from leaking every instance

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -129,6 +129,37 @@ def _sql_executor_cache_key(sql_redis_options: dict[str, Any]) -> str:
     return json.dumps(sql_redis_options, sort_keys=True, default=repr)
 
 
+def _close_owned_sync_client(client: SyncRedisClient) -> None:
+    """weakref.finalize callback that closes an index-owned sync client.
+
+    Must stay a module-level function taking the client as an argument: a
+    callback that references the index (e.g. a bound method) would be kept
+    alive by the finalizer registry and prevent the index from ever being
+    garbage collected.
+    """
+    try:
+        client.close()
+    except Exception:
+        # Finalizers may run during interpreter shutdown; never propagate.
+        pass
+
+
+def _close_owned_async_client(client: AsyncRedisClient) -> None:
+    """weakref.finalize callback that closes an index-owned async client.
+
+    Same constraint as :func:`_close_owned_sync_client`: must not reference
+    the index instance.
+    """
+
+    async def _aclose() -> None:
+        await client.aclose()
+
+    try:
+        sync_wrapper(_aclose)()
+    except Exception:
+        pass
+
+
 # Default number of documents processed per round-trip in bulk operations.
 DEFAULT_BULK_BATCH_SIZE = 500
 
@@ -346,8 +377,42 @@ class BaseSearchIndex:
 
     schema: IndexSchema
 
+    # Module-level callback (set per subclass) used to close an owned client
+    # when the index is garbage collected. Must never be a bound method.
+    _finalizer_close_client: Callable[[Any], None]
+
+    _client_finalizer: "weakref.finalize | None" = None
+
     def __init__(*args, **kwargs):
         pass
+
+    def _register_client_finalizer(self, client: Any) -> None:
+        """Register a finalizer that closes ``client`` once this index is
+        garbage collected.
+
+        Call this at every point where the index creates or takes over a
+        client it owns. The finalizer callback must only capture the client,
+        never ``self``: ``weakref.finalize`` keeps the callback alive in a
+        module-level registry until it fires, so a callback holding the
+        instance (a bound method, or any closure over ``self``) would keep
+        the instance reachable forever and the finalizer would never run.
+        """
+        self._detach_client_finalizer()
+        if client is not None and getattr(self, "_owns_redis_client", False):
+            self._client_finalizer = weakref.finalize(
+                self, type(self)._finalizer_close_client, client
+            )
+
+    def _detach_client_finalizer(self) -> None:
+        """Cancel the pending client finalizer, if any.
+
+        Called when the owned client is closed or replaced so the finalizer
+        neither double-closes a client nor keeps a replaced client alive.
+        """
+        finalizer = self._client_finalizer
+        if finalizer is not None:
+            finalizer.detach()
+        self._client_finalizer = None
 
     @property
     def _storage(self) -> BaseStorage:
@@ -600,8 +665,13 @@ class SearchIndex(BaseSearchIndex):
 
         self._validated_client = kwargs.pop("_client_validated", False)
         self._owns_redis_client = kwargs.pop("_owns_redis_client", redis_client is None)
-        if self._owns_redis_client:
-            weakref.finalize(self, self.disconnect)
+        self._client_finalizer = None
+        # Close the owned client when this index is garbage collected. When
+        # the client is created lazily, registration happens at creation time
+        # instead (see the _redis_client property).
+        self._register_client_finalizer(redis_client)
+
+    _finalizer_close_client = staticmethod(_close_owned_sync_client)
 
     def disconnect(self):
         """Disconnect from the Redis database."""
@@ -609,6 +679,7 @@ class SearchIndex(BaseSearchIndex):
         if self._owns_redis_client is False:
             logger.info("Index does not own client, not disconnecting")
             return
+        self._detach_client_finalizer()
         if self.__redis_client:
             self.__redis_client.close()
         self.__redis_client = None
@@ -698,6 +769,7 @@ class SearchIndex(BaseSearchIndex):
                         redis_url=self._redis_url,
                         **kwargs,
                     )
+                    self._register_client_finalizer(self.__redis_client)
         if not self._validated_client and self._lib_name:
             # Only set lib name for user-provided clients
             RedisConnectionFactory.validate_sync_redis(
@@ -730,6 +802,7 @@ class SearchIndex(BaseSearchIndex):
         self.__redis_client = RedisConnectionFactory.get_redis_connection(
             redis_url=redis_url, **kwargs
         )
+        self._register_client_finalizer(self.__redis_client)
 
     @deprecated_function("set_client", "Pass connection parameters in __init__.")
     def set_client(self, redis_client: SyncRedisClient, **kwargs):
@@ -749,6 +822,7 @@ class SearchIndex(BaseSearchIndex):
         RedisConnectionFactory.validate_sync_redis(redis_client)
         self.invalidate_sql_schema_cache()
         self.__redis_client = redis_client
+        self._register_client_finalizer(redis_client)
         return self
 
     def _check_svs_support(self) -> None:
@@ -1858,8 +1932,13 @@ class AsyncSearchIndex(BaseSearchIndex):
 
         self._validated_client = kwargs.pop("_client_validated", False)
         self._owns_redis_client = kwargs.pop("_owns_redis_client", redis_client is None)
-        if self._owns_redis_client:
-            weakref.finalize(self, sync_wrapper(self.disconnect))
+        self._client_finalizer = None
+        # Close the owned client when this index is garbage collected. When
+        # the client is created lazily, registration happens at creation time
+        # instead (see _get_client).
+        self._register_client_finalizer(redis_client)
+
+    _finalizer_close_client = staticmethod(_close_owned_async_client)
 
     @classmethod
     async def from_existing(
@@ -1957,6 +2036,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         await self.disconnect()
         async with self._lock:
             self._redis_client = redis_client
+        self._register_client_finalizer(redis_client)
         return self
 
     async def _get_client(self) -> AsyncRedisClient:
@@ -1974,6 +2054,7 @@ class AsyncSearchIndex(BaseSearchIndex):
                     self._redis_client = (
                         await RedisConnectionFactory._get_aredis_connection(**kwargs)
                     )
+                    self._register_client_finalizer(self._redis_client)
         if not self._validated_client and self._lib_name:
             # Set lib name for user-provided clients
             await RedisConnectionFactory.validate_async_redis(
@@ -2980,6 +3061,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         self.invalidate_sql_schema_cache()
         if self._owns_redis_client is False:
             return
+        self._detach_client_finalizer()
         if self._redis_client is not None:
             await self._redis_client.aclose()
         self._redis_client = None

--- a/tests/integration/test_index_gc_finalizer_integration.py
+++ b/tests/integration/test_index_gc_finalizer_integration.py
@@ -1,0 +1,196 @@
+"""Integration tests for SearchIndex / AsyncSearchIndex garbage collection.
+
+Runs against a real Redis (testcontainers). Verifies, with live connections,
+that:
+
+1. Index instances that own their client are collectable once dropped, and
+   collection closes the owned client's connections.
+2. Index instances built around a caller-provided client never close it.
+3. Building an index per operation (the reported production pattern) does not
+   accumulate live instances.
+
+See tests/unit/test_index_gc_finalizer.py for the mocked-client unit coverage
+of the same contract.
+"""
+
+import asyncio
+import gc
+import weakref
+
+import pytest
+
+from redisvl.index import AsyncSearchIndex, SearchIndex
+
+fields = [
+    {"name": "tag", "type": "tag"},
+    {"name": "num", "type": "numeric"},
+    {
+        "name": "vec",
+        "type": "vector",
+        "attrs": {
+            "dims": 8,
+            "algorithm": "flat",
+            "distance_metric": "cosine",
+            "datatype": "float32",
+        },
+    },
+]
+
+
+def collect():
+    for _ in range(3):
+        gc.collect()
+
+
+@pytest.fixture
+def schema_dict(redis_test_name):
+    name = redis_test_name("gc_finalizer")
+    return {
+        "index": {"name": name, "prefix": name, "storage_type": "hash"},
+        "fields": fields,
+    }
+
+
+def pool_sockets_closed(sync_client) -> bool:
+    """True when every connection in the client's pool has dropped its socket."""
+    pool = sync_client.connection_pool
+    conns = list(pool._available_connections) + list(pool._in_use_connections)
+    return all(getattr(conn, "_sock", None) is None for conn in conns)
+
+
+class TestOwnedClientLifecycle:
+    def test_sync_index_collected_and_owned_client_closed(self, redis_url, schema_dict):
+        index = SearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        # Force lazy client creation with a real round trip.
+        assert index.exists() is False
+        client = index.client
+        assert client is not None
+
+        close_calls = []
+        original_close = client.close
+
+        def recording_close():
+            close_calls.append(1)
+            original_close()
+
+        client.close = recording_close
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "owned sync index was not garbage collected"
+        assert close_calls == [1], "owned client was not closed exactly once"
+        assert pool_sockets_closed(
+            client
+        ), "owned client still holds open sockets after index collection"
+
+    def test_async_index_collected_and_owned_client_closed(
+        self, redis_url, schema_dict
+    ):
+        async def build():
+            index = AsyncSearchIndex.from_dict(schema_dict, redis_url=redis_url)
+            assert await index.exists() is False
+            return index, index.client
+
+        # Build inside a private loop, then drop the index outside any running
+        # loop so the finalizer's sync_wrapper can run the async close.
+        index, client = asyncio.run(build())
+        assert client is not None
+
+        aclose_calls = []
+        original_aclose = client.aclose
+
+        async def recording_aclose():
+            aclose_calls.append(1)
+            await original_aclose()
+
+        client.aclose = recording_aclose
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "owned async index was not garbage collected"
+        assert aclose_calls == [1], "owned async client was not closed exactly once"
+
+    def test_sync_explicit_disconnect_then_collection_closes_once(
+        self, redis_url, schema_dict
+    ):
+        index = SearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        assert index.exists() is False
+        client = index.client
+
+        close_calls = []
+        original_close = client.close
+
+        def recording_close():
+            close_calls.append(1)
+            original_close()
+
+        client.close = recording_close
+
+        index.disconnect()
+        assert close_calls == [1]
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None
+        assert close_calls == [1], "finalizer double-closed after disconnect()"
+
+
+class TestUnownedClientLifecycle:
+    def test_sync_injected_client_survives_index_collection(self, client, schema_dict):
+        from redisvl.schema import IndexSchema
+
+        index = SearchIndex(IndexSchema.from_dict(schema_dict), redis_client=client)
+        assert index.exists() is False
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "index with injected client was not collected"
+        assert client.ping() is True, "injected client was closed by the index"
+
+    async def test_async_injected_client_survives_index_collection(
+        self, async_client, schema_dict
+    ):
+        from redisvl.schema import IndexSchema
+
+        index = AsyncSearchIndex(
+            IndexSchema.from_dict(schema_dict), redis_client=async_client
+        )
+        assert await index.exists() is False
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "async index with injected client was not collected"
+        assert (
+            await async_client.ping() is True
+        ), "injected async client was closed by the index"
+
+
+class TestIndexPerRequestPattern:
+    def test_repeated_sync_construction_does_not_accumulate(
+        self, redis_url, schema_dict
+    ):
+        """The reported production pattern: one SearchIndex per request."""
+        collect()
+        baseline = sum(1 for o in gc.get_objects() if type(o) is SearchIndex)
+
+        for _ in range(20):
+            index = SearchIndex.from_dict(schema_dict, redis_url=redis_url)
+            assert index.exists() is False
+            del index
+
+        collect()
+        live = sum(1 for o in gc.get_objects() if type(o) is SearchIndex)
+        assert live == baseline, (
+            f"leaked {live - baseline} SearchIndex instances across 20 "
+            "construct/use/drop cycles"
+        )

--- a/tests/unit/test_index_gc_finalizer.py
+++ b/tests/unit/test_index_gc_finalizer.py
@@ -1,0 +1,225 @@
+"""Regression tests for the SearchIndex / AsyncSearchIndex finalizer memory leak.
+
+SearchIndex.__init__ historically registered ``weakref.finalize(self,
+self.disconnect)``. A bound method holds a strong reference to ``self``, and
+``weakref.finalize`` keeps its callback alive in a module-level registry until
+the finalizer fires. The finalizer can only fire once the instance is
+unreachable, but the instance can never become unreachable while the callback
+references it, so every index that owned its Redis client was retained for the
+lifetime of the process.
+
+These tests assert the two halves of the contract:
+
+1. Index instances must be garbage collectable after they go out of scope.
+2. The cleanup the finalizer exists to perform (closing an owned client) must
+   still happen when the index is collected, and must not touch clients the
+   index does not own.
+
+No Redis server is required here; client construction is mocked. Integration
+coverage against a real Redis lives in
+``tests/integration/test_index_gc_finalizer_integration.py``.
+"""
+
+import asyncio
+import gc
+import weakref
+from unittest import mock
+
+from redisvl.index import AsyncSearchIndex, SearchIndex
+from redisvl.schema import IndexSchema
+
+SCHEMA_DICT = {
+    "index": {"name": "gc-probe", "prefix": "gc", "storage_type": "hash"},
+    "fields": [
+        {"name": "tag", "type": "tag"},
+        {"name": "num", "type": "numeric"},
+        {
+            "name": "vec",
+            "type": "vector",
+            "attrs": {
+                "dims": 8,
+                "algorithm": "flat",
+                "distance_metric": "cosine",
+                "datatype": "float32",
+            },
+        },
+    ],
+}
+
+
+def collect():
+    """Run a couple of GC passes so collection is not order-dependent."""
+    for _ in range(3):
+        gc.collect()
+
+
+def count_live(cls) -> int:
+    return sum(1 for obj in gc.get_objects() if type(obj) is cls)
+
+
+class TestInstancesAreCollectable:
+    def test_sync_index_is_garbage_collected(self):
+        index = SearchIndex.from_dict(SCHEMA_DICT)
+        ref = weakref.ref(index)
+        del index
+        collect()
+        assert ref() is None, (
+            "SearchIndex instance survived del + gc.collect(); the finalizer "
+            "callback must not hold a reference to the instance"
+        )
+
+    def test_async_index_is_garbage_collected(self):
+        index = AsyncSearchIndex.from_dict(SCHEMA_DICT)
+        ref = weakref.ref(index)
+        del index
+        collect()
+        assert ref() is None, (
+            "AsyncSearchIndex instance survived del + gc.collect(); the "
+            "finalizer callback must not hold a reference to the instance"
+        )
+
+    def test_instances_do_not_accumulate_across_many_constructions(self):
+        """Mirror of the reported reproduction: build N indexes, drop them,
+        and require that none remain alive."""
+        for cls in (SearchIndex, AsyncSearchIndex):
+            collect()
+            baseline = count_live(cls)
+            for _ in range(50):
+                index = cls.from_dict(SCHEMA_DICT)
+                del index
+            collect()
+            assert count_live(cls) == baseline, (
+                f"{cls.__name__} leaked instances across repeated "
+                "construction and deletion"
+            )
+
+    def test_sync_index_with_injected_client_is_garbage_collected(self):
+        schema = IndexSchema.from_dict(SCHEMA_DICT)
+        fake_client = mock.MagicMock(name="injected_sync_client")
+        index = SearchIndex(schema, redis_client=fake_client)
+        ref = weakref.ref(index)
+        del index
+        collect()
+        assert ref() is None
+
+
+class TestOwnedClientIsClosedOnCollection:
+    def test_sync_lazily_created_client_closed_when_index_collected(self):
+        fake_client = mock.MagicMock(name="owned_sync_client")
+        with mock.patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+            return_value=fake_client,
+        ):
+            index = SearchIndex.from_dict(SCHEMA_DICT, redis_url="redis://fake:6379")
+            # Trigger lazy client creation through the internal accessor.
+            assert index._redis_client is fake_client
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None
+        fake_client.close.assert_called_once()
+
+    def test_async_lazily_created_client_closed_when_index_collected(self):
+        fake_client = mock.MagicMock(name="owned_async_client")
+        fake_client.aclose = mock.AsyncMock()
+
+        async def build():
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                new=mock.AsyncMock(return_value=fake_client),
+            ):
+                index = AsyncSearchIndex.from_dict(
+                    SCHEMA_DICT, redis_url="redis://fake:6379"
+                )
+                assert await index._get_client() is fake_client
+            return index
+
+        # Build inside a loop, then drop the reference outside of any running
+        # loop so the finalizer's sync_wrapper can create its own loop.
+        index = asyncio.run(build())
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None
+        fake_client.aclose.assert_awaited_once()
+
+    def test_sync_index_that_never_created_a_client_collects_cleanly(self):
+        index = SearchIndex.from_dict(SCHEMA_DICT, redis_url="redis://fake:6379")
+        ref = weakref.ref(index)
+        del index
+        collect()
+        assert ref() is None
+
+
+class TestExplicitDisconnect:
+    def test_sync_disconnect_closes_once_and_detaches_finalizer(self):
+        fake_client = mock.MagicMock(name="owned_sync_client")
+        with mock.patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+            return_value=fake_client,
+        ):
+            index = SearchIndex.from_dict(SCHEMA_DICT, redis_url="redis://fake:6379")
+            assert index._redis_client is fake_client
+
+        index.disconnect()
+        fake_client.close.assert_called_once()
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None
+        # The finalizer must not fire a second close after disconnect().
+        fake_client.close.assert_called_once()
+
+    def test_async_disconnect_closes_once_and_detaches_finalizer(self):
+        fake_client = mock.MagicMock(name="owned_async_client")
+        fake_client.aclose = mock.AsyncMock()
+
+        async def build_and_disconnect():
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                new=mock.AsyncMock(return_value=fake_client),
+            ):
+                index = AsyncSearchIndex.from_dict(
+                    SCHEMA_DICT, redis_url="redis://fake:6379"
+                )
+                assert await index._get_client() is fake_client
+            await index.disconnect()
+            return index
+
+        index = asyncio.run(build_and_disconnect())
+        fake_client.aclose.assert_awaited_once()
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None
+        fake_client.aclose.assert_awaited_once()
+
+
+class TestUnownedClientIsNeverClosed:
+    def test_sync_injected_client_not_closed_on_collection(self):
+        schema = IndexSchema.from_dict(SCHEMA_DICT)
+        fake_client = mock.MagicMock(name="injected_sync_client")
+        index = SearchIndex(schema, redis_client=fake_client)
+
+        del index
+        collect()
+
+        fake_client.close.assert_not_called()
+
+    def test_async_injected_client_not_closed_on_collection(self):
+        schema = IndexSchema.from_dict(SCHEMA_DICT)
+        fake_client = mock.MagicMock(name="injected_async_client")
+        fake_client.aclose = mock.AsyncMock()
+        index = AsyncSearchIndex(schema, redis_client=fake_client)
+
+        del index
+        collect()
+
+        fake_client.aclose.assert_not_awaited()


### PR DESCRIPTION
## Background

An external user reported that every `SearchIndex` and `AsyncSearchIndex` instance is retained for the lifetime of the process, and attributed unbounded memory growth in a document-ingestion service (which constructs an index per upload request) to it.

Their production telemetry, quoted here as reported and **not** independently verified: about 33.5 KB leaked per request, container RSS climbing 3.82 GB to 5.72 GB over 42 hours at roughly 21k requests/hour, and pods OOM-killed about every 4 days.

What was verified locally against origin/main (v0.24.0):

- 300 of 300 constructed indexes of each class survive `del` plus a full `gc.collect()`.
- Retained memory over 3000 construct-and-drop cycles, measured as RSS delta after `gc.collect()`: about 5.1 KB per construction with a 3-field schema, and about 29 KB with a 25-field schema (the instance drags its `IndexSchema`, every field object, its lock, and its Redis client along with it). With this fix both fall to noise (roughly 0.1 KB) and zero instances are retained.
- Explicit `disconnect()` does not mitigate the leak, and indexes given a caller-provided client never leaked. Both corollaries follow from the mechanism below.

The bug was introduced by #280 and first shipped in 0.4.0, so every release from 0.4.0 through 0.24.0 is affected (wider than the 0.18.2+ range in the original report).

## Description

`SearchIndex.__init__` registered a finalizer whose callback is a bound method of the instance being finalized:

```python
if self._owns_redis_client:
    weakref.finalize(self, self.disconnect)
```

A bound method holds a strong reference to its instance, and `weakref.finalize` stores its callback in a module-level registry that is a genuine GC root until the finalizer fires. The finalizer can only fire once the instance is unreachable, but the instance can never become unreachable while the registry holds the callback that references it. The finalizer therefore never fires, `disconnect()` never runs, and the index (schema, field objects, locks, and Redis client) is immortal.

`AsyncSearchIndex` had the same defect one level removed: `sync_wrapper(self.disconnect)` returns a closure over the bound method.

This is the documented constraint of [`weakref.finalize`](https://docs.python.org/3/library/weakref.html#weakref.finalize): the callback must not hold a reference to the object being finalized.

Reproduction (no Redis needed): construct and drop 300 indexes, then `gc.collect()`. Before this change, all 300 remain alive for both classes; after, zero. This also explains the two corollaries above: the registry entry retains the instance whether or not `disconnect()` is ever called, and no finalizer is registered at all on the caller-provided-client path.

## Fix

Bind the finalizer to the client, never to `self`. Binding at `__init__` alone is not enough: in the default `from_dict`/`from_yaml` + `redis_url` path the client does not exist yet at construction and is created lazily, so an `__init__`-bound finalizer would capture `None` and silently stop closing real connections.

Instead, the finalizer is registered at every site where an owned client is created or replaced, and detached whenever that client is closed or swapped out:

- Module-level close callbacks (`_close_owned_sync_client`, `_close_owned_async_client`) that take the client as an argument and cannot reference the index. The async callback reuses the existing shutdown-hardened `sync_wrapper`.
- `_register_client_finalizer` / `_detach_client_finalizer` helpers on `BaseSearchIndex`. Registration detaches any previous finalizer first, so a replaced client is never closed later by a stale finalizer.
- Registration sites: `__init__` (covers the `from_existing` constructors, which pass an owned client), lazy creation (sync `_redis_client` property, async `_get_client`), and the deprecated `connect()` / `set_client()` paths.
- Both `disconnect()` implementations detach the finalizer before closing, so an explicitly disconnected index is not double-closed at collection time.

Behavior is unchanged for indexes that do not own their client: no finalizer is registered and the caller's client is never touched.

## Testing

Test-driven: all tests were written first and confirmed failing against unmodified origin/main, then the fix was applied.

- `tests/unit/test_index_gc_finalizer.py` (11 tests, no Redis required): instances of both classes are collectable after `del` + `gc.collect()`; repeated construct/drop cycles do not accumulate; a lazily created owned client is closed exactly once on collection; explicit `disconnect()` closes once and detaches; injected clients are never closed. Before the fix 8 of 11 failed (the 3 passing were the unowned-client cases, consistent with the diagnosis).
- `tests/integration/test_index_gc_finalizer_integration.py` (6 tests, real Redis via testcontainers): an owned client that performed a real round trip is closed exactly once on index collection and its pool sockets are torn down; same for the async client through `sync_wrapper`; injected sync and async clients survive collection and still answer PING; the index-per-request pattern leaves no live instances. Before the fix 4 of 6 failed.
- Full non-API suite locally (`pytest -n auto`, `redis:8.4`): 1976 passed. Six `test_sql_redis_hybrid.py` tests failed locally at the time, and were verified to fail identically on unmodified origin/main, so they were unrelated to this change. Correction added after merge: their cause was a stale local virtualenv holding `sql-redis` 0.6.0 while `pyproject.toml` requires `>=0.7.1`. After `uv sync --all-extras` all six pass locally. They were never broken in the repository or in CI.
- `make format`, `make check-types` (mypy), and pre-commit all pass.

### On the `redis:latest` CI job

One matrix job (`Python 3.13 - redis-py 7.x [redis:latest]`) fails with two `test_hybrid.py` assertions returning zero rows. This looks unrelated to this change:

- `tests/docker-compose.yml` already documents this failure mode: Redis 8.8 changed the RediSearch worker-pool default to a multithreaded background executor, "which surfaces a race where FT.SEARCH can return nil fields for docs that expire mid-query -- the source of flaky redis:latest CI runs".
- Nightly runs on `main` fail the same way on `redis:latest` with a rotating cast of tests (`test_unf_noindex_integration` on Jul 31, `test_query_cosine_distance_un_normalized` on Jul 29), all with the same signature of fewer documents than expected.
- Both failing tests pass locally against `redis:latest` (8.10.0), repeatedly, under `-n auto`.
- Structurally, this change only closes a client the index itself created. `RedisConnectionFactory.get_redis_connection` builds a fresh pool per call via `Redis.from_url` with no caching, so a finalizer firing on one index cannot affect any other client's connections or document visibility.

Two separate observations for whoever picks up the `redis:latest` flakiness, neither of which blocks this PR:

1. The compose mitigation is inert. The official `redis` image does not read `REDIS_ARGS` (that is a redis-stack convention), so `--search-workers 0` is never applied. Confirmed locally: a container started with `REDIS_ARGS=--maxmemory 123mb` reports `maxmemory 0`, and one started with the compose settings reports `search-workers 14`. The flags belong in a compose `command:` entry.
2. That said, the root cause of the `redis:latest` failures is still unattributed. Loading documents and querying immediately, 150 iterations against `redis:latest` (8.10.0) with `search-workers 14` and again with `search-workers 0`, produced no shortfall in either configuration (vector and filter queries both saw all documents every time). So the worker-pool race described in the compose comment was not reproducible here, and fixing item 1 should not be assumed to fix the flake.

## Notes for users on affected versions (0.4.0 through 0.24.0)

- Prefer one long-lived index object per logical index rather than one per operation; this avoids the leak entirely and is also cheaper (no connection churn).
- Calling `disconnect()` does not mitigate the leak on affected versions; only instance reuse does.

