### PR TITLE
fix: bound Timestamp date comparisons to the whole UTC day

### DIFF
--- a/docs/api/filter.rst
+++ b/docs/api/filter.rst
@@ -68,3 +68,14 @@ GeoRadius
     :members:
     :special-members:
     :exclude-members: __hash__
+
+
+Timestamp
+=========
+
+.. currentmodule:: redisvl.query.filter
+
+.. autoclass:: Timestamp
+    :members:
+    :special-members:
+    :exclude-members: __hash__

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -720,13 +720,18 @@ class Timestamp(Num):
     def _as_date(value: Any) -> Any:
         """Normalize a date-only ISO string to a date, leaving anything else alone.
 
-        _convert_to_timestamp parses every string with fromisoformat, which turns
-        "2023-03-17" into a midnight *datetime* and so skips the date branch that
-        honors end_date. Coercing to a date first keeps date-only strings and bare
-        date objects on the same path.
+        Returns a datetime.date for a "YYYY-MM-DD" string, and the value
+        unchanged for every other input, including a date-shaped string that is
+        not a real calendar date.
         """
         if isinstance(value, str) and Timestamp._is_date_only(value):
-            return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+            try:
+                return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+            except ValueError:
+                # Date-shaped but not a real date, e.g. "2023-02-30": _is_date_only
+                # only checks the digit pattern. Hand it back so the caller below
+                # rejects it with one consistent message.
+                return value
         return value
 
     def _convert_to_timestamp(self, value, end_date=False):
@@ -749,6 +754,10 @@ class Timestamp(Num):
         if isinstance(value, (int, float)):
             # Already a Unix timestamp
             return float(value)
+
+        # Coerce before the fromisoformat call below, which would otherwise turn a
+        # date-only string into a midnight datetime and skip the end_date branch.
+        value = self._as_date(value)
 
         if isinstance(value, str):
             # Parse ISO format
@@ -849,7 +858,7 @@ class Timestamp(Num):
         """
         # end_date anchors a bare date to 23:59:59.999999 so the exclusive lower
         # bound skips the whole day rather than just its first instant.
-        timestamp = self._convert_to_timestamp(self._as_date(other), end_date=True)
+        timestamp = self._convert_to_timestamp(other, end_date=True)
         self._set_value(timestamp, self.SUPPORTED_TYPES, FilterOperator.GT)
         return FilterExpression(str(self))
 
@@ -902,7 +911,7 @@ class Timestamp(Num):
         """
         # end_date anchors a bare date to 23:59:59.999999 so the inclusive upper
         # bound covers the whole day rather than just its first instant.
-        timestamp = self._convert_to_timestamp(self._as_date(other), end_date=True)
+        timestamp = self._convert_to_timestamp(other, end_date=True)
         self._set_value(timestamp, self.SUPPORTED_TYPES, FilterOperator.LE)
         return FilterExpression(str(self))
 
@@ -910,9 +919,15 @@ class Timestamp(Num):
         """
         Filter for timestamps between start and end (inclusive).
 
+        Bare dates (and date-only ISO strings) span whole UTC calendar days:
+        start anchors to 00:00:00 of its day and end to 23:59:59.999999 of its
+        day, so both endpoint days are covered in full.
+
         Args:
             start: A datetime, date, ISO string, or Unix timestamp
             end: A datetime, date, ISO string, or Unix timestamp
+            inclusive: Which endpoints to include -- "both" (default), "left",
+                "right", or "neither".
 
         Returns:
             self: The filter object for method chaining

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -716,6 +716,19 @@ class Timestamp(Num):
         date_pattern = r"^\d{4}-\d{2}-\d{2}$"
         return bool(re.match(date_pattern, iso_string))
 
+    @staticmethod
+    def _as_date(value: Any) -> Any:
+        """Normalize a date-only ISO string to a date, leaving anything else alone.
+
+        _convert_to_timestamp parses every string with fromisoformat, which turns
+        "2023-03-17" into a midnight *datetime* and so skips the date branch that
+        honors end_date. Coercing to a date first keeps date-only strings and bare
+        date objects on the same path.
+        """
+        if isinstance(value, str) and Timestamp._is_date_only(value):
+            return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+        return value
+
     def _convert_to_timestamp(self, value, end_date=False):
         """
         Convert various inputs to a Unix timestamp (seconds since epoch in UTC).
@@ -825,19 +838,27 @@ class Timestamp(Num):
         """
         Filter for timestamps greater than the specified value.
 
+        For a bare date (or date-only ISO string), this means after the *end* of
+        that UTC day, so the day itself is excluded.
+
         Args:
             other: A datetime, date, ISO string, or Unix timestamp
 
         Returns:
             self: The filter object for method chaining
         """
-        timestamp = self._convert_to_timestamp(other)
+        # end_date anchors a bare date to 23:59:59.999999 so the exclusive lower
+        # bound skips the whole day rather than just its first instant.
+        timestamp = self._convert_to_timestamp(self._as_date(other), end_date=True)
         self._set_value(timestamp, self.SUPPORTED_TYPES, FilterOperator.GT)
         return FilterExpression(str(self))
 
     def __lt__(self, other):
         """
         Filter for timestamps less than the specified value.
+
+        For a bare date (or date-only ISO string), this means before the *start*
+        of that UTC day, so the day itself is excluded.
 
         Args:
             other: A datetime, date, ISO string, or Unix timestamp
@@ -853,6 +874,9 @@ class Timestamp(Num):
         """
         Filter for timestamps greater than or equal to the specified value.
 
+        For a bare date (or date-only ISO string), this means from the *start* of
+        that UTC day, so the day itself is included.
+
         Args:
             other: A datetime, date, ISO string, or Unix timestamp
 
@@ -867,13 +891,18 @@ class Timestamp(Num):
         """
         Filter for timestamps less than or equal to the specified value.
 
+        For a bare date (or date-only ISO string), this means through the *end* of
+        that UTC day, so the day itself is included.
+
         Args:
             other: A datetime, date, ISO string, or Unix timestamp
 
         Returns:
             self: The filter object for method chaining
         """
-        timestamp = self._convert_to_timestamp(other)
+        # end_date anchors a bare date to 23:59:59.999999 so the inclusive upper
+        # bound covers the whole day rather than just its first instant.
+        timestamp = self._convert_to_timestamp(self._as_date(other), end_date=True)
         self._set_value(timestamp, self.SUPPORTED_TYPES, FilterOperator.LE)
         return FilterExpression(str(self))
 

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -1,4 +1,5 @@
 import calendar
+import operator
 import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 
@@ -552,6 +553,91 @@ def test_timestamp_operators():
 
     ts = Timestamp("created_at").between(dt, dt2, inclusive="right")
     assert str(ts) == f"@created_at:[({ts_value} {ts_value2}]"
+
+
+# The four comparison operators, keyed by the symbol used in failure messages.
+TIMESTAMP_COMPARISONS = {
+    ">": operator.gt,
+    "<": operator.lt,
+    ">=": operator.ge,
+    "<=": operator.le,
+}
+
+
+def test_timestamp_comparison_operators_with_date():
+    """A bare date bounds the whole UTC day, so > and <= sit at its end.
+
+    Hard-coded against 2023-03-17T00:00:00Z / T23:59:59.999999Z so the test
+    cannot drift along with the implementation.
+    """
+    expected = {
+        ">": "@created_at:[(1679097599.999999 +inf]",
+        "<": "@created_at:[-inf (1679011200.0]",
+        ">=": "@created_at:[1679011200.0 +inf]",
+        "<=": "@created_at:[-inf 1679097599.999999]",
+    }
+
+    for symbol, op in TIMESTAMP_COMPARISONS.items():
+        # Bare dates and date-only ISO strings take the same branch
+        for value in (date(2023, 3, 17), "2023-03-17"):
+            assert (
+                str(op(Timestamp("created_at"), value)) == expected[symbol]
+            ), f"{symbol} {value!r}"
+
+
+@pytest.mark.skipif(not hasattr(time_module, "tzset"), reason="tzset() is POSIX-only")
+@pytest.mark.parametrize(
+    "d",
+    [
+        date(2023, 3, 17),  # ordinary date
+        date(2023, 3, 12),  # US DST spring-forward
+        date(2023, 11, 5),  # US DST fall-back
+        date(1970, 1, 1),  # Unix epoch
+        date(2038, 1, 20),  # past the signed 32-bit rollover
+    ],
+)
+def test_timestamp_comparison_date_bounds_are_utc_days(d, monkeypatch):
+    """Comparison operators bound the UTC day, whatever the host's local zone.
+
+    CI runs in UTC, where the correct and the local-time conversions agree, so
+    this is the only test that would catch a regression to local-day bounds.
+    """
+    # calendar.timegm is a timezone-independent oracle that shares no code with
+    # the conversion path under test.
+    start = float(calendar.timegm(datetime.combine(d, time.min).timetuple()))
+    end = float(calendar.timegm(datetime.combine(d, time.max).timetuple())) + 0.999999
+
+    # > and <= exclude/include the whole day, so they anchor to its end; >= and <
+    # anchor to its start.
+    expected = {
+        ">": f"@created_at:[({end} +inf]",
+        "<": f"@created_at:[-inf ({start}]",
+        ">=": f"@created_at:[{start} +inf]",
+        "<=": f"@created_at:[-inf {end}]",
+    }
+
+    try:
+        # Includes zones with non-hour offsets (+05:45, +12:45/+13:45), which an
+        # hour-granularity mistake would pass.
+        for tz in (
+            "UTC",
+            "America/New_York",
+            "Asia/Tokyo",
+            "Asia/Kathmandu",
+            "Pacific/Chatham",
+        ):
+            monkeypatch.setenv("TZ", tz)
+            time_module.tzset()
+
+            for symbol, op in TIMESTAMP_COMPARISONS.items():
+                for value in (d, d.isoformat()):
+                    assert (
+                        str(op(Timestamp("created_at"), value)) == expected[symbol]
+                    ), f"{symbol} {value!r} in TZ={tz}"
+    finally:
+        # Restore TZ and re-read it, so later tests see the original zone
+        monkeypatch.undo()
+        time_module.tzset()
 
 
 def test_timestamp_between():

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -585,6 +585,31 @@ def test_timestamp_comparison_operators_with_date():
             ), f"{symbol} {value!r}"
 
 
+def test_timestamp_between_date_only_string_matches_date_object():
+    """A date-only string endpoint spans the same whole day a date object does.
+
+    `end` is the interesting one: it goes through `end_date=True`, which only
+    reaches the end of the day if the string was coerced to a date first.
+    """
+    by_date = str(Timestamp("created_at").between(date(2023, 3, 1), date(2023, 3, 17)))
+    by_string = str(Timestamp("created_at").between("2023-03-01", "2023-03-17"))
+
+    assert by_string == by_date
+    assert by_date == "@created_at:[1677628800.0 1679097599.999999]"
+
+
+@pytest.mark.parametrize("symbol", list(TIMESTAMP_COMPARISONS))
+@pytest.mark.parametrize("value", ["2023-02-30", "2023-13-45", "0000-00-00"])
+def test_timestamp_date_shaped_but_invalid_string(symbol, value):
+    """Every operator rejects a date-shaped non-date the same way.
+
+    `_is_date_only` matches on the digit pattern alone, so these reach the
+    coercion and have to fall through to one shared error message.
+    """
+    with pytest.raises(ValueError, match=f"must be in ISO format: {value}"):
+        TIMESTAMP_COMPARISONS[symbol](Timestamp("created_at"), value)
+
+
 @pytest.mark.skipif(not hasattr(time_module, "tzset"), reason="tzset() is POSIX-only")
 @pytest.mark.parametrize(
     "d",
@@ -603,7 +628,11 @@ def test_timestamp_comparison_date_bounds_are_utc_days(d, monkeypatch):
     this is the only test that would catch a regression to local-day bounds.
     """
     # calendar.timegm is a timezone-independent oracle that shares no code with
-    # the conversion path under test.
+    # the conversion path under test. Caveat for anyone extending the list above:
+    # adding the microseconds back on is float-exact only for non-negative
+    # timestamps, so a pre-epoch date such as 1969-12-31 fails here spuriously
+    # (oracle -1.0000000000287557e-06 vs. a correct -1e-06). Assert those against
+    # datetime.combine(d, time.max, tzinfo=timezone.utc).timestamp() instead.
     start = float(calendar.timegm(datetime.combine(d, time.min).timetuple()))
     end = float(calendar.timegm(datetime.combine(d, time.max).timetuple())) + 0.999999
 


### PR DESCRIPTION
## What this fixes

`Timestamp` treats a bare `date` as a whole calendar day in `==`/`!=`, but not in the four comparison operators. `__gt__`, `__lt__`, `__ge__` and `__le__` all call `_convert_to_timestamp(other)` without `end_date=True`, and for a bare `date` that function combines with `time.min` — the *start* of the day — regardless of which operator is asking. Two of the four need the end of the day instead:

```python
from datetime import date
from redisvl.query.filter import Timestamp
for op in ['>', '<', '>=', '<=']:
    print(op, eval(f'Timestamp("x") {op} date(2023,3,17)'))
```

| Filter | Before | After | |
| --- | --- | --- | --- |
| `> date(2023,3,17)` | `@x:[(1679011200.0 +inf]` | `@x:[(1679097599.999999 +inf]` | ❌ → ✅ |
| `< date(2023,3,17)` | `@x:[-inf (1679011200.0]` | unchanged | ✅ |
| `>= date(2023,3,17)` | `@x:[1679011200.0 +inf]` | unchanged | ✅ |
| `<= date(2023,3,17)` | `@x:[-inf 1679011200.0]` | `@x:[-inf 1679097599.999999]` | ❌ → ✅ |

So `> date(d)` behaved like `>= date(d)`, matching nearly all of day `d` that the caller asked to exclude, and `<= date(d)` behaved like `< date(d)`, matching almost none of the day the caller asked to include. Both fail silently — a filter that returns the wrong rows, with no error or warning.

`>=` and `<` were correct only coincidentally: both legitimately anchor to the start of the day, so the missing argument never mattered for them.

Date-only ISO strings (`"2023-03-17"`) are affected identically, since `_is_date` puts them on the same footing.

## The fix

`_convert_to_timestamp(value, end_date=True)` already produces the 23:59:59.999999 bound — it's what `between()` uses for its upper end — so `__gt__` and `__le__` now pass it, reusing the existing mechanism rather than adding a second way to compute a day boundary. Resulting semantics for a bare date `d`:

- `> d` — after the **end** of UTC day `d`; the day is excluded
- `<= d` — through the **end** of UTC day `d`; the day is included
- `>= d` / `< d` — the **start** of UTC day `d`, unchanged

One extra step was needed for date-only strings. They arrive as `str`, where `fromisoformat` turns `"2023-03-17"` into a midnight *datetime* — which then fails the `isinstance(value, date) and not isinstance(value, datetime)` check and skips the branch that reads `end_date` altogether. So `end_date=True` alone would have fixed `date` objects and silently done nothing for strings. The new `_as_date` helper coerces a date-only string to a `date`, and it runs **inside `_convert_to_timestamp`** rather than at the call sites, which matters — see below.

The `datetime`, full-ISO-string and Unix-timestamp paths are untouched: `end_date` is only consulted for bare dates, and ints/floats return early. `"2023-03-17T00:00:00"` still resolves to a midnight instant, not a day range — a date-only string and a midnight datetime string remain distinct.

### `between()` is fixed too

An earlier revision of this PR applied `_as_date` at the two operator call sites. That left `between()` — the third caller passing `end_date=True` — still short-circuiting:

```python
Timestamp("f") <= "2023-03-19"                       # [-inf 1679270399.999999]  end of day
Timestamp("f").between("2023-03-17", "2023-03-19")   # [... 1679184000.0]        MIDNIGHT
Timestamp("f").between(date(2023,3,17), date(2023,3,19))  # [... 1679270399.999999]  end of day
```

Before this PR those agreed (all anchored to midnight — consistently wrong). Fixing only the operators would have made `between()` disagree with `<=` on identical input, *and* disagree with itself depending on whether you passed `date(2023, 3, 19)` or `"2023-03-19"`. Doing the coercion once inside `_convert_to_timestamp` fixes all three call sites and means future `end_date=True` callers can't forget it.

Verified across 52 input/operator combinations: identical output to the call-site version everywhere except the two `between()`-with-date-string cases, which now correctly reach end-of-day.

### Consistent error for a date-shaped non-date

`_is_date_only` matches on the digit pattern (`^\d{4}-\d{2}-\d{2}$`) alone, so `"2023-02-30"` reached `strptime` and raised its raw message from `>`/`<=` while `<`/`>=` raised the curated one. `_as_date` now falls through on `ValueError`, so all four operators report `String timestamp must be in ISO format: 2023-02-30` alike. Still a `ValueError` in every case, so no caller's `except` clause changes.

## Docs

`docs/api/filter.rst` autoclassed every sibling filter — `Tag`, `Text`, `Num`, `Geo`, `GeoRadius`, `FilterExpression` — but **not `Timestamp`**, so none of these docstrings reached docs.redisvl.com. Added the missing block. Confirmed with a sphinx build that the class, all six operators and `between()` now render, and that the private helpers stay out.

Also documented `between()`'s whole-day semantics and its previously undocumented `inclusive` argument, and `_convert_to_timestamp`'s `end_date` argument.

## Tests

`test_timestamp_operators` exercised all four operators with a full `datetime` only, never a bare `date` — which is why this went unnoticed. Added:

- **`test_timestamp_comparison_operators_with_date`** — all four operators × {`date` object, date-only string}, with bounds hard-coded against `2023-03-17T00:00:00Z` / `T23:59:59.999999Z` so the test cannot drift along with the implementation.
- **`test_timestamp_comparison_date_bounds_are_utc_days`** — the same matrix across five dates (ordinary, DST spring-forward, DST fall-back, the Unix epoch, past the signed 32-bit rollover) and five zones, using `calendar.timegm` as a timezone-independent oracle sharing no code with the path under test. Zones include the non-hour offsets `Asia/Kathmandu` (+05:45) and `Pacific/Chatham` (+12:45/+13:45), which an hour-granularity mistake would slip past. CI sets no `TZ` and GitHub runners default to UTC, so this is what would catch a regression to local-day bounds.
- **`test_timestamp_between_date_only_string_matches_date_object`** — pins the `between()` fix above.
- **`test_timestamp_date_shaped_but_invalid_string`** — 12 cases, four operators × three malformed-but-date-shaped inputs.

The six original cases fail without the fix (verified by stashing the `filter.py` change). `tests/unit/test_filter.py`: 87 pass, under both `TZ` unset and `TZ=Asia/Kathmandu`. Full unit suite: 1011 pass (the 2 failures are missing optional `sentence-transformers` in my venv, unrelated). `make format`, `make check-types` and `pre-commit` clean.

## Release note

> **Fixed:** `Timestamp` comparison filters now treat a bare `date` (or a date-only ISO string such as `"2023-03-17"`) as the whole UTC calendar day. Previously `> date(d)` behaved like `>=` and matched nearly all of day `d`, and `<= date(d)` behaved like `<` and matched almost none of it. `between()` with a date-only *string* upper bound likewise stopped at midnight instead of covering the closing day. `>= date(d)` and `< date(d)` are unchanged, as are all filters built from `datetime` objects, full ISO datetime strings, or Unix timestamps.

**This is a user-visible behavior change.** Of the four operators, **`<=` is the only one that now matches a larger row set** (up to one extra calendar day); `>` matches a smaller one; `<` and `>=` are byte-identical. `between()` with a date-only string end bound also widens by up to a day. So a caller who used `<= date(d)` as a hard cutoff — a subscription end date, a retention or legal-hold boundary — will now see records from that final UTC day that were previously excluded. In every case the new result is what the documented semantics call for, but the widening is worth checking for at upgrade time.

Code that wants the old start-of-day bound explicitly can pass a `datetime`:

```python
Timestamp("x") > datetime.combine(d, time.min, tzinfo=timezone.utc)
```

## Relationship to #666

#666 has now **merged** (`3707059`) and this branch is rebased on top of it. It fixed a different defect in the same class: the `==`/`!=` date branches anchored to the *host's local* day rather than the UTC day. The two changes are independent — the comparison operators go through `_convert_to_timestamp`, which already anchored bare dates to UTC, so this branch needed no UTC fix and makes none.

Together the two land the full contract. All six date forms now agree and are identical in every zone — verified under `UTC`, `Europe/Berlin` and `Asia/Kathmandu`:

| Filter | Bound |
| --- | --- |
| `< date(2023,3,17)` | `@x:[-inf (1679011200.0]` |
| `== date(2023,3,17)` | `@x:[1679011200.0 1679097599.999999]` |
| `> date(2023,3,17)` | `@x:[(1679097599.999999 +inf]` |
| `>= date(2023,3,17)` | `@x:[1679011200.0 +inf]` |
| `<= date(2023,3,17)` | `@x:[-inf 1679097599.999999]` |
| `between("2023-03-17", "2023-03-17")` | `@x:[1679011200.0 1679097599.999999]` |

`<`, `==` and `>` now tile the timeline exactly, with no gap and no overlap — which was not true of either PR alone. The rebase conflict was a single hunk (both PRs add imports to `tests/unit/test_filter.py`); #666's `test_timestamp_date_bounds_are_utc_regardless_of_local_timezone` and this PR's tests coexist, 87 passing in that file.

One consistency gap is deliberately left alone: `__eq__`/`__ne__` still do their own inline `strptime` for date-only strings rather than going through `_as_date`, so they raise the raw `strptime` message for a date-shaped non-date like `"2023-02-30"` where the four comparison operators now raise the curated `String timestamp must be in ISO format`. Routing those two through `_as_date` would remove the duplication and unify the error, but it touches lines #666 just rewrote, so it belongs in a follow-up rather than here.
