### PR TITLE
feat(mcp): add a locked-filter merge primitive to search-records

### DIFF
--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -367,6 +367,19 @@ def _find_range_end(rendered: str, position: int) -> int | None:
     return None
 
 
+def _span_holds_unescaped_pipe(rendered: str, start: int, end: int) -> bool:
+    """Report whether `rendered[start:end]` holds a `|` that is not escaped."""
+    position = start
+    while position < end:
+        if rendered[position] == "\\":
+            position += 2
+            continue
+        if rendered[position] == "|":
+            return True
+        position += 1
+    return False
+
+
 def _reject_escapable_filter(caller: FilterExpression) -> None:
     """Refuse a caller filter whose rendering could break out of a locked AND.
 
@@ -400,10 +413,17 @@ def _reject_escapable_filter(caller: FilterExpression) -> None:
         if character == "[":
             # A numeric range is bounds, not structure: an exclusive bound
             # renders as `[(5 +inf]`, where `(` is a marker rather than a group.
-            # Skip the whole span so those parens are never counted. Values
-            # inside are numbers, so no `|` can hide here.
+            # Skipping the span keeps those parens out of the depth count -- but
+            # suppressing paren depth is the *only* reason to skip, so `|`
+            # detection has to stay active inside it. A legitimate numeric or geo
+            # range holds numbers, so a `|` in here means a value reached the
+            # query string raw, which is exactly the case this backstop exists
+            # to catch; skipping past it would let a union hide behind brackets.
             end = _find_range_end(rendered, position + 1)
             if end is None:
+                escaped = True
+                break
+            if _span_holds_unescaped_pipe(rendered, position + 1, end):
                 escaped = True
                 break
             position = end + 1

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -7,6 +7,7 @@ from redisvl.mcp.config import reserved_score_metadata_field_names
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError, map_exception
 from redisvl.mcp.filters import parse_filter
 from redisvl.query import AggregateHybridQuery, HybridQuery, TextQuery, VectorQuery
+from redisvl.query.filter import FilterExpression
 from redisvl.schema import IndexSchema
 
 DEFAULT_SEARCH_DESCRIPTION = "Search records in the configured Redis index."
@@ -91,12 +92,18 @@ def _validate_request(
     return_fields: list[str] | None,
     runtime: Any,
     schema: Any,
+    limit_cap: int | None = None,
 ) -> tuple[int, list[str]]:
     """Validate a `search-records` request and resolve default projection.
 
     The MCP caller can only supply query text, pagination, filters, and return
     fields. Search mode and tuning are sourced from the selected binding's
     config, so this validation step focuses only on the public request contract.
+
+    ``limit_cap`` is a server-supplied ceiling from a custom tool profile. It has
+    to be applied here rather than in the caller, because an omitted ``limit``
+    resolves to the binding default at this point -- capping only the explicit
+    value would let the default sail past the cap.
     """
 
     if not isinstance(query, str) or not query.strip():
@@ -106,7 +113,20 @@ def _validate_request(
             retryable=False,
         )
 
-    effective_limit = runtime.default_limit if limit is None else limit
+    if limit is None:
+        # An unspecified limit is bounded silently: the caller never named a
+        # number, so there is nothing to reject.
+        effective_limit = runtime.default_limit
+        if limit_cap is not None:
+            effective_limit = min(effective_limit, limit_cap)
+    else:
+        effective_limit = limit
+        if limit_cap is not None and effective_limit > limit_cap:
+            raise RedisVLMCPError(
+                f"limit must be less than or equal to {limit_cap}",
+                code=MCPErrorCode.INVALID_REQUEST,
+                retryable=False,
+            )
     if not isinstance(effective_limit, int) or effective_limit <= 0:
         raise RedisVLMCPError(
             "limit must be greater than 0",
@@ -335,6 +355,128 @@ def _build_fallback_hybrid_kwargs(
     }
 
 
+def _find_range_end(rendered: str, position: int) -> int | None:
+    """Return the index of the `]` closing a numeric range, or None if unclosed."""
+    while position < len(rendered):
+        if rendered[position] == "\\":
+            position += 2
+            continue
+        if rendered[position] == "]":
+            return position
+        position += 1
+    return None
+
+
+def _reject_escapable_filter(caller: FilterExpression) -> None:
+    """Refuse a caller filter whose rendering could break out of a locked AND.
+
+    A well-formed expression built from escaped values cannot escape, so anything
+    this rejects means a value reached the query string unescaped. It is a
+    backstop, not the primary defense -- see ``merge_locked_filter``.
+    """
+    # Braces scope as much as parens do: a tag clause holds its alternatives in
+    # braces, so `@category:{sports|health}` is one scoped clause rather than a
+    # union. Counting parens alone would reject the most ordinary narrowing
+    # filter a caller can send.
+    openers = {"(", "{"}
+    closers = {")", "}"}
+
+    rendered = str(caller)
+    position = 0
+    depth = 0
+    escaped = False
+
+    while position < len(rendered):
+        character = rendered[position]
+
+        if character == "\\":
+            # Consume the pair. Checking whether the *previous* character was a
+            # backslash instead would misread `\\` -- a literal backslash -- as
+            # protecting whatever follows it, and a real delimiter after one
+            # would slip through unnoticed.
+            position += 2
+            continue
+
+        if character == "[":
+            # A numeric range is bounds, not structure: an exclusive bound
+            # renders as `[(5 +inf]`, where `(` is a marker rather than a group.
+            # Skip the whole span so those parens are never counted. Values
+            # inside are numbers, so no `|` can hide here.
+            end = _find_range_end(rendered, position + 1)
+            if end is None:
+                escaped = True
+                break
+            position = end + 1
+            continue
+
+        if character in openers:
+            depth += 1
+        elif character in closers:
+            depth -= 1
+            if depth < 0:
+                # Closed more than was opened, which would terminate the locked
+                # group early and leave the rest as bare syntax.
+                escaped = True
+                break
+        elif character == "]":
+            # Only reachable outside a range span, so the brackets are unbalanced.
+            escaped = True
+            break
+        elif character == "|" and depth == 0:
+            # Under DIALECT 2, `|` binds looser than the implicit intersection,
+            # so one at the top level turns `locked AND caller` into a union and
+            # the lock stops constraining anything.
+            escaped = True
+            break
+
+        position += 1
+
+    # Leftover depth means an unclosed group, which would swallow whatever the
+    # AND appends after it.
+    if escaped or depth != 0:
+        raise RedisVLMCPError(
+            "filter could not be safely combined with this tool's locked filter",
+            code=MCPErrorCode.INVALID_FILTER,
+            retryable=False,
+        )
+
+
+def merge_locked_filter(
+    locked: FilterExpression | None,
+    caller: str | FilterExpression | None,
+) -> str | FilterExpression | None:
+    """AND-combine an author-locked filter with a caller-supplied one.
+
+    The locked expression always applies, so a caller can only narrow within it
+    and never widen past it. That rests on two things: the caller's expression
+    rendering nested inside the AND, and every value staying inside its own
+    clause (which ``_parse_text_expression`` escaping provides).
+    """
+    if locked is None:
+        return caller
+    if caller is None:
+        return locked
+
+    if not isinstance(caller, FilterExpression):
+        # Strings skip the DSL's field validation and have no safe composition
+        # with an expression -- combining them means concatenation, where a
+        # crafted value can close the locked group and escape it.
+        raise RedisVLMCPError(
+            "filter must be an object when this tool locks a filter; "
+            "raw string filters cannot be combined with a locked filter",
+            code=MCPErrorCode.INVALID_FILTER,
+            retryable=False,
+        )
+
+    # Structure is necessary but not sufficient, so check the rendering too.
+    _reject_escapable_filter(caller)
+
+    # `__and__` wraps the pair and parenthesizes each compound side, so a
+    # caller's `or`/`not` cannot hoist itself to the top level. (Single clauses
+    # render bare; only compound sides could otherwise escape.)
+    return locked & caller
+
+
 async def _build_query(
     *,
     rt: Any,
@@ -343,6 +485,7 @@ async def _build_query(
     offset: int,
     filter_value: str | dict[str, Any] | None,
     return_fields: list[str],
+    locked_filter: FilterExpression | None = None,
 ) -> tuple[Any, str, str, str]:
     """Build the RedisVL query object from the binding's search mode and params.
 
@@ -352,7 +495,9 @@ async def _build_query(
     runtime = rt.binding.runtime
     search_type, search_params = _get_configured_search(rt)
     num_results = limit + offset
-    filter_expression = parse_filter(filter_value, rt.schema)
+    filter_expression = merge_locked_filter(
+        locked_filter, parse_filter(filter_value, rt.schema)
+    )
 
     if search_type == "vector":
         if runtime.vector_field_name is None:
@@ -446,6 +591,8 @@ async def search_records(
     offset: int = 0,
     filter: str | dict[str, Any] | None = None,
     return_fields: list[str] | None = None,
+    locked_filter: FilterExpression | None = None,
+    limit_cap: int | None = None,
 ) -> dict[str, Any]:
     """Execute `search-records` against the selected Redis index binding.
 
@@ -453,6 +600,12 @@ async def search_records(
     one binding is configured (preserving single-index behavior) and required
     when multiple bindings exist. The resolved logical id is echoed back in the
     response so multi-index clients can confirm routing.
+
+    ``locked_filter`` and ``limit_cap`` are server-supplied and never reach the
+    model: they are how a caller in-process pins an author-locked expression and
+    result ceiling onto this tool. The filter is AND-combined with ``filter`` so
+    a caller can only narrow within it, and the cap bounds the effective limit
+    whether the caller named one or fell through to the binding default.
     """
     try:
         rt = server.resolve_binding(index)
@@ -463,6 +616,7 @@ async def search_records(
             return_fields=return_fields,
             runtime=rt.binding.runtime,
             schema=rt.schema,
+            limit_cap=limit_cap,
         )
         built_query, score_field, score_type, search_type = await _build_query(
             rt=rt,
@@ -471,6 +625,7 @@ async def search_records(
             offset=offset,
             filter_value=filter,
             return_fields=effective_return_fields,
+            locked_filter=locked_filter,
         )
         raw_results = await server.run_guarded(
             "search-records",

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -299,6 +299,10 @@ def test_merge_locked_filter_ands_a_multi_value_tag_in_caller_filter():
         # A literal backslash does NOT escape what follows it, so this `|` is a
         # real union. Looking back one character would misread it as escaped.
         ("literal backslash then pipe", "@category:{a}\\\\|@category:{secret}"),
+        # The `[...]` span is skipped so an exclusive bound's `(` is not counted
+        # as a group. Skipping the span wholesale would also skip a `|` inside it,
+        # letting a union hide behind brackets.
+        ("pipe hidden inside a range span", "@rating:[4 | @category:{secret}]"),
     ],
 )
 def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
@@ -378,3 +382,26 @@ def test_merge_locked_filter_returns_each_side_unchanged_when_the_other_is_absen
     assert merge_locked_filter(None, "@category:{open}") == "@category:{open}"
     # A lock with no caller filter applies on its own.
     assert merge_locked_filter(locked, None) is locked
+
+
+@pytest.mark.parametrize(
+    ("label", "rendered"),
+    [
+        # The reason the span is skipped at all: `(` here is an exclusive-bound
+        # marker, not a group, so counting it would reject a legitimate range.
+        ("exclusive lower bound", "@rating:[(5 +inf]"),
+        ("exclusive upper bound", "@rating:[-inf (5]"),
+        ("plain inclusive range", "@rating:[4 +inf]"),
+    ],
+)
+def test_merge_locked_filter_still_accepts_legitimate_range_bounds(label, rendered):
+    """Narrowing the range skip to parens must not start rejecting real ranges."""
+    del label
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "science"}, _schema()
+    )
+
+    merged = merge_locked_filter(locked, FilterExpression(rendered))
+
+    assert isinstance(merged, FilterExpression)
+    assert "@category:{science}" in str(merged)

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -3,6 +3,7 @@ from conftest import _schema
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.filters import parse_filter
+from redisvl.mcp.tools.search import merge_locked_filter
 from redisvl.query.filter import FilterExpression, Text
 
 
@@ -201,3 +202,179 @@ def test_parse_filter_like_still_escapes_clause_delimiters():
     # within `content` rather than splitting the whole expression.
     assert skeleton.index("|") > skeleton.index("(")
     assert skeleton.index("|") < skeleton.rindex(")")
+
+
+# --------------------------------------------------------------------------
+# Caller shapes merged under a locked filter
+#
+# The merge is the security boundary for custom tool profiles: whatever the
+# caller sends must end up ANDed *under* the locked clause rather than beside or
+# instead of it. The caller shapes below are enumerated because they reach `&` as
+# different renderings -- a single clause, a parenthesized AND, a parenthesized
+# OR chain, a negation, a missing-field check -- and only the compound ones could
+# hoist themselves out of the AND.
+#
+# The locked side is a single shape rather than a second axis. Nothing in the
+# merge inspects it: the guard is `_reject_escapable_filter(caller)`, which takes
+# only the caller's rendering, so the locked shape cannot change whether a caller
+# shape is accepted. A compound AND is the one kept because it is the locked
+# shape most likely to be damaged by a careless merge -- it arrives already
+# parenthesized, so a merge that concatenated instead of nesting would show here.
+# --------------------------------------------------------------------------
+
+_LOCKED_SHAPE = {
+    "and": [
+        {"field": "category", "op": "eq", "value": "resolved"},
+        {"field": "rating", "op": "gte", "value": 3},
+    ]
+}
+
+_CALLER_SHAPES = {
+    "not": {"not": {"field": "category", "op": "eq", "value": "sports"}},
+    "and": {
+        "and": [
+            {"field": "rating", "op": "gte", "value": 4},
+            {"field": "content", "op": "like", "value": "jam*"},
+        ]
+    },
+    # Text and numeric `in` expand to an OR chain, so they reach `&` already
+    # parenthesized -- a different shape from the single-clause cases above.
+    "text_in": {"field": "content", "op": "in", "value": ["jam", "jelly"]},
+    "numeric_in": {"field": "rating", "op": "in", "value": [3, 5]},
+    "exists": {"field": "content", "op": "exists"},
+}
+
+
+@pytest.mark.parametrize("caller_shape", sorted(_CALLER_SHAPES))
+def test_merge_locked_filter_ands_every_caller_shape_under_the_locked_filter(
+    caller_shape,
+):
+    locked = parse_filter(_LOCKED_SHAPE, _schema())
+    caller = parse_filter(_CALLER_SHAPES[caller_shape], _schema())
+
+    merged = merge_locked_filter(locked, caller)
+
+    # Never a bare string: a string cannot be safely combined further, and a
+    # profile that received one back would have lost the composability the lock
+    # depends on.
+    assert isinstance(merged, FilterExpression)
+    # The merge is exactly the AND of the two sides as each renders on its own.
+    # That pins both halves of the guarantee at once: the locked clause is
+    # unchanged and still at the top level of the AND, and the caller's side is
+    # reproduced verbatim beside it -- fully parenthesized when compound, so
+    # neither its `|` nor its `-` can reach the top level and widen the scope.
+    assert str(merged) == f"({locked} {caller})"
+
+
+def test_merge_locked_filter_ands_a_multi_value_tag_in_caller_filter():
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "resolved"}, _schema()
+    )
+    caller = parse_filter(
+        {"field": "category", "op": "in", "value": ["sports", "health"]}, _schema()
+    )
+
+    # Tag `in` is the one caller shape that collapses to a SINGLE clause,
+    # `@category:{sports|health}`, instead of expanding to an OR chain the way
+    # text and numeric `in` do. The `|` is scoped by the tag braces and cannot
+    # widen past an enclosing AND, so this is a legitimate narrowing filter and
+    # should merge like any other clause.
+    merged = merge_locked_filter(locked, caller)
+
+    assert isinstance(merged, FilterExpression)
+    assert str(merged) == "(@category:{resolved} @category:{sports|health})"
+
+
+# --------------------------------------------------------------------------
+# The escape backstop -- what it refuses, not just what it lets through
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "rendered"),
+    [
+        ("stray close paren", "@content:(a) | (-@category:{secret})"),
+        ("unclosed group", "@content:(a( | (-@category:{secret})"),
+        ("stray close brace", "@category:{a} | @category:{secret}"),
+        # A literal backslash does NOT escape what follows it, so this `|` is a
+        # real union. Looking back one character would misread it as escaped.
+        ("literal backslash then pipe", "@category:{a}\\\\|@category:{secret}"),
+    ],
+)
+def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
+    label, rendered
+):
+    del label
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "science"}, _schema()
+    )
+
+    # Simulates a field type that renders a value unescaped. Text values are
+    # escaped today, so this path is unreachable through the DSL -- which is
+    # exactly why it needs an explicit test: without one, deleting the guard
+    # leaves the whole suite green.
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        merge_locked_filter(locked, FilterExpression(rendered))
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+
+
+@pytest.mark.parametrize(
+    ("label", "caller_filter"),
+    [
+        ("exclusive lower bound", {"field": "rating", "op": "gt", "value": 4}),
+        ("exclusive upper bound", {"field": "rating", "op": "lt", "value": 4}),
+        ("trailing backslash", {"field": "category", "op": "eq", "value": "ns\\\\"}),
+        (
+            "windows path",
+            {"field": "content", "op": "like", "value": "C:\\\\Users\\\\"},
+        ),
+        (
+            "compound with exclusive bound",
+            {
+                "and": [
+                    {"field": "category", "op": "eq", "value": "science"},
+                    {"field": "rating", "op": "gt", "value": 4},
+                ]
+            },
+        ),
+    ],
+)
+def test_merge_locked_filter_accepts_legitimate_narrowing_shapes(label, caller_filter):
+    del label
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "science"}, _schema()
+    )
+    caller = parse_filter(caller_filter, _schema())
+
+    # An exclusive numeric bound renders `[(4 +inf]` and an escaped value can end
+    # in a backslash. Neither is an escape, and refusing them would block the most
+    # ordinary narrowing a caller can ask for.
+    merged = merge_locked_filter(locked, caller)
+
+    assert isinstance(merged, FilterExpression)
+    assert "@category:{science}" in str(merged)
+
+
+def test_merge_locked_filter_rejects_a_raw_string_caller_filter_against_a_lock():
+    locked = parse_filter(_LOCKED_SHAPE, _schema())
+
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        merge_locked_filter(locked, "@category:{open}")
+
+    # A string has no safe composition with an expression: concatenating could
+    # close the locked group and escape the scope entirely.
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+    assert exc_info.value.retryable is False
+
+
+def test_merge_locked_filter_returns_each_side_unchanged_when_the_other_is_absent():
+    caller = parse_filter({"field": "category", "op": "eq", "value": "open"}, _schema())
+    locked = parse_filter(_LOCKED_SHAPE, _schema())
+
+    # No lock means the built-in's own behavior, including the raw-string form
+    # that a locked filter has to refuse.
+    assert merge_locked_filter(None, caller) is caller
+    assert merge_locked_filter(None, "@category:{open}") == "@category:{open}"
+    # A lock with no caller filter applies on its own.
+    assert merge_locked_filter(locked, None) is locked

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -16,6 +16,7 @@ from redisvl.mcp.tools.search import (
     search_records,
 )
 from redisvl.query import VectorQuery
+from redisvl.query.filter import Tag
 from redisvl.schema import IndexSchema
 
 
@@ -948,3 +949,105 @@ def test_empty_default_projection_still_yields_a_return_clause():
     assert "RETURN" in rendered
     # And what it returns is the score, not the embedding.
     assert "embedding" not in rendered.split("RETURN", 1)[1]
+
+
+# --------------------------------------------------------------------------
+# Server-supplied narrowing: `limit_cap` and `locked_filter`
+#
+# Both are passed in-process rather than by the model. They are exercised here
+# at the `search_records` boundary so the contract holds regardless of which
+# caller supplies them.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_records_rejects_an_explicit_limit_above_the_cap():
+    server = FakeServer()
+
+    with pytest.raises(RedisVLMCPError, match="less than or equal to 2") as exc:
+        await search_records(server, query="science", limit=3, limit_cap=2)
+
+    assert exc.value.code == MCPErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_search_records_caps_an_omitted_limit_instead_of_rejecting(monkeypatch):
+    """The binding default must not sail past the cap just because it is implicit."""
+    # default_limit is 2 and the cap is 1, so a cap applied only to explicit
+    # limits would let this request through at 2.
+    server = FakeServer()
+    built_queries = []
+
+    class FakeVectorQuery(FakeQuery):
+        def __init__(self, **kwargs):
+            built_queries.append(kwargs)
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.VectorQuery", FakeVectorQuery)
+
+    await search_records(server, query="science", limit_cap=1)
+
+    # No exception: the caller never named a number, so there is nothing to
+    # reject -- but the window is still bounded by the cap.
+    assert built_queries[0]["num_results"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_records_leaves_the_limit_alone_when_no_cap_is_supplied(
+    monkeypatch,
+):
+    server = FakeServer()
+    built_queries = []
+
+    class FakeVectorQuery(FakeQuery):
+        def __init__(self, **kwargs):
+            built_queries.append(kwargs)
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.VectorQuery", FakeVectorQuery)
+
+    await search_records(server, query="science", limit=3)
+
+    assert built_queries[0]["num_results"] == 3
+
+
+@pytest.mark.asyncio
+async def test_search_records_ands_a_locked_filter_under_the_caller_filter(monkeypatch):
+    server = FakeServer()
+    built_queries = []
+
+    class FakeVectorQuery(FakeQuery):
+        def __init__(self, **kwargs):
+            built_queries.append(kwargs)
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.VectorQuery", FakeVectorQuery)
+
+    await search_records(
+        server,
+        query="science",
+        filter={"field": "rating", "op": "gte", "value": 4},
+        locked_filter=Tag("category") == "resolved",
+    )
+
+    rendered = str(built_queries[0]["filter_expression"])
+    # Both clauses survive, and the caller's is nested rather than replacing the
+    # lock.
+    assert "@category:{resolved}" in rendered
+    assert "@rating:[4 +inf]" in rendered
+
+
+@pytest.mark.asyncio
+async def test_search_records_refuses_a_raw_string_filter_under_a_locked_filter():
+    server = FakeServer()
+
+    with pytest.raises(RedisVLMCPError) as exc:
+        await search_records(
+            server,
+            query="science",
+            filter="@category:{open}",
+            locked_filter=Tag("category") == "resolved",
+        )
+
+    # Strings bypass the DSL's field validation and cannot be safely composed.
+    assert exc.value.code == MCPErrorCode.INVALID_FILTER


### PR DESCRIPTION
**Stack position: 1 of 3.** Base is the `feat/mcp-custom-tool-profiles` integration branch, not `main` — see the sequencing note at the bottom.

Groundwork for custom tool profiles, split out on its own because it is the security crux of that feature and deserves attention it would not get buried in a 1,900-line PR. **Nothing calls the new parameters yet.**

## What it does

`merge_locked_filter(locked, caller)` AND-combines an author-locked filter expression with a caller-supplied one, so a caller can only narrow within the locked scope and never widen past it. That rests on two things: `FilterExpression.__and__` parenthesizing the combination, so a caller's `or`/`not` nests inside the AND rather than reaching the top level; and every filter value staying inside its own clause, which the text escaping already on `main` provides.

A raw string caller filter is refused outright — strings skip the DSL's field validation and have no safe composition with an expression, since combining them means concatenation.

## The backstop, and why it walks the rendering

`_reject_escapable_filter` sits behind that as a backstop, not the primary defense: a well-formed expression built from escaped values cannot escape, so anything it rejects means a value reached the query string raw.

It walks the rendered string rather than counting delimiters, because several things look like structure and are not:

- `\(` is an escaped literal, not a group
- a numeric range renders exclusive bounds as `[(5 +inf]`, where `(` is a marker
- a tag clause scopes its alternatives in braces, so `@category:{sports|health}` is one clause rather than a union

Escape pairs are consumed rather than tested against the previous character, so `\\|` is not misread as a protected delimiter. Both directions of that were wrong in earlier drafts, which is the main reason this is its own PR.

## `limit_cap`

Applied inside `_validate_request` rather than by the caller, because an omitted `limit` only resolves to the binding default at that point — capping just the explicit value would let the default sail past the cap. An explicit request above the cap is rejected; an omitted one is capped silently, since the caller never named a number.

## Not exposed to the model

Both parameters are keyword-only on `search_records` and never reach the advertised MCP schema: `register_search_tool` registers an inner wrapper with its own fixed signature. I verified that rather than assuming it.

## Verification

- MCP unit tests: 276 passing
- `make check-types`: clean
- The backstop accepts every legitimate `like` pattern (multi-word AND, `%` fuzzy, wildcards, in-clause `|`) while keeping the locked clause intact on an injection attempt

## Sequencing

This targets the integration branch so that `main` never receives a config surface that validates but enforces nothing — see the next PR in the stack for why that matters. The integration branch currently also carries #668; once that merges it rebases onto `main` and drops out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive filter composition for future profile enforcement; behavior is well-tested and not yet exposed to models, but mistakes in merge/backstop logic could allow filter bypass once profiles land.
> 
> **Overview**
> Adds **server-only** hooks on `search_records` for upcoming custom tool profiles: **`locked_filter`** AND-combined with the caller’s `filter`, and **`limit_cap`** applied in `_validate_request`. Neither is exposed on the registered MCP tool wrapper.
> 
> **`merge_locked_filter`** keeps the author lock always in force so callers can only narrow. Object filters are merged via `FilterExpression.__and__`; raw string caller filters are rejected. **`_reject_escapable_filter`** walks the caller’s rendered query as a backstop (top-level `|`, unbalanced groups/braces, pipes inside numeric ranges, etc.) so crafted renderings cannot break out of the locked AND.
> 
> **`limit_cap`**: explicit limits above the cap fail with `INVALID_REQUEST`; omitted limits are silently `min(default_limit, cap)` so binding defaults cannot bypass the ceiling.
> 
> Extensive unit tests cover merge shapes, escape cases, and `search_records` integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561da31551e25a6359aef6e00848446cadcd66bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->