### PR TITLE
fix: check index existence with FT.INFO instead of listing every index

### DIFF
--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -300,6 +300,16 @@ Returns a numbered list of all index names:
     2. documents_index
     3. embeddings_index
 
+.. note::
+
+   ``listall`` uses ``FT._LIST``, which Redis tags ``@admin`` as well as ``@search``.
+   An ACL that grants search access and then subtracts ``@admin``, such as
+   ``+@search -@admin``, denies this command with a permission error even though the
+   rest of the CLI works. The migration commands that discover indexes for you are
+   denied by the same ACL: ``rvl migrate helper``, ``rvl migrate wizard`` when no
+   ``-i/--index`` is given, and ``rvl migrate batch-plan --pattern``. See
+   :doc:`/user_guide/installation`.
+
 rvl index delete
 ^^^^^^^^^^^^^^^^
 

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -54,7 +54,7 @@ When each error is raised
    * - :class:`RedisSearchError`
      - An index or search operation fails, including errors returned by Redis
        itself.
-     - ``create()``, ``delete()``, ``search()``, ``aggregate()``
+     - ``create()``, ``exists()``, ``delete()``, ``search()``, ``aggregate()``
    * - :class:`RedisModuleVersionError`
      - The connected Redis or Redis Search version does not support a requested
        feature, such as an ``svs-vamana`` vector field.
@@ -144,6 +144,53 @@ unsupported feature from a genuine Redis failure.
         # Something went wrong talking to Redis, or the index definition was
         # rejected. The original redis-py exception is available as e.__cause__.
         print(f"Index creation failed: {e}")
+
+Insufficient permissions usually arrive as :class:`RedisSearchError` as well.
+``create()`` checks whether the index already exists before doing anything, so a
+credential that cannot run ``FT.INFO`` fails at that check rather than at
+``FT.CREATE``, with the chained ``redis.exceptions.NoPermissionError`` on
+``e.__cause__`` naming the denied command. The same applies to an existing index whose
+key prefix falls outside the credential's key patterns; for an index that does not exist
+yet, the check simply reports it as absent and ``create()`` proceeds.
+
+``listall()`` is the exception: it issues ``FT._LIST`` directly, so a permission failure
+there raises ``redis.exceptions.NoPermissionError`` itself rather than a wrapped
+:class:`RedisSearchError`. See :doc:`/user_guide/installation` for the ACL categories
+RedisVL needs.
+
+Telling "the index is missing" apart from other failures
+--------------------------------------------------------
+
+Redis Search reports an absent index as an ordinary error reply rather than a distinct
+type, and the wording has changed between versions -- older releases say ``Unknown index
+name``, Redis 8.6 and earlier say ``<name>: no such index``, and Redis 8.8 introduced
+``SEARCH_INDEX_NOT_FOUND Index not found: <name>``. There is no error code to branch on,
+so code that needs to distinguish "missing" from "something went wrong" has to match the
+message.
+
+:meth:`~redisvl.index.SearchIndex.exists` already does this for you, which is the reason
+to prefer it over catching errors from :meth:`~redisvl.index.SearchIndex.info`: it
+returns ``False`` only for a recognized missing-index reply and re-raises everything
+else, so a permission or connection failure is never reported as an absent index.
+
+.. code-block:: python
+
+    # Prefer this
+    if not index.exists():
+        index.create()
+
+    # over inspecting the error yourself, which couples your code to the
+    # wording of a particular Redis version
+    try:
+        index.info()
+    except RedisSearchError as e:
+        if "no such index" in str(e):  # breaks on Redis 8.8
+            index.create()
+
+When you do need the distinction elsewhere, read ``e.__cause__`` rather than the
+:class:`RedisSearchError` message: the wrapper interpolates the index name, so an index
+whose name happens to contain one of the wordings above would make an unrelated failure
+look like an absence.
 
 Catching everything
 -------------------

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -183,3 +183,41 @@ The Sentinel URL format supports:
 - Service name (defaults to `mymaster` if not specified)
 - Optional database number (defaults to 0)
 - Both sync (`SearchIndex`) and async (`AsyncSearchIndex`) connections
+
+## Redis permissions (ACLs)
+
+RedisVL works through Redis Search commands, so a connecting credential needs the `@search` ACL category, or the individual `FT.*` commands. Reading an index additionally requires key permissions covering its prefix: the [ACL documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/#command-categories) describes this rule for creating, modifying, and reading an index, and in practice `FT.INFO`, `FT.SEARCH`, and `FT.AGGREGATE` are denied when the index prefix falls outside the allowed key patterns. `FT.CREATE` is not checked this way, so a credential can create an index it is then unable to read.
+
+One command needs more than `@search`. Redis tags `FT._LIST` as `@admin` as well as `@search` and `@slow`, and ACL rules are applied left to right — so a rule that grants search access and then takes back administrative commands, such as `+@search -@admin` or `+@all -@admin`, denies it:
+
+```text
+User <name> has no permissions to run the 'FT._LIST' command
+```
+
+Note that `FT._LIST` does not *require* `@admin`: granting `+@search` on its own permits it. Only rules that subtract `@admin` after granting search are affected. To keep such a policy and still enumerate indexes, grant the command back explicitly with `+ft._list`.
+
+| Operation | Redis command | Permitted by `+@all -@admin` |
+|---|---|---|
+| `index.create()`, `index.exists()` | `FT.CREATE`, `FT.INFO` | Yes |
+| `index.query()`, `index.search()`, `index.aggregate()` | `FT.SEARCH`, `FT.AGGREGATE` | Yes |
+| `index.info()`, `rvl index info`, `rvl stats` | `FT.INFO` | Yes |
+| `index.load()` | `HSET` or `JSON.SET` (needs `@write` and key access) | Yes |
+| `index.delete()`, `rvl index delete`, `rvl index destroy` | `FT.DROPINDEX` | Yes |
+| Enumerating indexes (see below) | `FT._LIST` | No |
+
+`SemanticCache`, `SemanticMessageHistory`, `MessageHistory`, and `SemanticRouter` each call `index.create()` while being constructed, so they are covered by the first row.
+
+Index enumeration is the only thing an `-@admin` rule breaks. It is reached by `SearchIndex.listall()` and `AsyncSearchIndex.listall()`, by `rvl index listall`, and by the migration entry points that discover indexes for you: `rvl migrate helper`, `rvl migrate wizard` when no `-i/--index` is given, and `rvl migrate batch-plan --pattern`.
+
+Other categories gate different operations. `FT.DROPINDEX` is tagged `@dangerous` and `@write` as well as `@search`, so a policy that subtracts `@dangerous` denies `index.delete()`, `rvl index delete`, and `rvl index destroy`.
+
+Outside of Redis Search, RedisVL identifies itself on connect with `CLIENT SETINFO` and falls back to `ECHO`. A credential permitted to run neither currently fails when the connection is created, before any index operation.
+
+### Redis Cloud and Redis Software
+
+Both manage ACLs through their own control plane rather than the `ACL SETUSER` command, so permissions are attached to roles and users instead of being set on a connection.
+
+- **Redis Cloud** provides three predefined ACL rules that cannot be edited — Full-Access, Read-Write ("read and write commands and excludes dangerous commands"), and Read-Only — which you assign to a data access role. See [Configure permissions with Redis ACLs](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/). Custom rules use the same syntax as above.
+- **Redis Software** ships one predefined ACL, Full Access, and you define others in the Cluster Manager UI or with a [`POST /v1/redis_acls`](https://redis.io/docs/latest/operate/rs/security/access-control/create-db-roles/) request. It [does not support every `ACL` command](https://redis.io/docs/latest/operate/rs/security/access-control/redis-acl-overview/#acl-command-support), nor nested selectors, nor `(` and `)` in key patterns.
+
+Because the predefined rules' exact command sets are not published, confirm a credential against the database rather than inferring what its policy name implies. Redis Software's documentation uses `+@read +FT.INFO +FT.SEARCH` as an example rule, which is a good illustration: it permits querying and `index.exists()`, but not `index.create()` or index enumeration. Grant `FT.CREATE` explicitly when the application creates its own index, which `SemanticCache`, `SemanticMessageHistory`, `MessageHistory`, and `SemanticRouter` all do.

--- a/redisvl/exceptions.py
+++ b/redisvl/exceptions.py
@@ -53,3 +53,37 @@ class RedisModuleVersionError(RedisVLError):
             f"3) Remove compression parameters"
         )
         return cls(message)
+
+
+# Redis Search reports an absent index as an ordinary error reply whose wording
+# depends on the server version, so matching the message is the only option.
+# Every known wording lives here rather than at each call site. See the "Telling
+# 'the index is missing' apart from other failures" section of docs/api/exceptions.rst.
+_MISSING_INDEX_ERROR_FRAGMENTS = (
+    "unknown index name",
+    "no such index",
+    "search_index_not_found",
+    "index not found",
+)
+
+
+def _is_missing_index_error(exc: RedisSearchError) -> bool:
+    """Check whether a Redis Search error means the index does not exist.
+
+    Different Redis Search versions phrase the error differently, so every
+    known wording is matched. The check reads the underlying Redis error rather
+    than the :class:`RedisSearchError` wrapping it, because the wrapper's
+    message interpolates the index name and would otherwise match for an index
+    named after one of the wordings.
+
+    Args:
+        exc: A :class:`RedisSearchError` wrapping the ``redis-py`` exception
+            that Redis raised. Wrappers raised without a cause are matched on
+            their own message.
+
+    Returns:
+        bool: True if the error indicates a missing index, False otherwise.
+    """
+    cause = exc.__cause__ if exc.__cause__ is not None else exc
+    message = str(cause).lower()
+    return any(fragment in message for fragment in _MISSING_INDEX_ERROR_FRAGMENTS)

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -72,6 +72,7 @@ from redisvl.exceptions import (
     RedisSearchError,
     RedisVLError,
     SchemaValidationError,
+    _is_missing_index_error,
 )
 from redisvl.index.storage import BaseStorage, HashStorage, JsonStorage
 from redisvl.query import (
@@ -1063,12 +1064,19 @@ class SearchIndex(BaseSearchIndex):
         """Delete the search index while optionally dropping all keys associated
         with the index.
 
+        ``FT.DROPINDEX`` resolves index aliases, so if this schema's name happens
+        to be an alias, the index the alias points at is dropped instead -- along
+        with its documents when ``drop`` is True. :meth:`exists` reports an alias
+        as absent to keep :meth:`create` away from this path.
+
         Args:
             drop (bool, optional): Delete the key / documents pairs in the
                 index. Defaults to True.
 
-        raises:
-            redis.exceptions.ResponseError: If the index does not exist.
+        Raises:
+            RedisSearchError: If the index cannot be deleted, for example when it
+                does not exist. The original ``redis-py`` exception is available
+                as ``__cause__``.
         """
         try:
             # For Redis Cluster with drop=True, we need to handle key deletion manually
@@ -1965,8 +1973,23 @@ class SearchIndex(BaseSearchIndex):
 
         Returns:
             bool: True if the index exists, False otherwise.
+
+        Raises:
+            RedisSearchError: If the check fails for any reason other than the
+                index not existing, such as a connection failure or insufficient
+                permissions. The original ``redis-py`` exception is available as
+                ``__cause__``.
         """
-        return self.schema.index.name in self.listall()
+        try:
+            info = self._info(self.schema.index.name, self._redis_client)
+        except RedisSearchError as e:
+            if _is_missing_index_error(e):
+                return False
+            raise
+        # FT.INFO answers for an alias's target, so compare the resolved name:
+        # reporting an alias as existing would let create(overwrite=True) drop
+        # the index it points at.
+        return info.get("index_name") == self.schema.index.name
 
     @staticmethod
     def _info(name: str, redis_client: SyncRedisClient) -> dict[str, Any]:
@@ -2345,12 +2368,19 @@ class AsyncSearchIndex(BaseSearchIndex):
     async def delete(self, drop: bool = True):
         """Delete the search index.
 
+        ``FT.DROPINDEX`` resolves index aliases, so if this schema's name happens
+        to be an alias, the index the alias points at is dropped instead -- along
+        with its documents when ``drop`` is True. :meth:`exists` reports an alias
+        as absent to keep :meth:`create` away from this path.
+
         Args:
             drop (bool, optional): Delete the documents in the index.
                 Defaults to True.
 
         Raises:
-            redis.exceptions.ResponseError: If the index does not exist.
+            RedisSearchError: If the index cannot be deleted, for example when it
+                does not exist. The original ``redis-py`` exception is available
+                as ``__cause__``.
         """
         client = await self._get_client()
         try:
@@ -3188,8 +3218,24 @@ class AsyncSearchIndex(BaseSearchIndex):
 
         Returns:
             bool: True if the index exists, False otherwise.
+
+        Raises:
+            RedisSearchError: If the check fails for any reason other than the
+                index not existing, such as a connection failure or insufficient
+                permissions. The original ``redis-py`` exception is available as
+                ``__cause__``.
         """
-        return self.schema.index.name in await self.listall()
+        client = await self._get_client()
+        try:
+            info = await self._info(self.schema.index.name, client)
+        except RedisSearchError as e:
+            if _is_missing_index_error(e):
+                return False
+            raise
+        # FT.INFO answers for an alias's target, so compare the resolved name:
+        # reporting an alias as existing would let create(overwrite=True) drop
+        # the index it points at.
+        return info.get("index_name") == self.schema.index.name
 
     async def info(self, name: str | None = None) -> dict[str, Any]:
         """Get information about the index.

--- a/redisvl/mcp/server.py
+++ b/redisvl/mcp/server.py
@@ -8,7 +8,7 @@ from typing import Any, Awaitable
 
 from redis import __version__ as redis_py_version
 
-from redisvl.exceptions import RedisSearchError
+from redisvl.exceptions import RedisSearchError, _is_missing_index_error
 from redisvl.index import AsyncSearchIndex
 from redisvl.mcp.auth import build_auth_provider, resolve_auth_config
 from redisvl.mcp.config import MCPConfig, MCPIndexBindingConfig, load_mcp_config
@@ -293,22 +293,6 @@ class RedisVLMCPServer(FastMCP):
             register_upsert_tool(self)
         self._tools_registered = True
 
-    @staticmethod
-    def _is_missing_index_error(exc: RedisSearchError) -> bool:
-        """Detect the Redis search errors that mean the configured index is absent.
-
-        Different RediSearch versions phrase the error differently
-        (``unknown index name``, ``no such index``, or ``SEARCH_INDEX_NOT_FOUND
-        Index not found``), so check for each known wording.
-        """
-        message = str(exc).lower()
-        return (
-            "unknown index name" in message
-            or "no such index" in message
-            or "search_index_not_found" in message
-            or "index not found" in message
-        )
-
     @asynccontextmanager
     async def _server_lifespan(self, _server: Any):
         """Bridge FastMCP lifespan hooks onto the server's explicit lifecycle."""
@@ -514,7 +498,7 @@ class RedisVLMCPServer(FastMCP):
                 timeout=timeout,
             )
         except RedisSearchError as exc:
-            if self._is_missing_index_error(exc):
+            if _is_missing_index_error(exc):
                 raise ValueError(
                     f"Configured Redis index '{binding.redis_name}' does not exist"
                 ) from exc

--- a/tests/integration/test_async_search_index.py
+++ b/tests/integration/test_async_search_index.py
@@ -234,9 +234,9 @@ async def test_search_index_set_client(client, redis_url, index_schema):
 async def test_search_index_create(async_index):
     await async_index.create(overwrite=True, drop=True)
     assert await async_index.exists()
-    assert async_index.name in convert_bytes(
-        await async_index.client.execute_command("FT._LIST")
-    )
+    # exists() and listall() reach Redis by different commands, so keeping both
+    # assertions gives each an independent witness.
+    assert async_index.name in await async_index.listall()
 
 
 @pytest.mark.asyncio
@@ -244,9 +244,7 @@ async def test_search_index_delete(async_index):
     await async_index.create(overwrite=True, drop=True)
     await async_index.delete(drop=True)
     assert not await async_index.exists()
-    assert async_index.name not in convert_bytes(
-        await async_index.client.execute_command("FT._LIST")
-    )
+    assert async_index.name not in await async_index.listall()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_no_proactive_module_checks.py
+++ b/tests/integration/test_no_proactive_module_checks.py
@@ -188,10 +188,14 @@ class TestNoProactiveModuleChecks:
 
     def test_search_operations_fail_gracefully_without_modules(self):
         """Test that operations fail with clear errors when modules are missing."""
-        # Create a mock client that simulates missing modules
+        # A server without Redis Search rejects every FT.* command, so stub both
+        # the raw command path and the ft() helper that the existence check uses.
         mock_client = Mock(spec=Redis)
         mock_client.execute_command.side_effect = ResponseError(
             "unknown command 'FT.CREATE'"
+        )
+        mock_client.ft.return_value.info.side_effect = ResponseError(
+            "unknown command 'FT.INFO'"
         )
 
         schema = IndexSchema.from_dict(
@@ -207,12 +211,15 @@ class TestNoProactiveModuleChecks:
 
         index = SearchIndex(schema, redis_client=mock_client)
 
-        # Operations should fail with clear errors
-        with pytest.raises(ResponseError) as exc_info:
+        # create() checks for an existing index first, so that check is what
+        # surfaces the failure. Like every other Redis failure in create(), it
+        # arrives as RedisSearchError with the redis-py error on __cause__.
+        with pytest.raises(RedisSearchError) as exc_info:
             index.create()
 
         # Error message should be clear about what's missing
         assert "unknown command" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.__cause__, ResponseError)
 
     def test_semantic_router_no_proactive_validation(self, redis_url, worker_id):
         """Test that SemanticRouter doesn't validate modules proactively."""

--- a/tests/integration/test_search_index.py
+++ b/tests/integration/test_search_index.py
@@ -4,14 +4,17 @@ from unittest import mock
 
 import pytest
 from redis import Redis
+from redis.exceptions import NoPermissionError
 
 from redisvl.exceptions import QueryValidationError, RedisSearchError, RedisVLError
 from redisvl.index import SearchIndex
 from redisvl.query import VectorQuery
 from redisvl.query.query import FilterQuery
+from redisvl.redis.connection import RedisConnectionFactory
 from redisvl.redis.utils import convert_bytes
 from redisvl.schema import IndexSchema, StorageType
 from redisvl.schema.fields import VectorIndexAlgorithm
+from tests.conftest import skip_if_no_redis_search
 
 fields = [
     {"name": "test", "type": "tag"},
@@ -298,14 +301,88 @@ def test_search_index_connect(index, redis_url):
 def test_search_index_create(index):
     index.create(overwrite=True, drop=True)
     assert index.exists()
-    assert index.name in convert_bytes(index.client.execute_command("FT._LIST"))
+    # exists() and listall() reach Redis by different commands, so keeping both
+    # assertions gives each an independent witness.
+    assert index.name in index.listall()
 
 
 def test_search_index_delete(index):
     index.create(overwrite=True, drop=True)
     index.delete(drop=True)
     assert not index.exists()
-    assert index.name not in convert_bytes(index.client.execute_command("FT._LIST"))
+    assert index.name not in index.listall()
+
+
+def test_exists_under_acl_without_admin_commands(
+    index, client, redis_url, redis_test_name
+):
+    """exists() must work for a credential that grants search but drops @admin.
+
+    Redis tags FT._LIST @admin as well as @search, so this ACL shape used to
+    make exists() -- and therefore create() and every extension constructor --
+    fail outright. Only a live server can confirm FT.INFO is not gated the same
+    way, which is why this is an integration test.
+    """
+    # Probe with the unrestricted client: the module check itself uses FT._LIST.
+    skip_if_no_redis_search(client)
+    index.create(overwrite=True, drop=True)
+
+    username = redis_test_name("acl_no_admin")
+    password = "test-acl-password"
+    client.execute_command(
+        "ACL", "SETUSER", username, "on", f">{password}", "~*", "&*", "+@all", "-@admin"
+    )
+    restricted = None
+    try:
+        restricted = RedisConnectionFactory.get_redis_connection(
+            redis_url=redis_url, username=username, password=password
+        )
+        # Pin the premise so this test cannot quietly become vacuous: if a
+        # future Redis stops gating FT._LIST behind @admin, the reason for
+        # preferring FT.INFO is gone and we want to hear about it here.
+        with pytest.raises(NoPermissionError):
+            restricted.execute_command("FT._LIST")
+
+        restricted_index = SearchIndex(schema=index.schema, redis_client=restricted)
+        assert restricted_index.exists() is True
+    finally:
+        # Drop the ACL user before anything else that could raise: users are
+        # server-global, so a leaked one outlives this test and its worker.
+        client.execute_command("ACL", "DELUSER", username)
+        if restricted is not None:
+            restricted.close()
+        index.delete(drop=True)
+
+
+def test_exists_false_for_alias_pointing_at_another_index(
+    index, client, redis_test_name
+):
+    """An alias must not report as an existing index.
+
+    FT.INFO accepts an alias and answers for its target, where FT._LIST never
+    listed aliases at all. Left unhandled, that difference would make exists()
+    return True for an alias, and create(overwrite=True, drop=True) acts on
+    that answer by issuing FT.DROPINDEX <name> DD -- destroying the aliased
+    index and its documents.
+    """
+    index.create(overwrite=True, drop=True)
+    alias = redis_test_name("exists_alias")
+    client.execute_command("FT.ALIASADD", alias, index.name)
+    try:
+        alias_index = SearchIndex(
+            schema=IndexSchema.from_dict({"index": {"name": alias}, "fields": fields}),
+            redis_client=client,
+        )
+        assert alias_index.exists() is False
+        # And the guard must not be so strict that the real name breaks.
+        assert index.exists() is True
+    finally:
+        # Only FT.ALIASDEL removes an alias. Never call delete() or
+        # create(overwrite=True, drop=True) on alias_index here: FT.DROPINDEX
+        # resolves the alias and would drop the real index's data, which is the
+        # exact failure this test exists to catch.
+        client.execute_command("FT.ALIASDEL", alias)
+        index.delete(drop=True)
 
 
 @pytest.mark.parametrize("num_docs", [0, 1, 5, 10, 2042])

--- a/tests/unit/test_index_exists.py
+++ b/tests/unit/test_index_exists.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for how SearchIndex.exists() and AsyncSearchIndex.exists() classify
+the Redis response.
+
+exists() runs FT.INFO and has to distinguish three outcomes from a single
+command: the index is there, the index is absent, or the check itself failed.
+Redis Search offers no structured "not found" signal and phrases the error
+differently across versions, so these tests pin all three branches. They drive
+the real _info() helper rather than stubbing it, because _info() rewrites the
+message into "Error while fetching <name> index info: ..." and the not-found
+match has to survive that wrapping.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.cluster import RedisCluster
+from redis.exceptions import ConnectionError, ResponseError
+
+from redisvl.exceptions import RedisSearchError
+from redisvl.index import AsyncSearchIndex, SearchIndex
+from redisvl.schema import IndexSchema
+
+INDEX_NAME = "my_index"
+
+# Every wording Redis Search has used for an absent index. 8.8 replaced the
+# older prose with an error code, so a match on any single one of these would
+# break exists() on some supported server.
+MISSING_INDEX_MESSAGES = [
+    "Unknown index name",
+    f"{INDEX_NAME}: no such index",
+    f"SEARCH_INDEX_NOT_FOUND Index not found: {INDEX_NAME}",
+    "Index not found",
+]
+
+# Failures that must never be read as "the index is absent": reporting False
+# here would send callers on to create an index that already exists, and would
+# skip the schema-compatibility check the extensions perform first. The two
+# exception types matter -- _info() catches bare Exception, so narrowing it to
+# ResponseError would let the connection case escape unwrapped.
+NON_MISSING_INDEX_ERRORS = [
+    ResponseError("User acl_user has no permissions to run the 'FT.INFO' command"),
+    ConnectionError("Error 111 connecting to localhost:6379. Connection refused."),
+]
+
+
+def _schema(name=INDEX_NAME):
+    return IndexSchema.from_dict(
+        {
+            "index": {"name": name, "prefix": "test"},
+            "fields": [{"name": "t", "type": "text"}],
+        }
+    )
+
+
+def _sync_index(info_result=None, info_error=None, name=INDEX_NAME):
+    """Build a SearchIndex whose FT.INFO call returns or raises as directed."""
+    client = MagicMock(spec=Redis)
+    if info_error is not None:
+        client.ft.return_value.info.side_effect = info_error
+    else:
+        client.ft.return_value.info.return_value = info_result
+    return SearchIndex(schema=_schema(name), redis_client=client), client
+
+
+def _async_index(info_result=None, info_error=None):
+    """Build an AsyncSearchIndex whose FT.INFO call returns or raises as directed."""
+    client = MagicMock(spec=AsyncRedis)
+    if info_error is not None:
+        client.ft.return_value.info = AsyncMock(side_effect=info_error)
+    else:
+        client.ft.return_value.info = AsyncMock(return_value=info_result)
+    return AsyncSearchIndex(schema=_schema(), redis_client=client), client
+
+
+class TestExistsClassifiesRedisResponse:
+    """exists() must map FT.INFO outcomes to True, False, or an exception."""
+
+    @pytest.mark.parametrize("message", MISSING_INDEX_MESSAGES)
+    def test_missing_index_wording_returns_false(self, message):
+        index, _ = _sync_index(info_error=ResponseError(message))
+        assert index.exists() is False
+
+    @pytest.mark.parametrize("error", NON_MISSING_INDEX_ERRORS)
+    def test_other_failures_are_raised_not_reported_as_absent(self, error):
+        index, _ = _sync_index(info_error=error)
+        with pytest.raises(RedisSearchError):
+            index.exists()
+
+    def test_failure_on_index_named_after_a_wording_is_still_raised(self):
+        # _info() interpolates the index name into its message, so an index
+        # named after one of the wordings makes the *wrapper* look like an
+        # absence report. Classification therefore reads the original Redis
+        # error via __cause__; reading the wrapper would turn this permission
+        # error into exists() == False.
+        index, _ = _sync_index(
+            name="search_index_not_found",
+            info_error=ResponseError(
+                "User acl_user has no permissions to run the 'FT.INFO' command"
+            ),
+        )
+        with pytest.raises(RedisSearchError):
+            index.exists()
+
+    def test_index_name_resolving_elsewhere_returns_false(self):
+        # FT.INFO accepts an alias and answers for its target, so a successful
+        # reply naming a different index means this name is an alias, not an
+        # index. Reporting True would let create(overwrite=True, drop=True)
+        # drop the aliased index and its documents.
+        index, _ = _sync_index(info_result={"index_name": "some_other_index"})
+        assert index.exists() is False
+
+    # The async twin is a hand-maintained copy, so it needs its own witness for
+    # each branch -- but the branch logic itself is shared, so one wording is
+    # enough. Live servers cover the current wording via the integration suite;
+    # the newest one is only reachable here.
+    @pytest.mark.asyncio
+    async def test_async_missing_index_wording_returns_false(self):
+        index, _ = _async_index(info_error=ResponseError(MISSING_INDEX_MESSAGES[2]))
+        assert await index.exists() is False
+
+    @pytest.mark.asyncio
+    async def test_async_other_failures_are_raised(self):
+        index, _ = _async_index(info_error=NON_MISSING_INDEX_ERRORS[0])
+        with pytest.raises(RedisSearchError):
+            await index.exists()
+
+    @pytest.mark.asyncio
+    async def test_async_index_name_resolving_elsewhere_returns_false(self):
+        index, _ = _async_index(info_result={"index_name": "some_other_index"})
+        assert await index.exists() is False
+
+
+class TestExistsOnCluster:
+    """On a cluster, exists() must go through _info()'s node-targeted path.
+
+    Index metadata is cluster-wide, so any single node can answer -- but the
+    command has to carry target_nodes to get there. These are the only cluster
+    checks that run by default; the live cluster suite needs
+    --run-cluster-tests. Sync and async _info() each have their own cluster
+    branch, and exists() reaches both for the first time with this change.
+    """
+
+    def test_ft_info_is_routed_to_a_node(self):
+        node = Mock()
+        client = MagicMock(spec=RedisCluster)
+        client.get_random_node.return_value = node
+        client.execute_command.return_value = ["index_name", INDEX_NAME]
+        index = SearchIndex(schema=_schema(), redis_client=client)
+
+        assert index.exists() is True
+        client.execute_command.assert_called_once_with(
+            "FT.INFO", INDEX_NAME, target_nodes=node
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_ft_info_is_routed_to_a_node(self):
+        node = Mock()
+        client = MagicMock()
+        client.__class__ = AsyncRedisCluster  # isinstance drives the branch
+        client.get_random_node.return_value = node
+        client.execute_command = AsyncMock(return_value=["index_name", INDEX_NAME])
+        index = AsyncSearchIndex(schema=_schema(), redis_client=client)
+
+        assert await index.exists() is True
+        client.execute_command.assert_awaited_once_with(
+            "FT.INFO", INDEX_NAME, target_nodes=node
+        )


### PR DESCRIPTION
`exists()` asks a question about one index. It answered that question with `FT._LIST`, which returns the name of every index in the database, and then checked whether ours was in the list. That works — but it answers a narrow question with a broad command, and Redis prices the two differently.

`FT._LIST` is tagged `@admin`, alongside `@search` and `@slow`. `FT.INFO`, which reports on a single named index, is tagged `@search` only. ACL rules apply left to right, so a credential built the way least-privilege guidance recommends — grant what's needed, then take back administrative commands — loses `FT._LIST` while keeping `FT.INFO`:

```
+@all -@admin      →  FT._LIST denied,  FT.INFO allowed
+@search -@admin   →  FT._LIST denied,  FT.INFO allowed
```

`create()` checks `exists()` before it does anything else, and `SemanticCache`, `SemanticMessageHistory`, `MessageHistory`, and `SemanticRouter` all call `create()` while being constructed. So this wasn't a degraded mode users could route around — it was a hard failure on the first Redis call:

```
NoPermissionError: User <name> has no permissions to run the 'FT._LIST' command
```

This change points `exists()` at `FT.INFO`, reusing the existing `_info()` helper so it inherits that helper's cluster routing. `listall()`, which genuinely does need to enumerate the database, still uses `FT._LIST`.

**How narrow is this?** Narrower than it may look, and worth stating plainly so the fix isn't over-read. `FT._LIST` does not *require* `@admin` — granting `+@search` alone permits it. Only rules that explicitly subtract `@admin` after granting search were affected.

**Aliases, and why there's a name comparison.** `FT.INFO` accepts an index alias and answers for the index it points at. Left alone, that would make `exists()` return `True` for an alias — and because `create(overwrite=True, drop=True)` acts on that answer by issuing `FT.DROPINDEX <name> DD`, it would delete the aliased index and its documents. `exists()` therefore compares the `index_name` that `FT.INFO` returns against the schema's own name. `delete()` has the same hazard independently of this change and now carries a docstring warning; guarding it would cost a round-trip on every delete, so it's left as a follow-up.

**Classifying "missing".** Redis Search reports an absent index as an ordinary error reply, with wording that has changed between versions (`Unknown index name`, `<name>: no such index`, and `SEARCH_INDEX_NOT_FOUND Index not found:` as of 8.8). All known wordings now live in one shared predicate in `redisvl/exceptions.py`, replacing a duplicated copy in the MCP server. It reads `__cause__` rather than the wrapping `RedisSearchError`, whose message interpolates the index name — otherwise an index named after one of the wordings would make an unrelated failure look like an absence. Anything not recognised as a missing index is re-raised rather than reported as absence.

## Behaviour changes

- **`exists()` raises `RedisSearchError`** where it previously let raw `redis-py` exceptions escape. This makes `create()` uniform: it already wrapped every other Redis failure that way, and the existence check was the one path that leaked. Callers catching `redis.exceptions.ResponseError` around `create()` or an extension constructor should catch `RedisSearchError` and read `__cause__`.
- **A credential whose key patterns don't cover the index prefix** now gets a permission error instead of `True`, because `FT.INFO` is key-scoped and `FT._LIST` is not. Redis applies the same rule to `FT.SEARCH`, so such a credential could not have queried the index anyway.

## Tests

- `tests/unit/test_index_exists.py` — 13 cases covering the three branches for both twins, plus cluster `target_nodes` routing. They drive the real `_info()` rather than stubbing it, so the not-found match is exercised through that helper's message rewrapping. Mutation-checked: narrowing the predicate to one wording, replacing the `except` with a bare `return False`, deleting the `index_name` comparison, bypassing `_info()`, narrowing `_info()`'s `except`, and reading the wrapper instead of `__cause__` each fail specific cases.
- Two integration tests. One creates an ACL user with `+@all -@admin` and pins the premise with `pytest.raises(NoPermissionError)` on `FT._LIST`, so it can't silently go vacuous if Redis ever recategorises the command — it fails against the previous implementation with the original error. The other covers alias resolution. Verified on 8.2.7, 8.4.4, and 8.8.0.
- Four pre-existing assertions moved from a raw `FT._LIST` call to `listall()`, which had no direct coverage before.
- `test_no_proactive_module_checks.py` updated for the exception-type change above; it now also asserts the `redis-py` exception is chained.

## Docs

New "Redis permissions (ACLs)" section in `docs/user_guide/installation.md` with an operation-to-command table, a subsection on how Redis Cloud and Redis Software differ (both manage ACLs through their own control plane rather than `ACL SETUSER`), and a note that RedisVL's `CLIENT SETINFO`/`ECHO` identification step also needs permission. `docs/api/exceptions.rst` gains a section on telling a missing index apart from other failures. `docs/api/cli.rst` notes which commands `FT._LIST` gates.

## Not in scope

Sync `listall()` still lacks the cluster branch its async twin has. `delete()`'s alias hazard is documented but not guarded. `migration/utils.py` and `migration/async_executor.py` still have bare `except Exception: return False` blocks that this predicate would improve. Separately, `RedisConnectionFactory.get_redis_connection` cannot open a connection under an ACL that denies both `CLIENT SETINFO` and `ECHO`, because the fallback at `connection.py:550` is itself unguarded and `NoPermissionError` subclasses `ResponseError` — pre-existing, and filed separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core index lifecycle (`exists()` drives `create()` and several constructors) with new error semantics and alias handling; behavior shifts for restricted ACLs and key-scoped `FT.INFO`, but scope is focused and well tested.
> 
> **Overview**
> **`exists()`** on sync and async search indexes no longer calls **`FT._LIST`** (membership in the full index list). It uses **`FT.INFO`** via **`_info()`**, so least-privilege ACLs such as **`+@search -@admin`** can run **`create()`** and extension constructors that depend on **`exists()`**.
> 
> Missing-index detection is centralized in **`_is_missing_index_error()`** in **`redisvl/exceptions.py`** (version-specific Redis error text, matched on **`__cause__`**). **`exists()`** returns **`False`** only for those replies; permission and connection failures raise **`RedisSearchError`**. **`FT.INFO`** on an alias is treated as non-existent by comparing **`index_name`** from the response to the schema name, avoiding **`create(overwrite=True)`** dropping the aliased index.
> 
> **`listall()`** still uses **`FT._LIST`**. MCP reuses the shared missing-index helper. Docs add Redis ACL guidance, exception handling notes, and CLI notes for **`listall`** / migration discovery. Tests cover unit branches, ACL integration, and alias behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb00bb19f552f950fbe4f875413378847e9d2ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->