### PR TITLE
fix(mcp): escape text filter values and reject an empty projection

### DIFF
--- a/redisvl/mcp/config.py
+++ b/redisvl/mcp/config.py
@@ -472,10 +472,22 @@ class MCPIndexBindingConfig(BaseModel):
         """Ensure runtime mappings point at explicit fields in the effective schema."""
         field_names = set(schema.field_names)
 
-        if self.uses_text_search and self.runtime.text_field_name not in field_names:
-            raise ValueError(
-                f"runtime.text_field_name '{self.runtime.text_field_name}' not found in schema"
-            )
+        if self.uses_text_search:
+            if self.runtime.text_field_name not in field_names:
+                raise ValueError(
+                    f"runtime.text_field_name '{self.runtime.text_field_name}' not found in schema"
+                )
+            # Membership alone is not enough: a vector field cannot be searched as
+            # text, and pointing at one leaves the default projection empty (it is
+            # every *non-vector* field). An empty projection reaches Redis as no
+            # RETURN clause at all, which returns every stored field -- including
+            # the embedding this tool refuses to return when asked for by name.
+            text_field = schema.fields.get(self.runtime.text_field_name)
+            if text_field is not None and text_field.type == "vector":
+                raise ValueError(
+                    f"runtime.text_field_name '{self.runtime.text_field_name}' is a "
+                    "vector field; text search requires a text or tag field"
+                )
 
         if (
             self.supports_server_side_embedding

--- a/redisvl/mcp/filters.py
+++ b/redisvl/mcp/filters.py
@@ -3,6 +3,15 @@ from typing import Any, Iterable
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.query.filter import FilterExpression, Num, Tag, Text
 from redisvl.schema import IndexSchema
+from redisvl.utils.token_escaper import TokenEscaper
+
+# Text values reach the query string unescaped: `Text`'s operator templates are
+# `@field:("value")` for eq/ne and `@field:(value)` for like, so a caller value
+# containing a quote or a paren can close its own clause and inject arbitrary
+# RediSearch syntax after it -- including a `|` that escapes an enclosing AND.
+# Tag and numeric values are already escaped or type-checked upstream; text is
+# not, so this boundary escapes it before building the expression.
+_TEXT_ESCAPER = TokenEscaper()
 
 
 def parse_filter(
@@ -132,17 +141,28 @@ def _parse_tag_expression(field_name: str, op: str, operand: Any) -> FilterExpre
     )
 
 
+def _escape_text(value: str, *, preserve_wildcards: bool = False) -> str:
+    """Escape a caller-supplied text value so it cannot leave its own clause."""
+    return _TEXT_ESCAPER.escape(value, preserve_wildcards=preserve_wildcards)
+
+
 def _parse_text_expression(field_name: str, op: str, operand: Any) -> FilterExpression:
     field = Text(field_name)
     if op == "eq":
-        return field == _require_string(operand, field_name, op)
+        return field == _escape_text(_require_string(operand, field_name, op))
     if op == "ne":
-        return field != _require_string(operand, field_name, op)
+        return field != _escape_text(_require_string(operand, field_name, op))
     if op == "like":
-        return field % _require_string(operand, field_name, op)
+        # `like` is the pattern-matching operator, so `*` and `?` stay live.
+        return field % _escape_text(
+            _require_string(operand, field_name, op), preserve_wildcards=True
+        )
     if op == "in":
         return _combine_or(
-            [field == item for item in _require_string_list(operand, field_name, op)]
+            [
+                field == _escape_text(item)
+                for item in _require_string_list(operand, field_name, op)
+            ]
         )
     raise RedisVLMCPError(
         f"Unsupported operator '{op}' for text field '{field_name}'",

--- a/redisvl/mcp/filters.py
+++ b/redisvl/mcp/filters.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Iterable
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
@@ -12,6 +13,20 @@ from redisvl.utils.token_escaper import TokenEscaper
 # Tag and numeric values are already escaped or type-checked upstream; text is
 # not, so this boundary escapes it before building the expression.
 _TEXT_ESCAPER = TokenEscaper()
+
+# `like` is the pattern operator, so the metacharacters that give a pattern its
+# meaning have to stay live: `*` and `?` for wildcards, `%` for fuzzy matching,
+# and a space for the implicit AND between terms. Escaping those does not fail
+# loudly -- it silently turns a documented pattern into a literal that matches
+# nothing -- so this set is the shared no-wildcard set minus `%` and space.
+#
+# Dropping them costs nothing in containment, because containment comes from the
+# delimiters rather than from these. With `(` and `)` escaped, the value cannot
+# close its own `@field:(...)`, so anything it carries -- including a `|`, which
+# no escaper in RedisVL touches -- stays scoped to this one field instead of
+# reaching the surrounding expression.
+_LIKE_ESCAPED_CHARS = re.compile(r"[,.<>{}\[\]\\\"\':;!@#$^&()\-+=~\/]")
+_LIKE_ESCAPER = TokenEscaper(escape_chars_re=_LIKE_ESCAPED_CHARS)
 
 
 def parse_filter(
@@ -141,9 +156,14 @@ def _parse_tag_expression(field_name: str, op: str, operand: Any) -> FilterExpre
     )
 
 
-def _escape_text(value: str, *, preserve_wildcards: bool = False) -> str:
+def _escape_text(value: str) -> str:
     """Escape a caller-supplied text value so it cannot leave its own clause."""
-    return _TEXT_ESCAPER.escape(value, preserve_wildcards=preserve_wildcards)
+    return _TEXT_ESCAPER.escape(value)
+
+
+def _escape_like_pattern(value: str) -> str:
+    """Escape a `like` pattern, leaving its pattern metacharacters intact."""
+    return _LIKE_ESCAPER.escape(value)
 
 
 def _parse_text_expression(field_name: str, op: str, operand: Any) -> FilterExpression:
@@ -153,10 +173,9 @@ def _parse_text_expression(field_name: str, op: str, operand: Any) -> FilterExpr
     if op == "ne":
         return field != _escape_text(_require_string(operand, field_name, op))
     if op == "like":
-        # `like` is the pattern-matching operator, so `*` and `?` stay live.
-        return field % _escape_text(
-            _require_string(operand, field_name, op), preserve_wildcards=True
-        )
+        # An exact-match value is a literal, but a `like` value is a pattern, so
+        # the two need different escaping -- see `_LIKE_ESCAPED_CHARS`.
+        return field % _escape_like_pattern(_require_string(operand, field_name, op))
     if op == "in":
         return _combine_or(
             [

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -153,6 +153,17 @@ def _validate_request(
                 code=MCPErrorCode.INVALID_REQUEST,
                 retryable=False,
             )
+        if not return_fields:
+            # An empty projection reaches Redis as no RETURN clause at all, which
+            # returns *every* field -- including the vector this function refuses
+            # a few lines down. "Omit the argument" is the way to ask for the
+            # default projection.
+            raise RedisVLMCPError(
+                "return_fields must not be empty; omit it to use the default "
+                "projection",
+                code=MCPErrorCode.INVALID_REQUEST,
+                retryable=False,
+            )
         fields = []
         for field_name in return_fields:
             if not isinstance(field_name, str) or not field_name:

--- a/tests/unit/test_mcp/conftest.py
+++ b/tests/unit/test_mcp/conftest.py
@@ -1,8 +1,43 @@
 import pytest
 
+from redisvl.schema import IndexSchema
+
 
 @pytest.fixture(scope="session", autouse=True)
 def redis_container():
     # Shadow the repo-wide autouse Redis container fixture so MCP unit tests stay
     # pure-unit and do not require Docker; Redis coverage lives in integration tests.
     yield None
+
+
+def _schema() -> IndexSchema:
+    """The one index shape the filter, search, and profile unit tests all build against.
+
+    A plain function rather than a fixture: it is a stateless data builder that
+    module-level parametrization and helper functions both need to call, and the
+    convention in these files is per-module fakes rather than shared fixtures.
+    """
+    return IndexSchema.from_dict(
+        {
+            "index": {
+                "name": "docs-index",
+                "prefix": "doc",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {"name": "content", "type": "text"},
+                {"name": "category", "type": "tag"},
+                {"name": "rating", "type": "numeric"},
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "attrs": {
+                        "algorithm": "flat",
+                        "dims": 3,
+                        "distance_metric": "cosine",
+                        "datatype": "float32",
+                    },
+                },
+            ],
+        }
+    )

--- a/tests/unit/test_mcp/test_config.py
+++ b/tests/unit/test_mcp/test_config.py
@@ -525,3 +525,36 @@ def test_mcp_config_allows_linear_hybrid_fallback_params():
         schema=schema,
         supports_native_hybrid_search=False,
     )
+
+
+@pytest.mark.parametrize("search_type", ["fulltext", "hybrid"])
+def test_mcp_config_rejects_a_text_field_that_is_actually_the_vector_field(search_type):
+    """Membership in the schema is not enough -- the field must be text-searchable.
+
+    Pointing `text_field_name` at the vector field passes a name-only check while
+    leaving the default projection (every *non-vector* field) empty. An empty
+    projection reaches Redis as no RETURN clause, which returns every stored
+    field including the embedding, so this has to fail at startup.
+    """
+    config = _valid_config()
+    config["indexes"]["knowledge"]["search"] = {"type": search_type}
+    config["indexes"]["knowledge"]["runtime"]["text_field_name"] = "embedding"
+
+    binding = MCPConfig.model_validate(config).indexes["knowledge"]
+
+    # `to_index_schema` validates the runtime mapping against the effective
+    # schema, so startup fails here rather than at the first request.
+    with pytest.raises(ValueError, match="is a vector field"):
+        binding.to_index_schema(_inspected_schema())
+
+
+def test_mcp_config_still_accepts_a_real_text_field():
+    """The control: a genuine text field must keep validating."""
+    config = _valid_config()
+    config["indexes"]["knowledge"]["search"] = {"type": "fulltext"}
+    config["indexes"]["knowledge"]["runtime"]["text_field_name"] = "content"
+
+    binding = MCPConfig.model_validate(config).indexes["knowledge"]
+    schema = binding.to_index_schema(_inspected_schema())
+
+    binding.validate_runtime_mapping(schema)

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -1,42 +1,27 @@
 import pytest
+from conftest import _schema
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.filters import parse_filter
 from redisvl.query.filter import FilterExpression
-from redisvl.schema import IndexSchema
-
-
-def _schema() -> IndexSchema:
-    return IndexSchema.from_dict(
-        {
-            "index": {
-                "name": "docs-index",
-                "prefix": "doc",
-                "storage_type": "hash",
-            },
-            "fields": [
-                {"name": "content", "type": "text"},
-                {"name": "category", "type": "tag"},
-                {"name": "rating", "type": "numeric"},
-                {
-                    "name": "embedding",
-                    "type": "vector",
-                    "attrs": {
-                        "algorithm": "flat",
-                        "dims": 3,
-                        "distance_metric": "cosine",
-                        "datatype": "float32",
-                    },
-                },
-            ],
-        }
-    )
 
 
 def _render_filter(value):
     if isinstance(value, FilterExpression):
         return str(value)
     return value
+
+
+def _strip_escapes(rendered: str) -> str:
+    """Drop backslash-escaped pairs, leaving only unescaped query syntax."""
+    out, index = [], 0
+    while index < len(rendered):
+        if rendered[index] == "\\":
+            index += 2
+            continue
+        out.append(rendered[index])
+        index += 1
+    return "".join(out)
 
 
 def test_parse_filter_passes_through_raw_string():
@@ -134,3 +119,39 @@ def test_parse_filter_rejects_malformed_payload():
         parse_filter({"field": "category", "value": "science"}, _schema())
 
     assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+
+
+@pytest.mark.parametrize(
+    ("op", "operand"),
+    [
+        ("eq", 'alpha") | (-@category:{secret}'),
+        ("ne", 'alpha") | (-@category:{secret}'),
+        ("like", "alpha) | (-@category:{secret}"),
+        ("in", ['alpha") | (-@category:{secret}']),
+    ],
+)
+def test_parse_filter_escapes_text_values_so_they_cannot_leave_their_clause(
+    op, operand
+):
+    parsed = parse_filter({"field": "content", "op": op, "value": operand}, _schema())
+
+    # Text operator templates interpolate the value into `@field:("...")` or
+    # `@field:(...)`, so an unescaped quote or paren would close the clause and
+    # let the rest of the value inject query syntax -- including a `|` that
+    # escapes an enclosing AND. Stripping escape pairs leaves the structural
+    # skeleton: the payload must contribute no syntax to it.
+    skeleton = _strip_escapes(_render_filter(parsed))
+    # The clause boundary survives: quotes and parens from the payload are
+    # escaped, so its `|` stays scoped inside this field's own query instead of
+    # splitting the whole expression into a union.
+    assert skeleton.count("(") == skeleton.count(")")
+    assert skeleton.count('"') % 2 == 0
+
+
+def test_parse_filter_preserves_wildcards_in_text_like_patterns():
+    parsed = parse_filter(
+        {"field": "content", "op": "like", "value": "quant*"}, _schema()
+    )
+
+    # `like` is the pattern operator, so escaping must not neuter `*`.
+    assert _render_filter(parsed) == "@content:(quant*)"

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -3,7 +3,7 @@ from conftest import _schema
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.filters import parse_filter
-from redisvl.query.filter import FilterExpression
+from redisvl.query.filter import FilterExpression, Text
 
 
 def _render_filter(value):
@@ -148,10 +148,56 @@ def test_parse_filter_escapes_text_values_so_they_cannot_leave_their_clause(
     assert skeleton.count('"') % 2 == 0
 
 
-def test_parse_filter_preserves_wildcards_in_text_like_patterns():
-    parsed = parse_filter(
-        {"field": "content", "op": "like", "value": "quant*"}, _schema()
-    )
+@pytest.mark.parametrize(
+    ("value", "rendered"),
+    [
+        # Each metacharacter that gives a `like` pattern its meaning. Escaping any
+        # of these does not fail loudly -- it turns the pattern into a literal that
+        # matches nothing -- so each is pinned separately.
+        ("quant*", "@content:(quant*)"),
+        ("qu?nt", "@content:(qu?nt)"),
+        # A space is the implicit AND between terms, not padding.
+        ("foo bar", "@content:(foo bar)"),
+        # `%` is fuzzy matching.
+        ("%foo%", "@content:(%foo%)"),
+    ],
+)
+def test_parse_filter_preserves_like_pattern_metacharacters(value, rendered):
+    parsed = parse_filter({"field": "content", "op": "like", "value": value}, _schema())
 
-    # `like` is the pattern operator, so escaping must not neuter `*`.
-    assert _render_filter(parsed) == "@content:(quant*)"
+    assert _render_filter(parsed) == rendered
+
+
+def test_parse_filter_like_matches_library_semantics_for_patterns():
+    """MCP `like` must not diverge from `Text.__mod__` for ordinary patterns."""
+    for value in ["quant*", "foo bar", "%foo%", "qu?nt"]:
+        mcp = _render_filter(
+            parse_filter({"field": "content", "op": "like", "value": value}, _schema())
+        )
+        assert mcp == str(Text("content") % value), f"diverged for {value!r}"
+
+
+def test_parse_filter_like_still_escapes_clause_delimiters():
+    """Preserving pattern metacharacters must not cost containment.
+
+    Containment comes from the delimiters, not from `%`/space: with `(` and `)`
+    escaped the value cannot close its own `@field:(...)`, so a `|` it carries
+    stays scoped to this field. `|` is deliberately checked because no escaper in
+    RedisVL touches it.
+    """
+    parsed = parse_filter(
+        {"field": "content", "op": "like", "value": "alpha) | (-@category:{secret}"},
+        _schema(),
+    )
+    rendered = _render_filter(parsed)
+
+    # The payload's own parens are escaped...
+    assert "\\)" in rendered and "\\(" in rendered
+    # ...so stripping escape pairs leaves a balanced skeleton: nothing the payload
+    # contributed can terminate the clause early.
+    skeleton = _strip_escapes(rendered)
+    assert skeleton.count("(") == skeleton.count(")")
+    # The `|` survives unescaped but is inside the field clause, so it unions
+    # within `content` rather than splitting the whole expression.
+    assert skeleton.index("|") > skeleton.index("(")
+    assert skeleton.index("|") < skeleton.rindex(")")

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -11,9 +11,11 @@ from redisvl.mcp.tools.search import (
     _build_fallback_hybrid_kwargs,
     _build_search_tool_description,
     _embed_query,
+    _validate_request,
     register_search_tool,
     search_records,
 )
+from redisvl.query import VectorQuery
 from redisvl.schema import IndexSchema
 
 
@@ -884,3 +886,65 @@ async def test_default_projection_always_produces_a_return_clause(
     # Non-empty is what makes RedisVL emit RETURN; empty would silently widen the
     # response to every field.
     assert built[0]["return_fields"], "empty projection would omit RETURN entirely"
+
+
+def test_empty_default_projection_still_yields_a_return_clause():
+    """The one case where a falsy `return_fields` legitimately reaches a query.
+
+    `None` and `[]` are kept distinct at the request boundary -- the branch is
+    `is None`, so an explicit `[]` is rejected rather than read as "omitted". But
+    the *default* projection is every non-vector field, so an index with only a
+    vector field resolves it to `[]`, and RedisVL reads a falsy `return_fields`
+    as "no projection" and omits RETURN.
+
+    That is safe here only because `VectorQuery` adds `vector_distance` to its own
+    return fields, so a RETURN clause is emitted anyway. This pins that
+    dependency: if it ever stops holding, an index like this would start
+    returning every stored field, embedding included. Fulltext and hybrid cannot
+    reach this state at all, because `text_field_name` is required to be a
+    non-vector field and therefore always lands in the projection.
+    """
+    vector_only = IndexSchema.from_dict(
+        {
+            "index": {"name": "vec-only", "prefix": "v", "storage_type": "hash"},
+            "fields": [
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "attrs": {
+                        "algorithm": "flat",
+                        "dims": 3,
+                        "distance_metric": "cosine",
+                        "datatype": "float32",
+                    },
+                }
+            ],
+        }
+    )
+    runtime = SimpleNamespace(default_limit=2, max_limit=5, max_result_window=100)
+
+    _, fields = _validate_request(
+        query="science",
+        limit=None,
+        offset=0,
+        return_fields=None,
+        runtime=runtime,
+        schema=vector_only,
+    )
+
+    # The default projection really is empty here, so this is not passing for
+    # some other reason.
+    assert fields == []
+
+    rendered = str(
+        VectorQuery(
+            vector=[0.1, 0.2, 0.3],
+            vector_field_name="embedding",
+            return_fields=fields,
+            num_results=2,
+        )
+    )
+
+    assert "RETURN" in rendered
+    # And what it returns is the score, not the embedding.
+    assert "embedding" not in rendered.split("RETURN", 1)[1]

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -850,3 +850,37 @@ def test_build_search_tool_description_distinguishes_typed_and_exists_support():
         in description
     )
     assert "Allowed return_fields: content, category, rating, location." in description
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("search_type", ["vector", "fulltext"])
+async def test_default_projection_always_produces_a_return_clause(
+    monkeypatch, search_type
+):
+    """A query with no RETURN clause returns every stored field, vector included.
+
+    The default projection is every *non-vector* field, so on an index with no
+    other fields it is empty -- and an empty `return_fields` is falsy, which makes
+    RedisVL omit RETURN entirely. `VectorQuery` self-adds `vector_distance` so it
+    is safe; `TextQuery` does not, which is why config validation refuses to point
+    `text_field_name` at a vector field. This pins the resulting invariant: no
+    search path may build a query without a RETURN clause.
+    """
+    server = FakeServer(search_type=search_type)
+    built = []
+
+    monkeypatch.setattr(
+        "redisvl.mcp.tools.search.VectorQuery",
+        lambda **kw: built.append(kw) or FakeQuery(**kw),
+    )
+    monkeypatch.setattr(
+        "redisvl.mcp.tools.search.TextQuery",
+        lambda **kw: built.append(kw) or FakeQuery(**kw),
+    )
+
+    await search_records(server, query="science")
+
+    assert built, "no query was built"
+    # Non-empty is what makes RedisVL emit RETURN; empty would silently widen the
+    # response to every field.
+    assert built[0]["return_fields"], "empty projection would omit RETURN entirely"

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from conftest import _schema
 
 from redisvl.mcp.config import MCPConfig
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
@@ -14,33 +15,6 @@ from redisvl.mcp.tools.search import (
     search_records,
 )
 from redisvl.schema import IndexSchema
-
-
-def _schema() -> IndexSchema:
-    return IndexSchema.from_dict(
-        {
-            "index": {
-                "name": "docs-index",
-                "prefix": "doc",
-                "storage_type": "hash",
-            },
-            "fields": [
-                {"name": "content", "type": "text"},
-                {"name": "category", "type": "tag"},
-                {"name": "rating", "type": "numeric"},
-                {
-                    "name": "embedding",
-                    "type": "vector",
-                    "attrs": {
-                        "algorithm": "flat",
-                        "dims": 3,
-                        "distance_metric": "cosine",
-                        "datatype": "float32",
-                    },
-                },
-            ],
-        }
-    )
 
 
 def _config_with_search(
@@ -242,6 +216,20 @@ async def test_search_records_rejects_unknown_or_vector_return_fields():
 
     assert unknown_exc.value.code == MCPErrorCode.INVALID_REQUEST
     assert vector_exc.value.code == MCPErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_search_records_rejects_an_empty_return_fields_list():
+    server = FakeServer()
+
+    # An empty list is not "no projection" -- it reaches Redis as an absent
+    # RETURN clause, which widens the response to every field including the
+    # vector. Rejecting it keeps `[]` from quietly meaning the opposite of what
+    # it reads like.
+    with pytest.raises(RedisVLMCPError, match="return_fields must not be empty") as exc:
+        await search_records(server, query="science", return_fields=[])
+
+    assert exc.value.code == MCPErrorCode.INVALID_REQUEST
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two independent holes in the `search-records` request boundary. Both are fixes to code already on `main`, independent of any other MCP work in flight.

## Text filter values reached the query string unescaped

`Text`'s operator templates are `@field:("value")` for `eq`/`ne` and `@field:(value)` for `like`, so a value containing a quote or a paren could close its own clause and have the remainder parsed as RediSearch syntax. Tag values are already escaped and numeric values are type-checked; text was neither.

The fix escapes text at the MCP filter boundary rather than in `Text.__str__`, so library users who pass raw RediSearch syntax deliberately are unaffected. `like` keeps `*` and `?` live, since it is the pattern-matching operator.

**This is a behavior change on a surface that has shipped since v0.17.0** and is worth a release note. A structured DSL value that previously smuggled query syntax through now matches literally. That passthrough was never documented, and the raw-string `filter` form still serves callers who want raw syntax — but it is a change, not purely an internal fix.

## `return_fields: []` was accepted and meant the opposite of what it reads like

An empty list reached Redis as no `RETURN` clause at all, which returns *every* field — including the vector that the same function refuses a few lines down. An empty list now raises, with the error pointing at omitting the argument to get the default projection.

This guard had **no test coverage**. It does now, and I verified by mutation that the test fails when the guard is removed.

## Also

Moves the shared `_schema()` builder into `conftest.py`; the filter and search unit tests were carrying identical copies.

## Verification

- MCP unit tests: 232 passing
- `make check-types`: clean
- Pre-commit: passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query semantics for structured text filters (documented breaking behavior) and tightens search/config validation; scope is MCP-only, not core RedisVL Text rendering.
> 
> **Overview**
> Hardens the MCP **`search-records`** boundary in three related ways.
> 
> **Structured text filters** now escape caller values before building RediSearch `Text` expressions (`eq`/`ne`/`in` use full escaping; **`like`** uses a narrower escaper so `*`, `?`, `%`, and spaces stay pattern-active). Raw string **`filter`** passthrough is unchanged. This is a **behavior change** for DSL values that previously injected query syntax.
> 
> **`return_fields: []`** is rejected with guidance to omit the argument for the default projection, because an empty list omitted Redis **`RETURN`** and could return every field, including vectors the tool blocks when named explicitly.
> 
> **Startup validation** rejects **`runtime.text_field_name`** pointing at a **vector** field for fulltext/hybrid (not just missing from the schema), avoiding an empty default projection on text search paths.
> 
> Unit tests cover injection, `like` semantics, empty projection, and config; shared **`_schema()`** moved to **`conftest.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1c0785ed2c3021c4645908c2f43bc7e565d661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->