### PR TITLE
fix: do not close a caller-provided client passed to set_client()

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -955,8 +955,14 @@ class SearchIndex(BaseSearchIndex):
         # create a client in between, whose finalizer would then be detached by
         # the swap below without anything closing it.
         with self._lock:
-            if client is not self.__redis_client:
-                self._release_owned_client_locked()
+            if client is self.__redis_client:
+                # The factory handed back the client already installed, so its
+                # provenance has not changed and ownership stays as it is.
+                # Claiming it here would let this index close a caller-provided
+                # client. Only reachable with a factory that reuses clients;
+                # Redis.from_url always builds a fresh one.
+                return
+            self._release_owned_client_locked()
             self.__redis_client = client
             # This index created the client, so it owns and must close it. The
             # index may have been holding a caller-provided client until now

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -969,8 +969,14 @@ class SearchIndex(BaseSearchIndex):
         """
         RedisConnectionFactory.validate_sync_redis(redis_client)
         self.invalidate_sql_schema_cache()
+        # Release the client this index created for itself, if any, before
+        # taking on the caller's client.
+        self.disconnect()
         self.__redis_client = redis_client
-        self._register_client_finalizer(redis_client)
+        # The caller owns the client they passed in, so this index must never
+        # close it. This matches __init__(redis_client=...) semantics.
+        self._owns_redis_client = False
+        self._detach_client_finalizer()
         return self
 
     def _check_svs_support(self) -> None:
@@ -2171,7 +2177,8 @@ class AsyncSearchIndex(BaseSearchIndex):
         client = await RedisConnectionFactory._get_aredis_connection(
             redis_url=redis_url, **kwargs
         )
-        await self.set_client(client)
+        # This index created the client, so it owns and must close it.
+        await self._swap_client(client, owns=True)
 
     @deprecated_function("set_client", "Pass connection parameters in __init__.")
     async def set_client(self, redis_client: AsyncRedisClient | SyncRedisClient):
@@ -2179,12 +2186,31 @@ class AsyncSearchIndex(BaseSearchIndex):
         [DEPRECATED] Manually set the Redis client to use with the search index.
         This method is deprecated; please provide connection parameters in __init__.
         """
-        redis_client = await self._validate_client(redis_client)
+        # The caller owns the client they passed in, so this index must never
+        # close it. This matches __init__(redis_client=...) semantics.
+        return await self._swap_client(redis_client, owns=False)
+
+    async def _swap_client(
+        self, redis_client: AsyncRedisClient | SyncRedisClient, *, owns: bool
+    ):
+        """Replace the active client, releasing the previous one if owned.
+
+        Args:
+            redis_client: The client to start using.
+            owns: Whether this index owns the new client and is therefore
+                responsible for closing it. Callers passing their own client
+                must use False so it is never closed on their behalf.
+        """
+        validated_client = await self._validate_client(redis_client)
         self.invalidate_sql_schema_cache()
+        # Release the client this index created for itself, if any.
         await self.disconnect()
         async with self._lock:
-            self._redis_client = redis_client
-        self._register_client_finalizer(redis_client)
+            self._redis_client = validated_client
+        self._owns_redis_client = owns
+        # No-op when owns is False; also detaches any finalizer left over from
+        # a previously owned client.
+        self._register_client_finalizer(validated_client)
         return self
 
     async def _get_client(self) -> AsyncRedisClient:

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -987,15 +987,20 @@ class SearchIndex(BaseSearchIndex):
         # Release the previous client and install the caller's under a single
         # lock hold, for the reason described in connect().
         with self._lock:
-            # Skip the release when the caller hands back the client already
-            # installed: closing it would leave this index holding a client it
-            # had just closed.
-            if redis_client is not self.__redis_client:
-                self._release_owned_client_locked()
-            self.__redis_client = redis_client
-            # The caller owns the client they passed in, so this index must
-            # never close it. Matches __init__(redis_client=...) semantics.
+            if redis_client is self.__redis_client:
+                # The client is already installed, so there is nothing to
+                # release and nothing about its provenance has changed. Leaving
+                # ownership alone matters: clearing it for a client this index
+                # created would strand that client, since a later swap only
+                # closes what the index owns and its finalizer is detached
+                # below.
+                return self
+            self._release_owned_client_locked()
+            # Clear ownership before installing the caller's client. disconnect()
+            # does not take this lock, so another thread must never see the
+            # caller's client while ownership still says the index owns it.
             self._owns_redis_client = False
+            self.__redis_client = redis_client
             # A replacement client has not had this index's lib name applied.
             self._validated_client = False
             self._detach_client_finalizer()
@@ -2281,10 +2286,21 @@ class AsyncSearchIndex(BaseSearchIndex):
             # Skip the release when the client being installed is the one
             # already active: closing it would leave this index holding a
             # client it had just closed.
-            if validated_client is not self._redis_client:
-                await self._release_owned_client_locked()
-            self._redis_client = validated_client
-            self._owns_redis_client = owns_client
+            if validated_client is self._redis_client:
+                # Already installed: nothing to release, and its provenance is
+                # unchanged, so ownership stays as it is. Clearing it for a
+                # client this index created would strand that client.
+                return self
+            await self._release_owned_client_locked()
+            if owns_client:
+                # Install first, then claim, so no reader can see a client this
+                # index does not own marked as owned.
+                self._redis_client = validated_client
+                self._owns_redis_client = True
+            else:
+                # Give up ownership first, for the same reason in reverse.
+                self._owns_redis_client = False
+                self._redis_client = validated_client
             # A replacement client has not had this index's lib name applied.
             self._validated_client = False
             # No-op when ownership is False; also detaches any finalizer left

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -950,12 +950,12 @@ class SearchIndex(BaseSearchIndex):
         client = RedisConnectionFactory.get_redis_connection(
             redis_url=redis_url, **kwargs
         )
-        # Release the client this index owned before, if any. Registering a
-        # finalizer for the new client detaches the old client's finalizer, so
-        # without closing it here its connections would leak.
-        if self._owns_redis_client:
-            self.disconnect()
+        # Release the previous client and install the new one under a single
+        # lock hold. Releasing outside the lock would let another thread lazily
+        # create a client in between, whose finalizer would then be detached by
+        # the swap below without anything closing it.
         with self._lock:
+            self._release_owned_client_locked()
             self.__redis_client = client
             # This index created the client, so it owns and must close it. The
             # index may have been holding a caller-provided client until now
@@ -981,20 +981,25 @@ class SearchIndex(BaseSearchIndex):
         """
         RedisConnectionFactory.validate_sync_redis(redis_client)
         self.invalidate_sql_schema_cache()
-        # Release the client this index created for itself, if any. Skipped when
-        # the current client is not ours, where disconnect() would do nothing
-        # beyond logging that it is not disconnecting.
-        if self._owns_redis_client:
-            self.disconnect()
-        # Swap the client and its ownership together so no other thread can
-        # observe the new client while ownership still describes the old one.
+        # Release the previous client and install the caller's under a single
+        # lock hold, for the reason described in connect().
         with self._lock:
+            self._release_owned_client_locked()
             self.__redis_client = redis_client
             # The caller owns the client they passed in, so this index must
             # never close it. Matches __init__(redis_client=...) semantics.
             self._owns_redis_client = False
             self._detach_client_finalizer()
         return self
+
+    def _release_owned_client_locked(self) -> None:
+        """Close the current client if this index owns it. Call with ``_lock``
+        held, so releasing and replacing a client cannot interleave with the
+        lazy creation in the ``_redis_client`` property."""
+        if self._owns_redis_client and self.__redis_client is not None:
+            self._detach_client_finalizer()
+            self.__redis_client.close()
+            self.__redis_client = None
 
     def _check_svs_support(self) -> None:
         """Validate SVS-VAMANA support.
@@ -2219,20 +2224,26 @@ class AsyncSearchIndex(BaseSearchIndex):
                 must use False so it is never closed on their behalf.
         """
         validated_client = await self._validate_client(redis_client)
+        # A deprecated sync client is converted into a *new* async client with
+        # its own connection pool, so that object is ours to close even though
+        # the caller supplied the original. The conversion does not share the
+        # caller's pool, so closing it leaves the caller's client working.
+        owns_client = owns or validated_client is not redis_client
         self.invalidate_sql_schema_cache()
-        # Release the client this index created for itself, if any. Skipped when
-        # the current client is not ours, where disconnect() is a no-op.
-        if self._owns_redis_client:
-            await self.disconnect()
-        # Swap the client and its ownership together. Setting ownership outside
-        # the lock would leave a window where another coroutine could see the
-        # new client while ownership still describes the old one, and close a
-        # caller-provided client on that basis.
+        # Release the previous client and install the new one under a single
+        # lock hold. Releasing outside the lock would let another coroutine
+        # lazily create a client in between, whose finalizer would then be
+        # detached by the swap below without anything closing it. Holding the
+        # lock also means ownership is never observable out of step with the
+        # client it describes.
         async with self._lock:
+            if self._owns_redis_client and self._redis_client is not None:
+                self._detach_client_finalizer()
+                await self._redis_client.aclose()
             self._redis_client = validated_client
-            self._owns_redis_client = owns
-            # No-op when owns is False; also detaches any finalizer left over
-            # from a previously owned client.
+            self._owns_redis_client = owns_client
+            # No-op when ownership is False; also detaches any finalizer left
+            # over from a previously owned client.
             self._register_client_finalizer(validated_client)
         return self
 

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -955,13 +955,16 @@ class SearchIndex(BaseSearchIndex):
         # create a client in between, whose finalizer would then be detached by
         # the swap below without anything closing it.
         with self._lock:
-            self._release_owned_client_locked()
+            if client is not self.__redis_client:
+                self._release_owned_client_locked()
             self.__redis_client = client
             # This index created the client, so it owns and must close it. The
             # index may have been holding a caller-provided client until now
             # (constructor injection or set_client), in which case ownership
             # has to be taken back or nothing would ever close this one.
             self._owns_redis_client = True
+            # A different client has not had this index's lib name applied yet.
+            self._validated_client = False
             self._register_client_finalizer(client)
 
     @deprecated_function("set_client", "Pass connection parameters in __init__.")
@@ -984,11 +987,17 @@ class SearchIndex(BaseSearchIndex):
         # Release the previous client and install the caller's under a single
         # lock hold, for the reason described in connect().
         with self._lock:
-            self._release_owned_client_locked()
+            # Skip the release when the caller hands back the client already
+            # installed: closing it would leave this index holding a client it
+            # had just closed.
+            if redis_client is not self.__redis_client:
+                self._release_owned_client_locked()
             self.__redis_client = redis_client
             # The caller owns the client they passed in, so this index must
             # never close it. Matches __init__(redis_client=...) semantics.
             self._owns_redis_client = False
+            # A replacement client has not had this index's lib name applied.
+            self._validated_client = False
             self._detach_client_finalizer()
         return self
 
@@ -2237,11 +2246,17 @@ class AsyncSearchIndex(BaseSearchIndex):
         # lock also means ownership is never observable out of step with the
         # client it describes.
         async with self._lock:
-            if self._owns_redis_client and self._redis_client is not None:
-                self._detach_client_finalizer()
-                await self._redis_client.aclose()
+            # Skip the release when the client being installed is the one
+            # already active: closing it would leave this index holding a
+            # client it had just closed.
+            if validated_client is not self._redis_client:
+                if self._owns_redis_client and self._redis_client is not None:
+                    self._detach_client_finalizer()
+                    await self._redis_client.aclose()
             self._redis_client = validated_client
             self._owns_redis_client = owns_client
+            # A replacement client has not had this index's lib name applied.
+            self._validated_client = False
             # No-op when ownership is False; also detaches any finalizer left
             # over from a previously owned client.
             self._register_client_finalizer(validated_client)

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -1004,11 +1004,23 @@ class SearchIndex(BaseSearchIndex):
     def _release_owned_client_locked(self) -> None:
         """Close the current client if this index owns it. Call with ``_lock``
         held, so releasing and replacing a client cannot interleave with the
-        lazy creation in the ``_redis_client`` property."""
+        lazy creation in the ``_redis_client`` property.
+
+        The reference is cleared before the close so a failed close cannot
+        leave the index holding a client it already closed, and the failure is
+        swallowed so it cannot abort the swap and orphan the replacement.
+        """
         if self._owns_redis_client and self.__redis_client is not None:
+            client = self.__redis_client
             self._detach_client_finalizer()
-            self.__redis_client.close()
             self.__redis_client = None
+            try:
+                client.close()
+            except Exception as e:
+                # Deliberately not exc_info: retaining the traceback keeps the
+                # frames, and therefore this index, reachable, which is the
+                # class of leak this lifecycle code exists to avoid.
+                logger.warning("Failed to close the Redis client being replaced: %s", e)
 
     def _check_svs_support(self) -> None:
         """Validate SVS-VAMANA support.
@@ -2221,6 +2233,26 @@ class AsyncSearchIndex(BaseSearchIndex):
         # close it. This matches __init__(redis_client=...) semantics.
         return await self._swap_client(redis_client, owns=False)
 
+    async def _release_owned_client_locked(self) -> None:
+        """Close the current client if this index owns it. Call with ``_lock``
+        held, matching the sync counterpart.
+
+        The reference is cleared before awaiting the close so a failed or
+        in-flight close cannot leave the index holding a client it already
+        closed, and the failure is swallowed so it cannot abort the swap and
+        orphan the replacement.
+        """
+        if self._owns_redis_client and self._redis_client is not None:
+            client = self._redis_client
+            self._detach_client_finalizer()
+            self._redis_client = None
+            try:
+                await client.aclose()
+            except Exception as e:
+                # See the sync counterpart: no exc_info, so the traceback does
+                # not keep this index reachable.
+                logger.warning("Failed to close the Redis client being replaced: %s", e)
+
     async def _swap_client(
         self, redis_client: AsyncRedisClient | SyncRedisClient, *, owns: bool
     ):
@@ -2250,9 +2282,7 @@ class AsyncSearchIndex(BaseSearchIndex):
             # already active: closing it would leave this index holding a
             # client it had just closed.
             if validated_client is not self._redis_client:
-                if self._owns_redis_client and self._redis_client is not None:
-                    self._detach_client_finalizer()
-                    await self._redis_client.aclose()
+                await self._release_owned_client_locked()
             self._redis_client = validated_client
             self._owns_redis_client = owns_client
             # A replacement client has not had this index's lib name applied.

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -947,10 +947,17 @@ class SearchIndex(BaseSearchIndex):
             ModuleNotFoundError: If required Redis modules are not installed.
         """
         self.invalidate_sql_schema_cache()
-        self.__redis_client = RedisConnectionFactory.get_redis_connection(
+        client = RedisConnectionFactory.get_redis_connection(
             redis_url=redis_url, **kwargs
         )
-        self._register_client_finalizer(self.__redis_client)
+        with self._lock:
+            self.__redis_client = client
+            # This index created the client, so it owns and must close it. The
+            # index may have been holding a caller-provided client until now
+            # (constructor injection or set_client), in which case ownership
+            # has to be taken back or nothing would ever close this one.
+            self._owns_redis_client = True
+            self._register_client_finalizer(client)
 
     @deprecated_function("set_client", "Pass connection parameters in __init__.")
     def set_client(self, redis_client: SyncRedisClient, **kwargs):
@@ -969,14 +976,19 @@ class SearchIndex(BaseSearchIndex):
         """
         RedisConnectionFactory.validate_sync_redis(redis_client)
         self.invalidate_sql_schema_cache()
-        # Release the client this index created for itself, if any, before
-        # taking on the caller's client.
-        self.disconnect()
-        self.__redis_client = redis_client
-        # The caller owns the client they passed in, so this index must never
-        # close it. This matches __init__(redis_client=...) semantics.
-        self._owns_redis_client = False
-        self._detach_client_finalizer()
+        # Release the client this index created for itself, if any. Skipped when
+        # the current client is not ours, where disconnect() would do nothing
+        # beyond logging that it is not disconnecting.
+        if self._owns_redis_client:
+            self.disconnect()
+        # Swap the client and its ownership together so no other thread can
+        # observe the new client while ownership still describes the old one.
+        with self._lock:
+            self.__redis_client = redis_client
+            # The caller owns the client they passed in, so this index must
+            # never close it. Matches __init__(redis_client=...) semantics.
+            self._owns_redis_client = False
+            self._detach_client_finalizer()
         return self
 
     def _check_svs_support(self) -> None:
@@ -2203,14 +2215,20 @@ class AsyncSearchIndex(BaseSearchIndex):
         """
         validated_client = await self._validate_client(redis_client)
         self.invalidate_sql_schema_cache()
-        # Release the client this index created for itself, if any.
-        await self.disconnect()
+        # Release the client this index created for itself, if any. Skipped when
+        # the current client is not ours, where disconnect() is a no-op.
+        if self._owns_redis_client:
+            await self.disconnect()
+        # Swap the client and its ownership together. Setting ownership outside
+        # the lock would leave a window where another coroutine could see the
+        # new client while ownership still describes the old one, and close a
+        # caller-provided client on that basis.
         async with self._lock:
             self._redis_client = validated_client
-        self._owns_redis_client = owns
-        # No-op when owns is False; also detaches any finalizer left over from
-        # a previously owned client.
-        self._register_client_finalizer(validated_client)
+            self._owns_redis_client = owns
+            # No-op when owns is False; also detaches any finalizer left over
+            # from a previously owned client.
+            self._register_client_finalizer(validated_client)
         return self
 
     async def _get_client(self) -> AsyncRedisClient:

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -950,6 +950,11 @@ class SearchIndex(BaseSearchIndex):
         client = RedisConnectionFactory.get_redis_connection(
             redis_url=redis_url, **kwargs
         )
+        # Release the client this index owned before, if any. Registering a
+        # finalizer for the new client detaches the old client's finalizer, so
+        # without closing it here its connections would leak.
+        if self._owns_redis_client:
+            self.disconnect()
         with self._lock:
             self.__redis_client = client
             # This index created the client, so it owns and must close it. The

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -225,15 +225,15 @@ async def test_search_index_set_client(client, redis_url, index_schema):
             await async_index.set_client(client)
             assert isinstance(async_index.client, AsyncRedis)
 
-            # The caller supplied this client, so the index does not own it.
-            # disconnect() must therefore leave it in place and open, exactly
-            # as when a client is passed to __init__. The converted async
-            # wrapper shares the caller's connection pool, so closing it here
-            # would tear down connections the caller still relies on.
-            assert async_index._owns_redis_client is False
+            # Passing a sync client to the async index converts it into a new
+            # async client with its own connection pool, so the object the index
+            # holds was created by RedisVL and the index owns it. Closing it
+            # does not touch the caller's sync client, which keeps its own pool.
+            assert async_index._owns_redis_client is True
             await async_index.disconnect()
-            assert async_index.client is not None
-            assert await async_index.client.ping() is True
+            assert async_index.client is None
+            # The caller's own client is unaffected.
+            assert client.ping() is True
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -225,9 +225,15 @@ async def test_search_index_set_client(client, redis_url, index_schema):
             await async_index.set_client(client)
             assert isinstance(async_index.client, AsyncRedis)
 
-            if async_index.client:
-                await async_index.disconnect()
-            assert async_index.client is None
+            # The caller supplied this client, so the index does not own it.
+            # disconnect() must therefore leave it in place and open, exactly
+            # as when a client is passed to __init__. The converted async
+            # wrapper shares the caller's connection pool, so closing it here
+            # would tear down connections the caller still relies on.
+            assert async_index._owns_redis_client is False
+            await async_index.disconnect()
+            assert async_index.client is not None
+            assert await async_index.client.ping() is True
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_index_client_ownership_integration.py
+++ b/tests/integration/test_index_client_ownership_integration.py
@@ -1,0 +1,188 @@
+"""Client ownership semantics against a real Redis.
+
+Verifies with live connections that a client handed to an index via the
+deprecated `set_client()` is never closed by that index, while a client the
+index creates for itself (via the deprecated `connect()`) still is.
+
+See tests/unit/test_index_client_ownership.py for the mocked-client coverage.
+"""
+
+import asyncio
+import gc
+import warnings
+import weakref
+
+import pytest
+
+from redisvl.index import AsyncSearchIndex, SearchIndex
+
+fields = [{"name": "tag", "type": "tag"}, {"name": "num", "type": "numeric"}]
+
+
+def collect():
+    for _ in range(3):
+        gc.collect()
+
+
+@pytest.fixture
+def schema_dict(redis_test_name):
+    name = redis_test_name("ownership")
+    return {
+        "index": {"name": name, "prefix": name, "storage_type": "hash"},
+        "fields": fields,
+    }
+
+
+def pool_sockets_closed(sync_client) -> bool:
+    pool = sync_client.connection_pool
+    conns = list(pool._available_connections) + list(pool._in_use_connections)
+    return all(getattr(conn, "_sock", None) is None for conn in conns)
+
+
+class TestSetClientLeavesCallerClientOpen:
+    def test_sync_caller_client_usable_after_index_collected(
+        self, redis_url, schema_dict, client
+    ):
+        # Index owns a client of its own first, then the caller swaps theirs in.
+        index = SearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        assert index.exists() is False
+        index_own_client = index.client
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            index.set_client(client)
+
+        assert index._owns_redis_client is False
+        # The index's own client was released when it was replaced.
+        assert pool_sockets_closed(index_own_client)
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "index was not collected"
+        assert client.ping() is True, "caller's client was closed by the index"
+
+    def test_sync_disconnect_leaves_caller_client_open(
+        self, redis_url, schema_dict, client
+    ):
+        index = SearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            index.set_client(client)
+
+        index.disconnect()
+
+        assert client.ping() is True, "disconnect() closed the caller's client"
+
+    async def test_async_caller_client_usable_after_index_collected(
+        self, redis_url, schema_dict, async_client
+    ):
+        index = AsyncSearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        assert await index.exists() is False
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            await index.set_client(async_client)
+
+        assert index._owns_redis_client is False
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+        # Give any (incorrectly) scheduled close a chance to run.
+        await asyncio.sleep(0)
+
+        assert ref() is None, "async index was not collected"
+        assert (
+            await async_client.ping() is True
+        ), "caller's async client was closed by the index"
+
+    async def test_async_disconnect_leaves_caller_client_open(
+        self, redis_url, schema_dict, async_client
+    ):
+        index = AsyncSearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            await index.set_client(async_client)
+
+        await index.disconnect()
+
+        assert (
+            await async_client.ping() is True
+        ), "disconnect() closed the caller's async client"
+
+
+class TestConnectStillOwnsItsClient:
+    """The deprecated connect() creates the client, so the index must still
+    close it. This guards against over-correcting the ownership fix."""
+
+    def test_sync_connect_created_client_closed_on_collection(
+        self, redis_url, schema_dict
+    ):
+        index = SearchIndex.from_dict(schema_dict)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            index.connect(redis_url=redis_url)
+
+        assert index._owns_redis_client is True
+        created = index.client
+        assert created is not None
+        assert created.ping() is True
+
+        del index
+        collect()
+
+        assert pool_sockets_closed(
+            created
+        ), "client created by connect() was not closed on collection"
+
+    def test_async_connect_created_client_closed_on_collection(
+        self, redis_url, schema_dict
+    ):
+        aclose_calls = []
+
+        async def build():
+            index = AsyncSearchIndex.from_dict(schema_dict)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                await index.connect(redis_url=redis_url)
+            assert index._owns_redis_client is True
+            created = index.client
+            assert await created.ping() is True
+
+            original = created.aclose
+
+            async def recording_aclose():
+                aclose_calls.append(1)
+                await original()
+
+            created.aclose = recording_aclose
+            return index
+
+        index = asyncio.run(build())
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None
+        assert aclose_calls == [
+            1
+        ], "client created by connect() was not closed exactly once"
+
+
+class TestInjectedClientAtConstruction:
+    """Baseline: __init__ already got this right. Kept so the three entry
+    points (constructor, set_client, connect) are covered together."""
+
+    def test_sync_constructor_injected_client_survives(self, schema_dict, client):
+        from redisvl.schema import IndexSchema
+
+        index = SearchIndex(IndexSchema.from_dict(schema_dict), redis_client=client)
+        assert index._owns_redis_client is False
+        assert index.exists() is False
+
+        del index
+        collect()
+
+        assert client.ping() is True

--- a/tests/integration/test_index_client_ownership_integration.py
+++ b/tests/integration/test_index_client_ownership_integration.py
@@ -113,6 +113,64 @@ class TestSetClientLeavesCallerClientOpen:
         ), "disconnect() closed the caller's async client"
 
 
+class TestConvertedSyncClientIsOwned:
+    """Passing a sync client to an async index does not hand the index the
+    caller's object: `_validate_client` builds a new async client with its own
+    connection pool. That object is RedisVL's, so the index owns it, and closing
+    it must leave the caller's sync client untouched."""
+
+    async def test_converted_wrapper_is_owned_and_closed_without_harming_caller(
+        self, redis_url, schema_dict, client
+    ):
+        index = AsyncSearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        assert await index.exists() is False
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            await index.set_client(client)
+
+        wrapper = index.client
+        assert wrapper is not None
+        # A distinct object with its own pool, not the caller's client.
+        assert wrapper is not client
+        assert wrapper.connection_pool is not client.connection_pool
+        assert index._owns_redis_client is True
+        assert await wrapper.ping() is True
+
+        await index.disconnect()
+
+        assert index.client is None
+        # The caller's client keeps working: closing the wrapper only tore down
+        # the pool RedisVL created.
+        assert client.ping() is True
+
+    async def test_converted_wrapper_closed_when_index_is_collected(
+        self, redis_url, schema_dict, client
+    ):
+        aclose_calls = []
+
+        index = AsyncSearchIndex.from_dict(schema_dict, redis_url=redis_url)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            await index.set_client(client)
+
+        wrapper = index.client
+        original = wrapper.aclose
+
+        async def recording_aclose():
+            aclose_calls.append(1)
+            await original()
+
+        wrapper.aclose = recording_aclose
+
+        del index
+        collect()
+        await asyncio.sleep(0)
+
+        assert aclose_calls == [1], "converted wrapper was not closed on collection"
+        assert client.ping() is True
+
+
 class TestConnectStillOwnsItsClient:
     """The deprecated connect() creates the client, so the index must still
     close it. This guards against over-correcting the ownership fix."""

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -266,6 +266,81 @@ class TestConnectTakesOwnershipFromAnUnownedState:
         caller_client.aclose.assert_not_awaited()
 
 
+class TestConnectReleasesThePreviousOwnedClient:
+    """connect() replaces the active client. When the index owned the old one,
+    it must be closed: registering a finalizer for the new client detaches the
+    old client's finalizer, so nothing else would ever close it."""
+
+    def test_sync_repeated_connect_closes_the_first_client(self):
+        first = mock.MagicMock(name="first_client")
+        second = mock.MagicMock(name="second_client")
+        index = SearchIndex.from_dict(SCHEMA_DICT)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                side_effect=[first, second],
+            ):
+                index.connect(redis_url="redis://fake:6379")
+                index.connect(redis_url="redis://fake:6380")
+
+        first.close.assert_called_once()
+        assert index.client is second
+
+        del index
+        collect()
+        second.close.assert_called_once()
+
+    def test_sync_connect_closes_a_lazily_created_client(self):
+        lazy = mock.MagicMock(name="lazy_client")
+        connected = mock.MagicMock(name="connect_client")
+        index = SearchIndex.from_dict(SCHEMA_DICT, redis_url="redis://fake:6379")
+
+        with mock.patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+            return_value=lazy,
+        ):
+            assert index._redis_client is lazy
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                return_value=connected,
+            ):
+                index.connect(redis_url="redis://fake:6380")
+
+        lazy.close.assert_called_once()
+
+    def test_async_repeated_connect_closes_the_first_client(self):
+        first = mock.MagicMock(name="first_async_client")
+        first.aclose = mock.AsyncMock()
+        second = mock.MagicMock(name="second_async_client")
+        second.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(SCHEMA_DICT)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with mock.patch(
+                    "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                    new=mock.AsyncMock(side_effect=[first, second]),
+                ):
+                    with mock.patch.object(
+                        AsyncSearchIndex,
+                        "_validate_client",
+                        new=mock.AsyncMock(side_effect=lambda c: c),
+                    ):
+                        await index.connect(redis_url="redis://fake:6379")
+                        await index.connect(redis_url="redis://fake:6380")
+            return index
+
+        index = asyncio.run(run())
+        first.aclose.assert_awaited_once()
+        assert index.client is second
+
+
 class TestPreviouslyOwnedClientIsReleased:
     """Swapping in a caller's client must not silently abandon a client the
     index created for itself."""

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -18,6 +18,7 @@ import weakref
 from unittest import mock
 
 from redisvl.index import AsyncSearchIndex, SearchIndex
+from redisvl.schema import IndexSchema
 
 SCHEMA_DICT = {
     "index": {"name": "ownership-probe", "prefix": "own", "storage_type": "hash"},
@@ -179,6 +180,90 @@ class TestIndexCreatedClientIsStillOwned:
         del index
         collect()
         created.aclose.assert_awaited_once()
+
+
+class TestConnectTakesOwnershipFromAnUnownedState:
+    """connect() creates the client itself, so the index must own it even when
+    the index was previously holding a caller-provided (unowned) client. Async
+    gets this right via _swap_client(owns=True); sync must match, otherwise the
+    client it just created is never closed."""
+
+    def test_sync_connect_takes_ownership_over_a_caller_client(self):
+        caller_client = mock.MagicMock(name="caller_client")
+        created = mock.MagicMock(name="connect_created_client")
+        schema = IndexSchema.from_dict(SCHEMA_DICT)
+        index = SearchIndex(schema, redis_client=caller_client)
+        assert index._owns_redis_client is False
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                return_value=created,
+            ):
+                index.connect(redis_url="redis://fake:6379")
+
+        assert (
+            index._owns_redis_client is True
+        ), "connect() created this client, so the index must own it"
+        del index
+        collect()
+        created.close.assert_called_once()
+        caller_client.close.assert_not_called()
+
+    def test_sync_connect_takes_ownership_after_set_client(self):
+        caller_client = mock.MagicMock(name="caller_client")
+        created = mock.MagicMock(name="connect_created_client")
+        index = sync_index_owning_client()
+        set_client_sync(index, caller_client)
+        assert index._owns_redis_client is False
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                return_value=created,
+            ):
+                index.connect(redis_url="redis://fake:6379")
+
+        assert index._owns_redis_client is True
+        del index
+        collect()
+        created.close.assert_called_once()
+        caller_client.close.assert_not_called()
+
+    def test_async_connect_takes_ownership_after_set_client(self):
+        caller_client = mock.MagicMock(name="caller_async_client")
+        caller_client.aclose = mock.AsyncMock()
+        created = mock.MagicMock(name="aconnect_created_client")
+        created.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            await set_client_async(index, caller_client)
+            assert index._owns_redis_client is False
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with mock.patch(
+                    "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                    new=mock.AsyncMock(return_value=created),
+                ):
+                    with mock.patch.object(
+                        AsyncSearchIndex,
+                        "_validate_client",
+                        new=mock.AsyncMock(return_value=created),
+                    ):
+                        await index.connect(redis_url="redis://fake:6379")
+            return index
+
+        index = asyncio.run(run())
+        assert index._owns_redis_client is True
+        del index
+        collect()
+        created.aclose.assert_awaited_once()
+        caller_client.aclose.assert_not_awaited()
 
 
 class TestPreviouslyOwnedClientIsReleased:

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -341,6 +341,71 @@ class TestConnectReleasesThePreviousOwnedClient:
         assert index.client is second
 
 
+class TestSwappingInTheSameClient:
+    """Handing back the client the index already holds must not close it.
+    Releasing the old client unconditionally would close the very instance
+    being installed, leaving the index holding a closed client."""
+
+    def test_sync_set_client_with_the_current_client_does_not_close_it(self):
+        owned = mock.MagicMock(name="owned_client")
+        index = sync_index_owning_client(created_client=owned)
+        assert index.client is owned
+
+        set_client_sync(index, owned)
+
+        owned.close.assert_not_called()
+        assert index.client is owned
+        assert index._owns_redis_client is False
+
+    def test_async_set_client_with_the_current_client_does_not_close_it(self):
+        owned = mock.MagicMock(name="owned_async_client")
+        owned.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                new=mock.AsyncMock(return_value=owned),
+            ):
+                assert await index._get_client() is owned
+            await set_client_async(index, owned)
+            return index
+
+        index = asyncio.run(run())
+        owned.aclose.assert_not_awaited()
+        assert index.client is owned
+        assert index._owns_redis_client is False
+
+
+class TestSwapResetsValidation:
+    """A replacement client has not had this index's lib name applied, so the
+    validated flag must clear or the new client keeps the old one's state."""
+
+    def test_sync_set_client_clears_validated_flag(self):
+        index = SearchIndex.from_dict(
+            SCHEMA_DICT, redis_url="redis://fake:6379", lib_name="probe"
+        )
+        index._validated_client = True
+        set_client_sync(index, mock.MagicMock(name="caller_client"))
+        assert index._validated_client is False
+
+    def test_async_set_client_clears_validated_flag(self):
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379", lib_name="probe"
+            )
+            index._validated_client = True
+            caller = mock.MagicMock(name="caller_async_client")
+            caller.aclose = mock.AsyncMock()
+            await set_client_async(index, caller)
+            return index
+
+        index = asyncio.run(run())
+        assert index._validated_client is False
+
+
 class TestPreviouslyOwnedClientIsReleased:
     """Swapping in a caller's client must not silently abandon a client the
     index created for itself."""

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -406,6 +406,66 @@ class TestSwapResetsValidation:
         assert index._validated_client is False
 
 
+class TestSwapSurvivesAFailingClose:
+    """Closing the outgoing client must not abort the swap. If it did, the
+    replacement would never be installed and nothing would close it, and the
+    index would be left holding a client it had already closed."""
+
+    def test_sync_set_client_completes_when_closing_the_old_client_raises(self):
+        old = mock.MagicMock(name="old_client")
+        old.close.side_effect = RuntimeError  # fresh instance per call
+        index = sync_index_owning_client(created_client=old)
+        caller_client = mock.MagicMock(name="caller_client")
+
+        set_client_sync(index, caller_client)
+
+        assert index.client is caller_client
+        assert index._owns_redis_client is False
+
+    def test_sync_connect_completes_and_owns_when_closing_the_old_client_raises(self):
+        old = mock.MagicMock(name="old_client")
+        old.close.side_effect = RuntimeError  # fresh instance per call
+        created = mock.MagicMock(name="connect_created_client")
+        index = sync_index_owning_client(created_client=old)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                return_value=created,
+            ):
+                index.connect(redis_url="redis://fake:6379")
+
+        assert index.client is created
+        assert index._owns_redis_client is True
+        # The replacement is still tracked, so it is not leaked.
+        del index
+        collect()
+        created.close.assert_called_once()
+
+    def test_async_set_client_completes_when_closing_the_old_client_raises(self):
+        old = mock.MagicMock(name="old_async_client")
+        old.aclose = mock.AsyncMock(side_effect=RuntimeError)
+        caller_client = mock.MagicMock(name="caller_async_client")
+        caller_client.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                new=mock.AsyncMock(return_value=old),
+            ):
+                assert await index._get_client() is old
+            await set_client_async(index, caller_client)
+            return index
+
+        index = asyncio.run(run())
+        assert index.client is caller_client
+        assert index._owns_redis_client is False
+
+
 class TestPreviouslyOwnedClientIsReleased:
     """Swapping in a caller's client must not silently abandon a client the
     index created for itself."""

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -371,6 +371,31 @@ class TestSwappingInTheSameClient:
         owned.close.assert_called_once()
         other.close.assert_not_called()
 
+    def test_sync_connect_returning_the_active_caller_client_does_not_claim_it(self):
+        """`connect()` normally builds a fresh client, so this branch is only
+        reachable when the connection factory hands back an existing client, for
+        example an application that caches one client per URL. Claiming it would
+        make the index close a client it never created."""
+        caller_client = mock.MagicMock(name="caller_client")
+        schema = IndexSchema.from_dict(SCHEMA_DICT)
+        index = SearchIndex(schema, redis_client=caller_client)
+        assert index._owns_redis_client is False
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                return_value=caller_client,
+            ):
+                index.connect(redis_url="redis://fake:6379")
+
+        assert index._owns_redis_client is False
+        assert index.client is caller_client
+
+        del index
+        collect()
+        caller_client.close.assert_not_called()
+
     def test_sync_set_client_with_an_unowned_current_client_stays_unowned(self):
         caller_client = mock.MagicMock(name="caller_client")
         schema = IndexSchema.from_dict(SCHEMA_DICT)

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -355,7 +355,72 @@ class TestSwappingInTheSameClient:
 
         owned.close.assert_not_called()
         assert index.client is owned
+        # Ownership tracks who created the object, so handing the same client
+        # back does not change it. Flipping to unowned here would strand this
+        # client: a later swap would not close it and its finalizer is gone.
+        assert index._owns_redis_client is True
+
+    def test_sync_reinstalled_client_is_still_closed_by_a_later_swap(self):
+        owned = mock.MagicMock(name="owned_client")
+        other = mock.MagicMock(name="other_client")
+        index = sync_index_owning_client(created_client=owned)
+
+        set_client_sync(index, owned)
+        set_client_sync(index, other)
+
+        owned.close.assert_called_once()
+        other.close.assert_not_called()
+
+    def test_sync_set_client_with_an_unowned_current_client_stays_unowned(self):
+        caller_client = mock.MagicMock(name="caller_client")
+        schema = IndexSchema.from_dict(SCHEMA_DICT)
+        index = SearchIndex(schema, redis_client=caller_client)
+
+        set_client_sync(index, caller_client)
+
         assert index._owns_redis_client is False
+        caller_client.close.assert_not_called()
+
+    def test_sync_ownership_is_cleared_before_the_caller_client_is_installed(self):
+        """`disconnect()` does not take the lock, so another thread must never
+        be able to observe a caller-provided client while ownership still says
+        the index owns it: it would close a client it does not own."""
+
+        class RecordingIndex(SearchIndex):
+            def __init__(self, *args, **kwargs):
+                self.attr_writes: list[str] = []
+                super().__init__(*args, **kwargs)
+
+            def __setattr__(self, name, value):
+                if name in ("_SearchIndex__redis_client", "_owns_redis_client"):
+                    self.attr_writes.append(name)
+                super().__setattr__(name, value)
+
+        owned = mock.MagicMock(name="owned_client")
+        index = RecordingIndex(
+            IndexSchema.from_dict(SCHEMA_DICT), redis_url="redis://fake:6379"
+        )
+        with mock.patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+            return_value=owned,
+        ):
+            assert index._redis_client is owned
+
+        index.attr_writes.clear()
+        set_client_sync(index, mock.MagicMock(name="caller_client"))
+
+        last_owns = max(
+            i for i, n in enumerate(index.attr_writes) if n == "_owns_redis_client"
+        )
+        last_client = max(
+            i
+            for i, n in enumerate(index.attr_writes)
+            if n == "_SearchIndex__redis_client"
+        )
+        assert last_owns < last_client, (
+            "ownership must be cleared before the caller's client is installed, "
+            f"got write order {index.attr_writes}"
+        )
 
     def test_async_set_client_with_the_current_client_does_not_close_it(self):
         owned = mock.MagicMock(name="owned_async_client")
@@ -376,7 +441,9 @@ class TestSwappingInTheSameClient:
         index = asyncio.run(run())
         owned.aclose.assert_not_awaited()
         assert index.client is owned
-        assert index._owns_redis_client is False
+        # Same rule as the sync case: reinstalling the active client changes
+        # nothing about who created it, so ownership is left alone.
+        assert index._owns_redis_client is True
 
 
 class TestSwapResetsValidation:

--- a/tests/unit/test_index_client_ownership.py
+++ b/tests/unit/test_index_client_ownership.py
@@ -1,0 +1,217 @@
+"""Ownership semantics for clients handed to an index after construction.
+
+`__init__` already treats a caller-provided client as not owned, and never
+closes it. The deprecated `set_client()` did not follow that rule: an index
+created with `redis_url` keeps `_owns_redis_client=True`, so after
+`set_client(caller_client)` the index would close a client it never created.
+Since 0.25.0 the client finalizer actually fires, which made that observable
+as the caller's client being closed when the index is garbage collected.
+
+The deprecated `connect()` is the mirror case and must keep working: it
+creates the client itself, so the index does own it and must still close it.
+"""
+
+import asyncio
+import gc
+import warnings
+import weakref
+from unittest import mock
+
+from redisvl.index import AsyncSearchIndex, SearchIndex
+
+SCHEMA_DICT = {
+    "index": {"name": "ownership-probe", "prefix": "own", "storage_type": "hash"},
+    "fields": [{"name": "tag", "type": "tag"}],
+}
+
+
+def collect():
+    for _ in range(3):
+        gc.collect()
+
+
+def sync_index_owning_client(created_client=None):
+    """Index built from a URL, so it owns whatever client it creates."""
+    index = SearchIndex.from_dict(SCHEMA_DICT, redis_url="redis://fake:6379")
+    if created_client is not None:
+        with mock.patch(
+            "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+            return_value=created_client,
+        ):
+            assert index._redis_client is created_client
+    return index
+
+
+def set_client_sync(index, client):
+    with mock.patch(
+        "redisvl.index.index.RedisConnectionFactory.validate_sync_redis",
+        return_value=None,
+    ):
+        return index.set_client(client)
+
+
+async def set_client_async(index, client):
+    with mock.patch.object(
+        AsyncSearchIndex, "_validate_client", new=mock.AsyncMock(return_value=client)
+    ):
+        return await index.set_client(client)
+
+
+class TestCallerProvidedClientIsNotOwned:
+    def test_sync_set_client_marks_client_unowned(self):
+        index = sync_index_owning_client()
+        caller_client = mock.MagicMock(name="caller_client")
+        set_client_sync(index, caller_client)
+        assert index._owns_redis_client is False
+
+    def test_sync_set_client_client_survives_gc(self):
+        index = sync_index_owning_client()
+        caller_client = mock.MagicMock(name="caller_client")
+        set_client_sync(index, caller_client)
+
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "index was not collected"
+        caller_client.close.assert_not_called()
+
+    def test_sync_set_client_client_survives_disconnect(self):
+        index = sync_index_owning_client()
+        caller_client = mock.MagicMock(name="caller_client")
+        set_client_sync(index, caller_client)
+
+        index.disconnect()
+
+        caller_client.close.assert_not_called()
+
+    def test_async_set_client_marks_client_unowned(self):
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            caller_client = mock.MagicMock(name="caller_async_client")
+            caller_client.aclose = mock.AsyncMock()
+            await set_client_async(index, caller_client)
+            return index
+
+        index = asyncio.run(run())
+        assert index._owns_redis_client is False
+
+    def test_async_set_client_client_survives_gc(self):
+        caller_client = mock.MagicMock(name="caller_async_client")
+        caller_client.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            await set_client_async(index, caller_client)
+            return index
+
+        index = asyncio.run(run())
+        ref = weakref.ref(index)
+        del index
+        collect()
+
+        assert ref() is None, "index was not collected"
+        caller_client.aclose.assert_not_awaited()
+
+    def test_async_set_client_client_survives_disconnect(self):
+        caller_client = mock.MagicMock(name="caller_async_client")
+        caller_client.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            await set_client_async(index, caller_client)
+            await index.disconnect()
+
+        asyncio.run(run())
+        caller_client.aclose.assert_not_awaited()
+
+
+class TestIndexCreatedClientIsStillOwned:
+    """Regression guard: the deprecated connect() creates its own client, so
+    the index must keep ownership and still close it."""
+
+    def test_sync_connect_keeps_ownership_and_closes_on_gc(self):
+        created = mock.MagicMock(name="connect_created_client")
+        index = SearchIndex.from_dict(SCHEMA_DICT)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+                return_value=created,
+            ):
+                index.connect(redis_url="redis://fake:6379")
+
+        assert index._owns_redis_client is True
+        del index
+        collect()
+        created.close.assert_called_once()
+
+    def test_async_connect_keeps_ownership_and_closes_on_gc(self):
+        created = mock.MagicMock(name="aconnect_created_client")
+        created.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(SCHEMA_DICT)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with mock.patch(
+                    "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                    new=mock.AsyncMock(return_value=created),
+                ):
+                    with mock.patch.object(
+                        AsyncSearchIndex,
+                        "_validate_client",
+                        new=mock.AsyncMock(return_value=created),
+                    ):
+                        await index.connect(redis_url="redis://fake:6379")
+            return index
+
+        index = asyncio.run(run())
+        assert (
+            index._owns_redis_client is True
+        ), "connect() created the client, so the index must still own it"
+        del index
+        collect()
+        created.aclose.assert_awaited_once()
+
+
+class TestPreviouslyOwnedClientIsReleased:
+    """Swapping in a caller's client must not silently abandon a client the
+    index created for itself."""
+
+    def test_sync_set_client_closes_previously_owned_client(self):
+        owned = mock.MagicMock(name="index_owned_client")
+        index = sync_index_owning_client(created_client=owned)
+
+        caller_client = mock.MagicMock(name="caller_client")
+        set_client_sync(index, caller_client)
+
+        owned.close.assert_called_once()
+        caller_client.close.assert_not_called()
+
+    def test_async_set_client_closes_previously_owned_client(self):
+        owned = mock.MagicMock(name="index_owned_async_client")
+        owned.aclose = mock.AsyncMock()
+        caller_client = mock.MagicMock(name="caller_async_client")
+        caller_client.aclose = mock.AsyncMock()
+
+        async def run():
+            index = AsyncSearchIndex.from_dict(
+                SCHEMA_DICT, redis_url="redis://fake:6379"
+            )
+            with mock.patch(
+                "redisvl.index.index.RedisConnectionFactory._get_aredis_connection",
+                new=mock.AsyncMock(return_value=owned),
+            ):
+                assert await index._get_client() is owned
+            await set_client_async(index, caller_client)
+
+        asyncio.run(run())
+        owned.aclose.assert_awaited_once()
+        caller_client.aclose.assert_not_awaited()


### PR DESCRIPTION
Fixes #660

Client ownership fixes for the deprecated `connect()` and `set_client()` paths. Based on `main`, no longer stacked.

## The bug (#660)

`__init__(redis_client=...)` already treats a caller-provided client as not owned and never closes it. The deprecated `set_client()` did not follow that rule: an index created with `redis_url` owns the client it lazily creates, so `_owns_redis_client` stays `True`, and `set_client()` never reset it. The index went on believing it owned a client it had never created.

Latent before 0.25.0 because the finalizer never fired (#657). Now that it works, the index closes the caller's client on garbage collection, and `disconnect()` closes it too. Verified on 0.25.0 before this change, both classes:

```
_owns_redis_client after __init__(redis_url=...):  True
_owns_redis_client after set_client(caller):       True
caller's client closed on GC (sync):               True
caller's client aclosed on GC (async):             True
```

Severity is low: redis-py clients recover from `close()` and `aclose()` by reconnecting, so the effect is unexpected connection churn rather than a broken client, and `set_client()` is deprecated. Confirmed directly, `ping()` returns `True` after both.

The trap was the deprecated async `connect()`, which creates its own client and then delegated to `set_client()`. A plain ownership flip would have left a client the index created with nobody to close it. Both now route through `_swap_client(client, *, owns: bool)`, so `connect()` keeps ownership and `set_client()` gives it up.

Ownership is now consistent across every entry point:

| Entry point | Who created the client | Index owns it |
|---|---|---|
| `__init__(redis_client=...)` | caller | no (unchanged) |
| `__init__(redis_url=...)` then lazy creation | index | yes (unchanged) |
| `connect()` (deprecated) | index | yes (**fixed**, was whatever it was before) |
| `set_client()` (deprecated) | caller | no (**fixed**, was yes) |

## Two related bugs found while fixing it

**Sync `set_client()` abandoned the index's own client.** It overwrote the client, and since 0.25.0 the overwrite also detached that client's finalizer, so nothing closed it. It now releases the previous client first.

**`connect()` leaked the client it replaced.** Same mechanism: registering a finalizer for the new client detaches the old client's, so an owned client being replaced had nothing left to close it. Reachable by calling `connect()` twice, or after a client was lazily created from `redis_url`. Also predates this PR, fixed here since this PR is already reworking ownership in these methods. The async path avoided it by going through `_swap_client()`, which disconnects an owned client first.

## Bot review findings addressed

- **Bugbot:** sync `connect()` never set `_owns_redis_client`, so after `set_client()` cleared ownership, a client `connect()` had just created was never closed. Fixed, with tests, for both classes.
- **Copilot:** `_swap_client()` assigned `_redis_client` under the lock but flipped `_owns_redis_client` outside it. Both fields plus the finalizer registration now happen together inside the lock, and the sync paths do the same under their threading lock. In a single event loop there is no await point between those statements, so the window was effectively nil, but relying on that is fragile to future edits.
- **Copilot:** `set_client()` called `disconnect()` unconditionally, which for a non-owned client only logged that it was not disconnecting. Now guarded; the SQL schema cache is still invalidated explicitly, so nothing is skipped.
- **Copilot:** the `connect()` leak above.

## One existing test changed

`test_search_index_set_client` asserted `.client is None` after `disconnect()`. That was only reachable through the bug: for a client the index does not own, `disconnect()` has always left the client in place rather than closing or clearing it, exactly as it does for constructor-injected clients. It now asserts the corrected semantics, including that the caller's client still answers `PING`. That last part matters here because the test passes a **sync** client, which `_validate_client` converts into an async wrapper sharing the caller's pool; closing that wrapper would tear down connections the caller still needs.

## Testing

Test-driven throughout; every test below was confirmed failing first.

- `tests/unit/test_index_client_ownership.py`, 16 tests: `set_client()` marks the client unowned and never closes it, on GC or via `disconnect()`, both classes; `connect()` keeps ownership and still closes its own client; `connect()` takes ownership back from an unowned state; `connect()` releases the client it replaces, including after lazy creation; previous owned clients are released on swap; indexes stay garbage collectable throughout.
- `tests/integration/test_index_client_ownership_integration.py`, 7 tests against real Redis: a caller's client still answers `PING` after the index is collected and after `disconnect()`, both classes; the index's own client has its pool sockets torn down when replaced; a client created by `connect()` is closed exactly once on collection; plus the constructor-injection baseline.

Full suite: **2005 passed**, 143 skipped, 2 xfailed, no failures. `make format`, mypy, and pre-commit all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection lifecycle and ownership for sync/async index client swaps (including locking and finalizers); impact is limited to deprecated `connect`/`set_client` paths but mistakes could leak connections or close caller-owned clients.
> 
> **Overview**
> Fixes **#660** by aligning Redis client **ownership** across deprecated `connect()` / `set_client()` with constructor injection: caller-supplied clients are never closed on `disconnect()` or GC, while clients the index creates remain owned and are released on swap.
> 
> **Sync `SearchIndex`:** `connect()` and `set_client()` now swap clients under `_lock` via `_release_owned_client_locked()`—closing a previously **owned** client before installing the replacement, setting `_owns_redis_client` appropriately (`True` for `connect()`, `False` for `set_client()`), clearing `_validated_client`, and registering or detaching finalizers. No-op when the same client is reinstalled.
> 
> **Async `AsyncSearchIndex`:** Both paths route through new `_swap_client(client, owns=…)` (`connect()` → `owns=True`, `set_client()` → `owns=False`), replacing the old pattern that called `disconnect()` then assigned the client. Sync clients passed to the async index are converted to a **new** async client that the index owns.
> 
> **Tests:** Added `tests/unit/test_index_client_ownership.py` and `tests/integration/test_index_client_ownership_integration.py`; updated async `set_client` integration expectations (caller sync client still works after disconnect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42fa1a952ad1981f48705a9c0823046c9ac455e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->