### PR TITLE
test: apply Redis server flags via compose command, not REDIS_ARGS

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,14 +3,26 @@ services:
     image: "${REDIS_IMAGE:-redis:8.4}"
     ports:
       - "6379"
-    environment:
-      # Pin the RediSearch worker pool to 0 (single-threaded, foreground
-      # execution). Redis 8.8 changed the default from 0 to a multithreaded
-      # background executor, which surfaces a race where FT.SEARCH can return
-      # nil fields for docs that expire mid-query -- the source of flaky
-      # redis:latest CI runs. WORKERS=0 avoids the race and is already the
-      # default on the pinned 8.2/8.4 images, so this is a no-op there.
-      - "REDIS_ARGS=--save '' --appendonly no --search-workers ${REDIS_SEARCH_WORKERS:-0}"
+    # Server flags have to be passed as real arguments. REDIS_ARGS is a
+    # redis-stack image convention: the official docker.io/library/redis image
+    # used here never reads it, so anything set that way is silently ignored.
+    #
+    # --save "" disables RDB save points and --appendonly no disables the AOF;
+    # test data is disposable.
+    #
+    # --search-workers pins the RediSearch worker pool to 0 (single-threaded,
+    # foreground execution). Redis 8.8 changed the default from 0 to a
+    # multithreaded background executor, so pinning it keeps newer images on the
+    # same query execution model as the pinned 8.2/8.4 images, where 0 is
+    # already the default (a no-op there). Override with REDIS_SEARCH_WORKERS.
+    command:
+      - "redis-server"
+      - "--save"
+      - ""
+      - "--appendonly"
+      - "no"
+      - "--search-workers"
+      - "${REDIS_SEARCH_WORKERS:-0}"
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
Fixes #658

## Problem

`tests/docker-compose.yml` passed Redis server flags through the `REDIS_ARGS` environment variable. `REDIS_ARGS` is a redis-stack image convention: its entrypoint reads the variable and appends it to the server command line. The official `docker.io/library/redis` image that this compose file uses never reads it, so `--save ''`, `--appendonly no`, and `--search-workers` were all silently discarded.

The practical effect was that the `--search-workers 0` pin, added to keep newer Redis images on the same query execution model as the pinned ones, had never taken effect on any image.

This is test infrastructure only. No shipped `redisvl` code is affected, so no released version carries a defect from this.

## Fix

The flags are now passed as real server arguments via a compose `command:` entry, with the `${REDIS_SEARCH_WORKERS:-0}` parameterization preserved. The accompanying comment was rewritten to explain the actual mechanism (the official image ignores `REDIS_ARGS`) and no longer asserts the FT.SEARCH nil-field race as established fact, for the reason in the next section.

Exec (list) form turned out to express `--save ''` correctly, so no shell-form fallback was needed. `docker inspect -f '{{json .Args}}'` confirms the argv reaching the server:

```
["redis-server","--save","","--appendonly","no","--search-workers","0"]
```

## Verification

Containers were started from this compose file and inspected directly. On `redis:latest` (8.10.0):

```
CONFIG GET search-workers  ->  0        (was 14 before this change)
CONFIG GET save            ->  ""       (zero-length string, no save points)
CONFIG GET appendonly      ->  no
```

The same three checks pass on `redis:8.4` (8.4.5) and `redis:8.2` (8.2.8), where `search-workers 0` is already the default so the pin is a no-op, and both containers start normally. `--search-workers` is accepted on all three images, so no version gating is needed.

Parameterization still works: `REDIS_SEARCH_WORKERS=4` yields `CONFIG GET search-workers -> 4` on both `redis:latest` and `redis:8.4`, with `save` and `appendonly` unchanged.

Integration tests exercising the testcontainers `DockerCompose` fixture that drives this file:

- `tests/integration/test_search_index.py`: 46 passed
- `tests/integration/test_hybrid.py`: 12 passed, 2 skipped

## Why this matters: it fixes the flaky redis:latest jobs

The comment being replaced attributed flaky `redis:latest` runs to the Redis 8.8 change that enables a multithreaded RediSearch worker pool. That attribution is correct, and because `REDIS_ARGS` was ignored, `search-workers` has been at the image default on every `redis:latest` CI job, so the intended mitigation was never in effect.

Reproduced with 8 concurrent threads each creating an index, loading 3 documents, and querying immediately expecting all 3, 60 iterations per thread (480 total), against `redis:latest` (8.10.0):

| configuration | shortfalls | documents seen at first query |
|---|---|---|
| `search-workers 14` (image default), 1 CPU | 17/480 | 0, 1, or 2 instead of 3 |
| `search-workers 14` (image default), unconstrained CPU | 17/480 | 0, 1, or 2 instead of 3 |
| `search-workers 0` | **0/480** | always 3 |

The partial-result distribution matches the observed CI failures: zero documents (`test_hybrid.py` returning 0 of 7) and 1 or 2 of 3 (`test_unf_noindex_integration`).

The writes are not lost. Across 30 shortfall events, all 3 hashes were already in the keyspace every time, and the index caught up in every case within 0.8 to 2.6 ms (median 1.6 ms). So `FT.SEARCH` briefly loses read-your-writes consistency under concurrent write and query load, and `search-workers 0` eliminates it.

A single-threaded probe against an idle server shows no shortfall at all, which is why an earlier attempt of mine failed to reproduce this. Concurrency is required to surface it.

This is server behavior and also affects library users who load and then immediately query under concurrency. That is tracked separately for documentation and is not addressed by this PR.
