### PR TITLE
fix: anchor Timestamp date filters to the UTC day

### DIFF
--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -687,6 +687,8 @@ class Timestamp(Num):
     - Unix timestamps (as integers or floats)
 
     All timestamps are converted to Unix timestamps in UTC for consistency.
+    Bare date values and date-only ISO strings are anchored to the UTC calendar
+    day, not the host's local day, and naive datetimes are read as UTC.
     """
 
     SUPPORTED_TYPES = (
@@ -718,8 +720,12 @@ class Timestamp(Num):
         """
         Convert various inputs to a Unix timestamp (seconds since epoch in UTC).
 
+        Naive datetimes are interpreted as UTC rather than local time.
+
         Args:
             value: A datetime, date, string, int, or float
+            end_date: For a bare date, anchor to the end of that UTC day
+                (23:59:59.999999) instead of the start (00:00:00).
 
         Returns:
             float: Unix timestamp
@@ -764,7 +770,8 @@ class Timestamp(Num):
     ) -> FilterExpression:
         """
         Filter for timestamps equal to the specified value.
-        For date objects (without time), this matches the entire day.
+        For date objects (without time), this matches the entire UTC calendar
+        day, from 00:00:00 to 23:59:59.999999 UTC.
 
         Args:
             other: A datetime, date, ISO string, or Unix timestamp
@@ -789,7 +796,8 @@ class Timestamp(Num):
     ) -> FilterExpression:
         """
         Filter for timestamps not equal to the specified value.
-        For date objects (without time), this excludes the entire day.
+        For date objects (without time), this excludes the entire UTC calendar
+        day, from 00:00:00 to 23:59:59.999999 UTC.
 
         Args:
             other: A datetime, date, ISO string, or Unix timestamp

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -773,17 +773,12 @@ class Timestamp(Num):
             self: The filter object for method chaining
         """
         if self._is_date(other):
-            # For date objects, match the entire day
+            # For date objects, match the entire day. Passing the date itself
+            # lets _convert_to_timestamp derive the UTC day bounds.
             if isinstance(other, str):
                 other = datetime.datetime.strptime(other, "%Y-%m-%d").date()
             assert isinstance(other, datetime.date)  # validate for mypy
-            start = datetime.datetime.combine(other, datetime.time.min).astimezone(
-                datetime.timezone.utc
-            )
-            end = datetime.datetime.combine(other, datetime.time.max).astimezone(
-                datetime.timezone.utc
-            )
-            return self.between(start, end)
+            return self.between(other, other)
 
         timestamp = self._convert_to_timestamp(other)
         self._set_value(timestamp, self.SUPPORTED_TYPES, FilterOperator.EQ)
@@ -808,14 +803,8 @@ class Timestamp(Num):
             if isinstance(other, str):
                 other = datetime.datetime.strptime(other, "%Y-%m-%d").date()
             assert isinstance(other, datetime.date)  # validate for mypy
-            start = datetime.datetime.combine(other, datetime.time.min).astimezone(
-                datetime.timezone.utc
-            )
-            end = datetime.datetime.combine(other, datetime.time.max).astimezone(
-                datetime.timezone.utc
-            )
-            start_ts = self._convert_to_timestamp(start)
-            end_ts = self._convert_to_timestamp(end, end_date=True)
+            start_ts = self._convert_to_timestamp(other)
+            end_ts = self._convert_to_timestamp(other, end_date=True)
             return FilterExpression(
                 self.OPERATOR_MAP[FilterOperator.NE] % (self._field, start_ts, end_ts)
             )

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -1,3 +1,4 @@
+import calendar
 import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 
@@ -410,6 +411,10 @@ def test_timestamp_date():
 
     assert str(ts) == f"@created_at:[{expected_ts_start} {expected_ts_end}]"
 
+    # Independent ground truth: 2023-03-17T00:00:00Z / T23:59:59.999999Z.
+    # Hard-coded so this test cannot drift along with the implementation.
+    assert str(ts) == "@created_at:[1679011200.0 1679097599.999999]"
+
 
 def test_timestamp_not_equal_date():
     """Test Timestamp != with date objects (should exclude the full day in UTC)."""
@@ -430,24 +435,45 @@ def test_timestamp_not_equal_date():
 
 
 @pytest.mark.skipif(not hasattr(time_module, "tzset"), reason="tzset() is POSIX-only")
-def test_timestamp_date_bounds_are_utc_regardless_of_local_timezone(monkeypatch):
-    """Date filters resolve to the UTC day, not the host's local day."""
-    d = date(2023, 3, 17)
-    expected_eq = (
-        f"@created_at:"
-        f"[{datetime.combine(d, time.min, tzinfo=timezone.utc).timestamp()} "
-        f"{datetime.combine(d, time.max, tzinfo=timezone.utc).timestamp()}]"
-    )
+@pytest.mark.parametrize(
+    "d",
+    [
+        date(2023, 3, 17),  # ordinary date
+        date(2023, 3, 12),  # US DST spring-forward
+        date(2023, 11, 5),  # US DST fall-back
+        date(1970, 1, 1),  # Unix epoch
+        date(2038, 1, 20),  # past the signed 32-bit rollover
+    ],
+)
+def test_timestamp_date_bounds_are_utc_regardless_of_local_timezone(d, monkeypatch):
+    """Date filters resolve to the UTC day, not the host's local day.
+
+    CI runs in UTC, where the correct and the local-time conversions agree, so
+    this is the only test that would catch a regression to local-day bounds.
+    """
+    # calendar.timegm is a timezone-independent oracle that shares no code with
+    # the conversion path under test.
+    start = float(calendar.timegm(datetime.combine(d, time.min).timetuple()))
+    end = float(calendar.timegm(datetime.combine(d, time.max).timetuple())) + 0.999999
+    expected_eq = f"@created_at:[{start} {end}]"
 
     try:
-        for tz in ("UTC", "America/New_York", "Asia/Tokyo"):
+        # Includes zones with non-hour offsets (+05:45, +12:45/+13:45), which an
+        # hour-granularity mistake would pass.
+        for tz in (
+            "UTC",
+            "America/New_York",
+            "Asia/Tokyo",
+            "Asia/Kathmandu",
+            "Pacific/Chatham",
+        ):
             monkeypatch.setenv("TZ", tz)
             time_module.tzset()
 
             assert str(Timestamp("created_at") == d) == expected_eq
             assert str(Timestamp("created_at") != d) == f"(-{expected_eq})"
             # Date-only ISO strings take the same branch
-            assert str(Timestamp("created_at") == "2023-03-17") == expected_eq
+            assert str(Timestamp("created_at") == d.isoformat()) == expected_eq
     finally:
         # Restore TZ and re-read it, so later tests see the original zone
         monkeypatch.undo()

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -1,3 +1,4 @@
+import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
@@ -400,27 +401,23 @@ def test_timestamp_datetime():
 
 
 def test_timestamp_date():
-    """Test Timestamp filter with date objects (should match full day)."""
+    """Test Timestamp filter with date objects (should match full day in UTC)."""
     d = date(2023, 3, 17)
     ts = Timestamp("created_at") == d
 
-    expected_ts_start = (
-        datetime.combine(d, time.min).astimezone(timezone.utc).timestamp()
-    )
-    expected_ts_end = datetime.combine(d, time.max).astimezone(timezone.utc).timestamp()
+    expected_ts_start = datetime.combine(d, time.min, tzinfo=timezone.utc).timestamp()
+    expected_ts_end = datetime.combine(d, time.max, tzinfo=timezone.utc).timestamp()
 
     assert str(ts) == f"@created_at:[{expected_ts_start} {expected_ts_end}]"
 
 
 def test_timestamp_not_equal_date():
-    """Test Timestamp != with date objects (should exclude the full day)."""
+    """Test Timestamp != with date objects (should exclude the full day in UTC)."""
     d = date(2023, 3, 17)
     ts = Timestamp("created_at") != d
 
-    expected_ts_start = (
-        datetime.combine(d, time.min).astimezone(timezone.utc).timestamp()
-    )
-    expected_ts_end = datetime.combine(d, time.max).astimezone(timezone.utc).timestamp()
+    expected_ts_start = datetime.combine(d, time.min, tzinfo=timezone.utc).timestamp()
+    expected_ts_end = datetime.combine(d, time.max, tzinfo=timezone.utc).timestamp()
 
     assert str(ts) == f"(-@created_at:[{expected_ts_start} {expected_ts_end}])"
 
@@ -432,15 +429,38 @@ def test_timestamp_not_equal_date():
     assert str(Timestamp("created_at") != "2023-03-17") == str(ts)
 
 
+@pytest.mark.skipif(not hasattr(time_module, "tzset"), reason="tzset() is POSIX-only")
+def test_timestamp_date_bounds_are_utc_regardless_of_local_timezone(monkeypatch):
+    """Date filters resolve to the UTC day, not the host's local day."""
+    d = date(2023, 3, 17)
+    expected_eq = (
+        f"@created_at:"
+        f"[{datetime.combine(d, time.min, tzinfo=timezone.utc).timestamp()} "
+        f"{datetime.combine(d, time.max, tzinfo=timezone.utc).timestamp()}]"
+    )
+
+    try:
+        for tz in ("UTC", "America/New_York", "Asia/Tokyo"):
+            monkeypatch.setenv("TZ", tz)
+            time_module.tzset()
+
+            assert str(Timestamp("created_at") == d) == expected_eq
+            assert str(Timestamp("created_at") != d) == f"(-{expected_eq})"
+            # Date-only ISO strings take the same branch
+            assert str(Timestamp("created_at") == "2023-03-17") == expected_eq
+    finally:
+        # Restore TZ and re-read it, so later tests see the original zone
+        monkeypatch.undo()
+        time_module.tzset()
+
+
 def test_timestamp_iso_string():
     """Test Timestamp filter with ISO format strings."""
     # Date-only ISO string
     ts = Timestamp("created_at") == "2023-03-17"
     d = date(2023, 3, 17)
-    expected_ts_start = (
-        datetime.combine(d, time.min).astimezone(timezone.utc).timestamp()
-    )
-    expected_ts_end = datetime.combine(d, time.max).astimezone(timezone.utc).timestamp()
+    expected_ts_start = datetime.combine(d, time.min, tzinfo=timezone.utc).timestamp()
+    expected_ts_end = datetime.combine(d, time.max, tzinfo=timezone.utc).timestamp()
     assert str(ts) == f"@created_at:[{expected_ts_start} {expected_ts_end}]"
 
     # Full ISO datetime string


### PR DESCRIPTION
## What this fixes

`Timestamp`'s class docstring states that "All timestamps are converted to Unix timestamps in UTC for consistency." That holds for datetimes, ISO strings, and Unix timestamps — but not for bare `date` objects (or date-only ISO strings). Those were anchored to the **host's local timezone**, so the same query produced different day boundaries depending on where it ran:

```python
d = date(2023, 3, 17)
Timestamp("f") == d                              # TZ-dependent
Timestamp("f") == datetime(2023, 3, 17, 0, 0)    # always UTC
```

| `TZ` | `== date(2023,3,17)` starts at | naive `datetime` / `between()` starts at |
| --- | --- | --- |
| `UTC` | `1679011200.0` | `1679011200.0` |
| `America/New_York` | `1679025600.0` (+4h) | `1679011200.0` |
| `Asia/Tokyo` | `1678978800.0` (−9h) | `1679011200.0` |

A `date` and its equivalent naive `datetime` resolved to different instants unless the machine ran on UTC.

## Root cause

Two code paths converted naive datetimes with opposite conventions.

`_convert_to_timestamp` treats a naive datetime as **already UTC** (`filter.py:751-756`):

```python
if value.tzinfo is None:
    value = value.replace(tzinfo=datetime.timezone.utc)
```

The `__eq__`/`__ne__` date branches instead called `.astimezone(utc)` on a naive datetime, which Python interprets as **local time** before converting:

```python
start = datetime.datetime.combine(other, datetime.time.min).astimezone(
    datetime.timezone.utc
)
```

## The fix

`_convert_to_timestamp` already derives day bounds from a bare `date` — that's what the `end_date` flag is for, combining with `time.min`/`time.max` — and `between()` already calls it correctly for both bounds. So the manual combine was duplicated logic with divergent semantics, and the fix is to delete it and pass the date straight through:

```python
if self._is_date(other):
    if isinstance(other, str):
        other = datetime.datetime.strptime(other, "%Y-%m-%d").date()
    assert isinstance(other, datetime.date)
    return self.between(other, other)
```

Net −13 lines in `filter.py`.

One subtlety worth flagging for review: the `strptime` normalization has to stay. `_convert_to_timestamp` parses `"2023-03-17"` with `fromisoformat`, which returns a *datetime*, not a `date` — so the `end_date` branch would never fire and the upper bound would collapse to midnight. Normalizing to a `date` first keeps date-only strings on the same path as `date` objects.

`==` and `!=` remain exact negations of each other, preserving the invariant established in #655.

## Verification

Timezone-stable where it previously was not:

| `TZ` | before | after |
| --- | --- | --- |
| `UTC` | `[1679011200.0 1679097599.999999]` | `[1679011200.0 1679097599.999999]` |
| `America/New_York` | `[1679025600.0 1679111999.999999]` | `[1679011200.0 1679097599.999999]` |
| `Asia/Tokyo` | `[1678978800.0 1679065199.999999]` | `[1679011200.0 1679097599.999999]` |

## Tests

Three existing tests (`test_timestamp_date`, `test_timestamp_not_equal_date`, `test_timestamp_iso_string`) computed their expected values with the same `.astimezone(utc)` idiom as the implementation, so they mirrored the bug and passed regardless. They now specify the intended UTC semantics directly, and `test_timestamp_date` additionally asserts a hard-coded epoch literal (`1679011200.0` / `1679097599.999999`) as ground truth independent of any formula.

Added `test_timestamp_date_bounds_are_utc_regardless_of_local_timezone`. This is the test that actually pins the fix — CI sets no `TZ` and GitHub runners default to UTC, where the correct and the buggy conversions agree, so nothing else in the suite would catch a regression to local-day bounds. It parametrizes over five dates (an ordinary date, both US DST transitions, the Unix epoch, and a post-2038 date) and asserts identical output under `UTC`, `America/New_York`, `Asia/Tokyo`, `Asia/Kathmandu` (+05:45), and `Pacific/Chatham` (+12:45/+13:45) — the non-hour offsets would catch an hour-granularity mistake that whole-hour zones alone would not. Expected values come from `calendar.timegm`, an oracle that shares no code with the conversion path under test. It restores `TZ` and calls `tzset()` in a `finally` block so a mid-loop failure cannot leak a changed zone into later tests, and is skipped where `tzset()` is unavailable.

All of these fail on `main` and pass here.

`tests/unit/test_filter.py`: 68/68 pass. Full `tests/unit` (excluding `test_mcp`): 991 passed, 1 skipped, with 2 failures and 28 errors identical on unmodified `main` in my environment (missing optional `pydantic_settings` / `google-genai` deps). `black`, `isort`, `mypy`, and `codespell` clean via `pre-commit`.

## Documentation

The `__eq__`/`__ne__` docstrings previously said date inputs match "the entire day" — the same ambiguity that let this bug exist. They now name the UTC calendar day explicitly, as does the class docstring. `_convert_to_timestamp` now documents its `end_date` parameter, which the fix relies on to derive the upper bound, and records that naive datetimes are read as UTC.

Note that `Timestamp` is not autodocumented in `docs/api/filter.rst` (only `FilterExpression`, `Tag`, `Text`, `Num`, `Geo`, `GeoRadius` are), so these docstrings currently reach IDE and source readers but not the published API docs. That gap predates this PR and is worth a separate follow-up.

## Behavior change

This changes results for non-UTC clients using `date` filters — the window moves by the host's offset. Output is unchanged for clients already on UTC. Worth a release-note callout; anyone depending on local-day semantics can pass explicit tz-aware `datetime` bounds to `between()`.

No docs or integration tests exercise the `date` path (all use `datetime`), so nothing else needed updating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query semantics for date-based `Timestamp` filters on non-UTC hosts (intentional fix), which can alter production search results until callers adapt or use explicit tz-aware `between()` bounds.
> 
> **Overview**
> **Fixes inconsistent day boundaries** when filtering on bare `date` values or date-only ISO strings (`YYYY-MM-DD`). Those paths previously built bounds with naive `datetime.combine` + `.astimezone(UTC)`, which Python treats as **local** time, while other `Timestamp` inputs already convert as **UTC**.
> 
> `==` / `!=` on dates now delegate to the same logic as `between()`—passing the `date` through `_convert_to_timestamp` (with `end_date` for the upper bound on `!=`) so the window is always **00:00:00–23:59:59.999999 UTC** for that calendar day. Docstrings now state UTC-day semantics explicitly.
> 
> Tests were updated to expect UTC bounds (including fixed epoch literals) and a new POSIX-only test varies `TZ` across several zones to ensure output does not depend on the host timezone.
> 
> **Behavior change:** clients not on UTC will see different query ranges for date filters; UTC hosts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2608402914bd248dbb55a24d14ac472fd95287d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->