### PR TITLE
fix: do not fail connection setup when ACL denies both CLIENT SETINFO and ECHO

### DIFF
--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -551,7 +551,9 @@ class RedisConnectionFactory:
                 try:
                     client.echo(_lib_name)
                 except ResponseError as e:
-                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
+                    logger.debug(
+                        f"Failed to echo lib_name due to ACL restrictions: {e}"
+                    )
         return client
 
     @staticmethod
@@ -613,7 +615,9 @@ class RedisConnectionFactory:
                 try:
                     await client.echo(_lib_name)
                 except ResponseError as e:
-                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
+                    logger.debug(
+                        f"Failed to echo lib_name due to ACL restrictions: {e}"
+                    )
         return client
 
     @staticmethod
@@ -745,7 +749,9 @@ class RedisConnectionFactory:
                 try:
                     redis_client.echo(_lib_name)
                 except ResponseError as e:
-                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
+                    logger.debug(
+                        f"Failed to echo lib_name due to ACL restrictions: {e}"
+                    )
 
         # Module validation removed - operations will fail naturally if modules are missing
 
@@ -773,7 +779,9 @@ class RedisConnectionFactory:
                 try:
                     await redis_client.echo(_lib_name)
                 except ResponseError as e:
-                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
+                    logger.debug(
+                        f"Failed to echo lib_name due to ACL restrictions: {e}"
+                    )
 
         # Module validation removed - operations will fail naturally if modules are missing
 

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -548,7 +548,10 @@ class RedisConnectionFactory:
         except ResponseError:
             # Fall back to a simple log echo
             if hasattr(client, "echo"):
-                client.echo(_lib_name)
+                try:
+                    client.echo(_lib_name)
+                except ResponseError as e:
+                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
         return client
 
     @staticmethod
@@ -607,7 +610,10 @@ class RedisConnectionFactory:
         except ResponseError:
             # Fall back to a simple log echo
             if hasattr(client, "echo"):
-                await client.echo(_lib_name)
+                try:
+                    await client.echo(_lib_name)
+                except ResponseError as e:
+                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
         return client
 
     @staticmethod
@@ -736,7 +742,10 @@ class RedisConnectionFactory:
             # Fall back to a simple log echo
             # For RedisCluster, echo is not available
             if hasattr(redis_client, "echo"):
-                redis_client.echo(_lib_name)
+                try:
+                    redis_client.echo(_lib_name)
+                except ResponseError as e:
+                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
 
         # Module validation removed - operations will fail naturally if modules are missing
 
@@ -761,7 +770,10 @@ class RedisConnectionFactory:
         except ResponseError:
             # Fall back to a simple log echo
             if hasattr(redis_client, "echo"):
-                await redis_client.echo(_lib_name)
+                try:
+                    await redis_client.echo(_lib_name)
+                except ResponseError as e:
+                    logger.debug(f"Failed to echo lib_name due to ACL restrictions: {e}")
 
         # Module validation removed - operations will fail naturally if modules are missing
 

--- a/tests/unit/test_connection_acl.py
+++ b/tests/unit/test_connection_acl.py
@@ -1,62 +1,90 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ResponseError
 
 from redisvl.redis.connection import RedisConnectionFactory
 
 
 def test_get_redis_connection_acl_fallback_denied():
+    """Connection setup must survive an ACL that denies CLIENT SETINFO and ECHO."""
     mock_client = MagicMock()
-    mock_client.client_setinfo.side_effect = ResponseError("NOPERM client setinfo denied")
+    mock_client.client_setinfo.side_effect = ResponseError(
+        "NOPERM client setinfo denied"
+    )
     mock_client.echo.side_effect = ResponseError("NOPERM echo denied")
 
     with patch("redisvl.redis.connection.Redis.from_url", return_value=mock_client):
-        # Should not raise exception even when both client_setinfo and echo fail with ACL ResponseError
         client = RedisConnectionFactory.get_redis_connection("redis://localhost:6379")
-        assert client == mock_client
-        mock_client.client_setinfo.assert_called_once()
-        mock_client.echo.assert_called_once()
+
+    assert client == mock_client
+    mock_client.client_setinfo.assert_called_once()
+    mock_client.echo.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_get_aredis_connection_acl_fallback_denied():
+    """The async factory must behave identically to the sync one."""
     mock_client = MagicMock()
-    mock_client.client_setinfo = AsyncMock(side_effect=ResponseError("NOPERM client setinfo denied"))
+    mock_client.client_setinfo = AsyncMock(
+        side_effect=ResponseError("NOPERM client setinfo denied")
+    )
     mock_client.echo = AsyncMock(side_effect=ResponseError("NOPERM echo denied"))
 
-    with patch("redisvl.redis.connection.AsyncRedis.from_url", return_value=mock_client):
-        client = await RedisConnectionFactory._get_aredis_connection("redis://localhost:6379")
-        assert client == mock_client
-        mock_client.client_setinfo.assert_called_once()
-        mock_client.echo.assert_called_once()
+    with patch(
+        "redisvl.redis.connection.AsyncRedis.from_url", return_value=mock_client
+    ):
+        client = await RedisConnectionFactory._get_aredis_connection(
+            "redis://localhost:6379"
+        )
+
+    assert client == mock_client
+    mock_client.client_setinfo.assert_called_once()
+    mock_client.echo.assert_called_once()
 
 
 def test_validate_sync_redis_acl_fallback_denied():
-    mock_client = MagicMock()
-    # Ensure issubclass check passes by mocking type or using Redis subclass
-    from redis import Redis
-    class MockRedis(Redis):
-        pass
+    """validate_sync_redis must not propagate a denied ECHO fallback.
 
-    mock_client = MagicMock(spec=MockRedis)
-    mock_client.client_setinfo.side_effect = ResponseError("NOPERM client setinfo denied")
-    mock_client.echo.side_effect = ResponseError("NOPERM echo denied")
+    A real ``Redis`` instance is used because ``validate_sync_redis`` gates on
+    ``issubclass(type(redis_client), ...)``, which a ``MagicMock(spec=Redis)``
+    does not satisfy. Construction does not open a socket, and both commands are
+    patched, so no server is contacted.
+    """
+    client = Redis(host="localhost", port=6379)
 
-    RedisConnectionFactory.validate_sync_redis(mock_client)
-    mock_client.client_setinfo.assert_called_once()
-    mock_client.echo.assert_called_once()
+    with (
+        patch.object(
+            client, "client_setinfo", side_effect=ResponseError("NOPERM setinfo denied")
+        ) as setinfo,
+        patch.object(
+            client, "echo", side_effect=ResponseError("NOPERM echo denied")
+        ) as echo,
+    ):
+        RedisConnectionFactory.validate_sync_redis(client)
+
+    setinfo.assert_called_once()
+    echo.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_validate_async_redis_acl_fallback_denied():
-    from redis.asyncio import Redis as AsyncRedis
-    class MockAsyncRedis(AsyncRedis):
-        pass
+    """validate_async_redis must not propagate a denied ECHO fallback."""
+    client = AsyncRedis(host="localhost", port=6379)
 
-    mock_client = MagicMock(spec=MockAsyncRedis)
-    mock_client.client_setinfo = AsyncMock(side_effect=ResponseError("NOPERM client setinfo denied"))
-    mock_client.echo = AsyncMock(side_effect=ResponseError("NOPERM echo denied"))
+    with (
+        patch.object(
+            client,
+            "client_setinfo",
+            AsyncMock(side_effect=ResponseError("NOPERM setinfo denied")),
+        ) as setinfo,
+        patch.object(
+            client, "echo", AsyncMock(side_effect=ResponseError("NOPERM echo denied"))
+        ) as echo,
+    ):
+        await RedisConnectionFactory.validate_async_redis(client)
 
-    await RedisConnectionFactory.validate_async_redis(mock_client)
-    mock_client.client_setinfo.assert_called_once()
-    mock_client.echo.assert_called_once()
+    setinfo.assert_called_once()
+    echo.assert_called_once()

--- a/tests/unit/test_connection_acl.py
+++ b/tests/unit/test_connection_acl.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from redis.exceptions import ResponseError
+
+from redisvl.redis.connection import RedisConnectionFactory
+
+
+def test_get_redis_connection_acl_fallback_denied():
+    mock_client = MagicMock()
+    mock_client.client_setinfo.side_effect = ResponseError("NOPERM client setinfo denied")
+    mock_client.echo.side_effect = ResponseError("NOPERM echo denied")
+
+    with patch("redisvl.redis.connection.Redis.from_url", return_value=mock_client):
+        # Should not raise exception even when both client_setinfo and echo fail with ACL ResponseError
+        client = RedisConnectionFactory.get_redis_connection("redis://localhost:6379")
+        assert client == mock_client
+        mock_client.client_setinfo.assert_called_once()
+        mock_client.echo.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_aredis_connection_acl_fallback_denied():
+    mock_client = MagicMock()
+    mock_client.client_setinfo = AsyncMock(side_effect=ResponseError("NOPERM client setinfo denied"))
+    mock_client.echo = AsyncMock(side_effect=ResponseError("NOPERM echo denied"))
+
+    with patch("redisvl.redis.connection.AsyncRedis.from_url", return_value=mock_client):
+        client = await RedisConnectionFactory._get_aredis_connection("redis://localhost:6379")
+        assert client == mock_client
+        mock_client.client_setinfo.assert_called_once()
+        mock_client.echo.assert_called_once()
+
+
+def test_validate_sync_redis_acl_fallback_denied():
+    mock_client = MagicMock()
+    # Ensure issubclass check passes by mocking type or using Redis subclass
+    from redis import Redis
+    class MockRedis(Redis):
+        pass
+
+    mock_client = MagicMock(spec=MockRedis)
+    mock_client.client_setinfo.side_effect = ResponseError("NOPERM client setinfo denied")
+    mock_client.echo.side_effect = ResponseError("NOPERM echo denied")
+
+    RedisConnectionFactory.validate_sync_redis(mock_client)
+    mock_client.client_setinfo.assert_called_once()
+    mock_client.echo.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_validate_async_redis_acl_fallback_denied():
+    from redis.asyncio import Redis as AsyncRedis
+    class MockAsyncRedis(AsyncRedis):
+        pass
+
+    mock_client = MagicMock(spec=MockAsyncRedis)
+    mock_client.client_setinfo = AsyncMock(side_effect=ResponseError("NOPERM client setinfo denied"))
+    mock_client.echo = AsyncMock(side_effect=ResponseError("NOPERM echo denied"))
+
+    await RedisConnectionFactory.validate_async_redis(mock_client)
+    mock_client.client_setinfo.assert_called_once()
+    mock_client.echo.assert_called_once()


### PR DESCRIPTION
Fixes #673

Client identification is best-effort telemetry, so it should never be the reason a connection cannot be created. Today it can be.

`NoPermissionError` subclasses `ResponseError`, so an ACL user denied `CLIENT SETINFO` lands in the `except ResponseError` branch as intended — but the `echo` fallback inside that branch is not itself guarded. If the same ACL also denies `ECHO`, the second `NoPermissionError` propagates straight out of connection setup, and the user sees a confusing message about the `echo` command when all they did was connect.

The same unguarded-fallback shape appears in four places in `redisvl/redis/connection.py`, so all four are fixed:

- `RedisConnectionFactory.get_redis_connection`
- `RedisConnectionFactory._get_aredis_connection`
- `RedisConnectionFactory.validate_sync_redis`
- `RedisConnectionFactory.validate_async_redis`

Each fallback `echo` is now wrapped in its own `try`/`except ResponseError` that logs at debug level and continues. No other behaviour changes: a client whose ACL permits either command still gets its library name set exactly as before.

`tests/unit/test_connection_acl.py` covers all four entry points. The two `validate_*` tests construct real `Redis`/`AsyncRedis` instances rather than mocks, because `validate_sync_redis` gates on `issubclass(type(redis_client), ...)`, which a `MagicMock(spec=Redis)` does not satisfy — construction opens no socket and both commands are patched, so no server is contacted.

Verified the tests fail against unmodified `main` (4 failed) and pass with the change (4 passed). Full unit suite is green, and `isort --profile black` / `black --target-version py311` report no changes.

Happy to fold the four guards into one shared private helper if you would prefer that shape — I kept the diff local so the fix is easy to read.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change around best-effort client identification; successful paths unchanged and covered by new unit tests.
> 
> **Overview**
> **Connection setup no longer fails** when Redis ACL denies both `CLIENT SETINFO` and the `ECHO` fallback used for library-name telemetry.
> 
> After `client_setinfo` raises `ResponseError`, the existing `echo` fallback in `get_redis_connection`, `_get_aredis_connection`, `validate_sync_redis`, and `validate_async_redis` is now wrapped in its own `try`/`except ResponseError`. Denied `ECHO` is logged at debug and setup continues; behavior is unchanged when either command is allowed.
> 
> Adds `tests/unit/test_connection_acl.py` with four unit tests (sync/async factory and validate paths) asserting both commands are attempted without raising.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d54097a1cdf3be8187d6bd52aec0a68cf36191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->