### PR TITLE
chore(ci): stop notebook tests wasting 33 minutes on a blocking cell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,19 @@ test-all: ## Run all tests including API tests
 	@echo "🧪 Running all tests including API tests"
 	uv run python -m pytest -n auto --log-level=CRITICAL --run-api-tests $(ARGS)
 
+# nbval defaults to a 2000s per-cell timeout, so a cell that blocks on a network
+# call can silently add half an hour to CI. Cap it: no legitimate cell is slow.
+NBVAL_CELL_TIMEOUT ?= 60
+
 test-notebooks: ## Run notebook tests
 	@echo "📓 Running notebook tests"
 	@echo "🔍 Checking Redis version..."
 	@if uv run python -c "import redis; from redisvl.redis.connection import supports_svs; client = redis.Redis.from_url('redis://localhost:6379'); exit(0 if supports_svs(client) else 1)" 2>/dev/null; then \
 		echo "✅ Redis 8.2.0+ detected - running all notebooks"; \
-		uv run python -m pytest --nbval-lax ./docs/user_guide -vvv $(ARGS); \
+		uv run python -m pytest --nbval-lax --nbval-cell-timeout=$(NBVAL_CELL_TIMEOUT) ./docs/user_guide -vvv $(ARGS); \
 	else \
 		echo "⚠️ Redis < 8.2.0 detected - skipping SVS notebook"; \
-		uv run python -m pytest --nbval-lax ./docs/user_guide -vvv --ignore=./docs/user_guide/09_svs_vamana.ipynb $(ARGS); \
+		uv run python -m pytest --nbval-lax --nbval-cell-timeout=$(NBVAL_CELL_TIMEOUT) ./docs/user_guide -vvv --ignore=./docs/user_guide/09_svs_vamana.ipynb $(ARGS); \
 	fi
 
 check: lint test ## Run all checks (lint + test)

--- a/Makefile
+++ b/Makefile
@@ -62,15 +62,20 @@ test-all: ## Run all tests including API tests
 # call can silently add half an hour to CI. Cap it: no legitimate cell is slow.
 NBVAL_CELL_TIMEOUT ?= 60
 
+# Every cell in this notebook is NBVAL_SKIP -- it needs a hosted LangCache cache
+# ID and API key -- so collecting it only starts a kernel to validate nothing.
+# Drop the ignore if any of its cells ever become runnable in CI.
+NBVAL_IGNORE = --ignore=./docs/user_guide/13_langcache_semantic_cache.ipynb
+
 test-notebooks: ## Run notebook tests
 	@echo "📓 Running notebook tests"
 	@echo "🔍 Checking Redis version..."
 	@if uv run python -c "import redis; from redisvl.redis.connection import supports_svs; client = redis.Redis.from_url('redis://localhost:6379'); exit(0 if supports_svs(client) else 1)" 2>/dev/null; then \
 		echo "✅ Redis 8.2.0+ detected - running all notebooks"; \
-		uv run python -m pytest --nbval-lax --nbval-cell-timeout=$(NBVAL_CELL_TIMEOUT) ./docs/user_guide -vvv $(ARGS); \
+		uv run python -m pytest --nbval-lax --nbval-cell-timeout=$(NBVAL_CELL_TIMEOUT) ./docs/user_guide -vvv $(NBVAL_IGNORE) $(ARGS); \
 	else \
 		echo "⚠️ Redis < 8.2.0 detected - skipping SVS notebook"; \
-		uv run python -m pytest --nbval-lax --nbval-cell-timeout=$(NBVAL_CELL_TIMEOUT) ./docs/user_guide -vvv --ignore=./docs/user_guide/09_svs_vamana.ipynb $(ARGS); \
+		uv run python -m pytest --nbval-lax --nbval-cell-timeout=$(NBVAL_CELL_TIMEOUT) ./docs/user_guide -vvv $(NBVAL_IGNORE) --ignore=./docs/user_guide/09_svs_vamana.ipynb $(ARGS); \
 	fi
 
 check: lint test ## Run all checks (lint + test)

--- a/docs/user_guide/04_vectorizers.ipynb
+++ b/docs/user_guide/04_vectorizers.ipynb
@@ -314,6 +314,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "# NBVAL_SKIP\n",
+        "# No Ollama server in CI, so this only burns time on connection retries.\n",
         "from redisvl.utils.vectorize import OllamaTextVectorizer\n",
         "\n",
         "ollama_model = os.environ.get(\"OLLAMA_MODEL\", \"nomic-embed-text\")\n",
@@ -335,6 +337,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "# NBVAL_SKIP\n",
+        "# Depends on the Ollama cell above, which is not executed in CI.\n",
         "if ollama is not None:\n",
         "    embeddings = ollama.embed_many(sentences, batch_size=2)\n",
         "    print(\"Number of embeddings:\", len(embeddings))\n",
@@ -349,6 +353,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "# NBVAL_SKIP\n",
+        "# Depends on the Ollama cell above, which is not executed in CI.\n",
         "if ollama is not None:\n",
         "    embeddings = await ollama.aembed_many(sentences, batch_size=2)\n",
         "    print(\"Number of async embeddings:\", len(embeddings))\n",
@@ -447,7 +453,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# NBVAL_SKIP  (docs example; not executed in CI so notebook validation makes no API calls)\n",
+        "# NBVAL_SKIP\n",
+        "# Docs example; not executed in CI so notebook validation makes no API calls.\n",
         "from redisvl.utils.vectorize import GoogleGenAIVectorizer\n",
         "\n",
         "# Auto-detects the backend: GEMINI_API_KEY -> Gemini, else GCP project/location -> Vertex AI.\n",

--- a/docs/user_guide/cli.ipynb
+++ b/docs/user_guide/cli.ipynb
@@ -438,25 +438,8 @@
    "execution_count": null
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-16T15:58:10.876537Z",
-     "iopub.status.busy": "2026-02-16T15:58:10.876406Z",
-     "iopub.status.idle": "2026-02-16T15:58:13.099937Z",
-     "shell.execute_reply": "2026-02-16T15:58:13.099303Z"
-    }
-   },
-   "source": [
-    "# NBVAL_SKIP\n",
-    "# Not run in CI. This cell would block until the nbval cell timeout\n",
-    "# connect to rediss://jane_doe:password123@localhost:6379\n",
-    "!rvl index listall --user jane_doe -a password123 --ssl"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-02-16T15:58:13.101500Z",
@@ -465,16 +448,11 @@
      "shell.execute_reply": "2026-02-16T15:58:15.342681Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Index deleted successfully\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
+    "# Not run in CI: there is no TLS-enabled Redis to connect to, so the client\n",
+    "# blocks on the handshake until the nbval cell timeout expires.\n",
     "# connect to rediss://jane_doe:password123@localhost:6379\n",
     "!rvl index listall --user jane_doe -a password123 --ssl"
    ]


### PR DESCRIPTION
## Motivation

The `Run notebooks` CI step takes **~36 minutes**, while the entire unit + integration suite takes ~2. Per-cell timings pulled from the CI logs show that **one cell in `cli.ipynb` accounts for 2000.3s — 93% of the whole notebook suite**. Everything else combined is ~150s.

```
!rvl index listall --user jane_doe -a password123 --ssl
```

It's a docs illustration that opens a TLS handshake against a plaintext Redis with fake credentials. There's no socket timeout, so it blocks until nbval's default `--nbval-cell-timeout` of 2000s — the measured 2000.3s matches exactly.

It never showed up as a failure. `!rvl ...` is a shell magic, so the interrupt at timeout produces no Python traceback, and `--nbval-lax` skips output comparison — the cell reports **PASSED** after burning 33 minutes.

This is a regression. [#594](https://github.com/redis/redis-vl-python/pull/594) already fixed it by adding `# NBVAL_SKIP` to that cell; [#583](https://github.com/redis/redis-vl-python/pull/583) clobbered it in a notebook merge — the guarded version became a *markdown* cell (where the marker is inert, since markdown is never executed) and an unguarded code cell reappeared alongside it.

| Date | `Run notebooks` |
|---|---|
| 2026-05-26 | **2m05s** |
| 2026-06-30 | 35m57s |
| 2026-07-27 | 35m55s |
| 2026-08-06 | 35m58s |

## Changes

- **`cli.ipynb`** — drop the inert markdown duplicate and restore `# NBVAL_SKIP` on the code cell. Also clears the stale `Index deleted successfully` output that cell picked up from the `index destroy` cell during the bad merge.
- **`Makefile`** — pass `--nbval-cell-timeout=60` (overridable via `NBVAL_CELL_TIMEOUT`). This is the guard against silent recurrence: nbval's 2000s default lets any blocking cell hide half an hour behind a green run, and no legitimate cell here needs more than a few seconds.
- **`04_vectorizers.ipynb`** — skip the Ollama block (3 cells). No Ollama server exists in CI, so the first cell spent 22.5s (the largest remaining cell) on connection retries before swallowing the error. Cells 11–12 read the `ollama` name that cell 10 binds, so they're skipped as a unit.
- **`04_vectorizers.ipynb`** — fix the GoogleGenAI cell's marker. nbval requires the comment to equal `NBVAL_SKIP` **exactly**, so `# NBVAL_SKIP  (docs example; not executed in CI so notebook validation makes no API calls)` never registered — that cell has been making live API calls despite the comment saying it doesn't.
- **`Makefile`** — drop `13_langcache_semantic_cache.ipynb` from collection. All 6 of its cells are `NBVAL_SKIP` (it needs a hosted LangCache cache ID and API key), so collecting it only started a kernel to validate nothing. Ignored via a shared `NBVAL_IGNORE` variable, with a note to remove it if any of those cells become runnable.

## Verification

Locally, `make test-notebooks` goes from **216s → 153s** with the same set of results — 318 passed, 13 failed, and skips down from 12 to 6 once the LangCache notebook stops being collected. The 13 failures are pre-existing and unrelated: cells needing Cohere/Mistral/Azure/AWS/GCP keys I don't have locally, which CI has.

Skips confirmed registering: `cli` Cell 11, `04_vectorizers` Cells 10/11/12/14.

## Also worth a look, not changed here

`04_vectorizers.ipynb` and `06_rerankers.ipynb` make live calls to OpenAI, Azure, VertexAI, Cohere, Mistral, VoyageAI, and Bedrock. That's only ~60s of runtime, but it's worth deciding separately whether notebook validation should hit external providers at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation notebook test configuration only; no production library behavior changes.
> 
> **Overview**
> Cuts **~33 minutes** from the notebook CI job by fixing cells that blocked on network calls while still reporting green under `--nbval-lax`.
> 
> **`Makefile`** — `test-notebooks` now passes **`--nbval-cell-timeout=60`** (override via `NBVAL_CELL_TIMEOUT`) instead of nbval’s 2000s default, and **`--ignore`** for `13_langcache_semantic_cache.ipynb` via `NBVAL_IGNORE` so an all-`NBVAL_SKIP` notebook isn’t collected.
> 
> **`cli.ipynb`** — Restores **`# NBVAL_SKIP`** on the TLS `rvl index listall --ssl` demo (regression from a bad merge), removes the duplicate markdown cell, and clears stale outputs.
> 
> **`04_vectorizers.ipynb`** — Adds **`# NBVAL_SKIP`** to the three Ollama cells (no Ollama in CI). Fixes the Google GenAI cell so the skip comment is **`# NBVAL_SKIP` exactly** (extra text on the same line prevented nbval from skipping live API calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd052565504d7db9f9fbdf4076c9ed9ac495e392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->