### PR TITLE
feat: add delete_where()/adelete_where() and share batching internals with clear()

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -1149,9 +1149,7 @@ class SearchIndex(BaseSearchIndex):
         batch_size: int = DEFAULT_BULK_BATCH_SIZE,
     ) -> int:
         filter_expr = (
-            FilterExpression("*")
-            if filter_expression is None
-            else filter_expression
+            FilterExpression("*") if filter_expression is None else filter_expression
         )
         matched_count = cast(int, self.query(CountQuery(filter_expr)))
         max_ratio = 1.01
@@ -2511,9 +2509,7 @@ class AsyncSearchIndex(BaseSearchIndex):
         batch_size: int = DEFAULT_BULK_BATCH_SIZE,
     ) -> int:
         filter_expr = (
-            FilterExpression("*")
-            if filter_expression is None
-            else filter_expression
+            FilterExpression("*") if filter_expression is None else filter_expression
         )
         matched_count = cast(int, await self.query(CountQuery(filter_expr)))
         max_ratio = 1.01

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -1143,26 +1143,22 @@ class SearchIndex(BaseSearchIndex):
             records_deleted_in_batch = cast(int, client.delete(*batch_keys))
         return records_deleted_in_batch
 
-    def clear(self) -> int:
-        """Clear all keys in Redis associated with the index, leaving the index
-        available and in-place for future insertions or updates.
-
-        NOTE: This method requires custom behavior for Redis Cluster because
-        here, we can't easily give control of the keys we're clearing to the
-        user so they can separate them based on hash tag.
-
-        Returns:
-            int: Count of records deleted from Redis.
-        """
-        batch_size = 500
+    def _delete_where(
+        self,
+        filter_expression: str | FilterExpression | None = None,
+        batch_size: int = DEFAULT_BULK_BATCH_SIZE,
+    ) -> int:
+        filter_expr = (
+            FilterExpression("*")
+            if filter_expression is None
+            else filter_expression
+        )
+        matched_count = cast(int, self.query(CountQuery(filter_expr)))
         max_ratio = 1.01
-
-        info = self.info()
-        max_records_deleted = ceil(
-            info["num_docs"] * max_ratio
-        )  # Allow to remove some additional concurrent inserts
+        max_records_deleted = ceil(matched_count * max_ratio)
         total_records_deleted: int = 0
-        query = FilterQuery(FilterExpression("*"), return_fields=["id"])
+
+        query = FilterQuery(filter_expr, return_fields=["id"])
         query.paging(0, batch_size)
 
         while True:
@@ -1175,6 +1171,38 @@ class SearchIndex(BaseSearchIndex):
 
         self.invalidate_sql_schema_cache()
         return total_records_deleted
+
+    def delete_where(
+        self,
+        filter_expression: str | FilterExpression | None = None,
+        batch_size: int = DEFAULT_BULK_BATCH_SIZE,
+    ) -> int:
+        """Delete documents matching a filter expression.
+
+        Args:
+            filter_expression (Union[str, FilterExpression, None]): Selects the
+                documents to delete. Defaults to None (all documents).
+            batch_size (int): Number of documents to resolve and delete per round-trip.
+
+        Returns:
+            int: Count of records deleted from Redis.
+        """
+        return self._delete_where(
+            filter_expression=filter_expression, batch_size=batch_size
+        )
+
+    def clear(self) -> int:
+        """Clear all keys in Redis associated with the index, leaving the index
+        available and in-place for future insertions or updates.
+
+        NOTE: This method requires custom behavior for Redis Cluster because here,
+        we can't easily give control of the keys we're clearing to the user so they
+        can separate them based on hash tag.
+
+        Returns:
+            int: Count of records deleted from Redis.
+        """
+        return self._delete_where(FilterExpression("*"))
 
     def invalidate_sql_schema_cache(self) -> None:
         """Clear cached sql-redis executors and schema state for this index."""
@@ -2477,26 +2505,22 @@ class AsyncSearchIndex(BaseSearchIndex):
             records_deleted_in_batch = await client.delete(*batch_keys)
         return records_deleted_in_batch
 
-    async def clear(self) -> int:
-        """Clear all keys in Redis associated with the index, leaving the index
-        available and in-place for future insertions or updates.
-
-        NOTE: This method requires custom behavior for Redis Cluster because here,
-        we can't easily give control of the keys we're clearing to the user so they
-        can separate them based on hash tag.
-
-        Returns:
-            int: Count of records deleted from Redis.
-        """
-        batch_size = 500
+    async def _adelete_where(
+        self,
+        filter_expression: str | FilterExpression | None = None,
+        batch_size: int = DEFAULT_BULK_BATCH_SIZE,
+    ) -> int:
+        filter_expr = (
+            FilterExpression("*")
+            if filter_expression is None
+            else filter_expression
+        )
+        matched_count = cast(int, await self.query(CountQuery(filter_expr)))
         max_ratio = 1.01
-
-        info = await self.info()
-        max_records_deleted = ceil(
-            info["num_docs"] * max_ratio
-        )  # Allow to remove some additional concurrent inserts
+        max_records_deleted = ceil(matched_count * max_ratio)
         total_records_deleted: int = 0
-        query = FilterQuery(FilterExpression("*"), return_fields=["id"])
+
+        query = FilterQuery(filter_expr, return_fields=["id"])
         query.paging(0, batch_size)
 
         while True:
@@ -2509,6 +2533,38 @@ class AsyncSearchIndex(BaseSearchIndex):
 
         self.invalidate_sql_schema_cache()
         return total_records_deleted
+
+    async def adelete_where(
+        self,
+        filter_expression: str | FilterExpression | None = None,
+        batch_size: int = DEFAULT_BULK_BATCH_SIZE,
+    ) -> int:
+        """Delete documents matching a filter expression asynchronously.
+
+        Args:
+            filter_expression (Union[str, FilterExpression, None]): Selects the
+                documents to delete. Defaults to None (all documents).
+            batch_size (int): Number of documents to resolve and delete per round-trip.
+
+        Returns:
+            int: Count of records deleted from Redis.
+        """
+        return await self._adelete_where(
+            filter_expression=filter_expression, batch_size=batch_size
+        )
+
+    async def clear(self) -> int:
+        """Clear all keys in Redis associated with the index, leaving the index
+        available and in-place for future insertions or updates.
+
+        NOTE: This method requires custom behavior for Redis Cluster because here,
+        we can't easily give control of the keys we're clearing to the user so they
+        can separate them based on hash tag.
+
+        Returns:
+            int: Count of records deleted from Redis.
+        """
+        return await self._adelete_where(FilterExpression("*"))
 
     def invalidate_sql_schema_cache(self) -> None:
         """Clear cached sql-redis executors and schema state for this index."""

--- a/tests/integration/test_delete_where.py
+++ b/tests/integration/test_delete_where.py
@@ -1,6 +1,26 @@
 import pytest
-from redisvl.index import SearchIndex, AsyncSearchIndex
-from redisvl.query.filter import Tag
+
+from redisvl.index import AsyncSearchIndex, SearchIndex
+from redisvl.query import FilterQuery
+from redisvl.query.filter import FilterExpression, Tag
+
+DOCS = [
+    {"id": "1", "category": "A"},
+    {"id": "2", "category": "B"},
+    {"id": "3", "category": "A"},
+    {"id": "4", "category": "C"},
+]
+
+
+def _all_keys(index):
+    """Return every key in the index, without relying on other unmerged APIs."""
+    query = FilterQuery(FilterExpression("*"), return_fields=["id"], num_results=100)
+    return {record["id"] for record in index.query(query)}
+
+
+async def _all_keys_async(index):
+    query = FilterQuery(FilterExpression("*"), return_fields=["id"], num_results=100)
+    return {record["id"] for record in await index.query(query)}
 
 
 @pytest.fixture
@@ -15,13 +35,7 @@ def sample_delete_index(redis_url, redis_test_name):
         redis_url=redis_url,
     )
     index.create(overwrite=True)
-    docs = [
-        {"id": f"{prefix}:1", "category": "A"},
-        {"id": f"{prefix}:2", "category": "B"},
-        {"id": f"{prefix}:3", "category": "A"},
-        {"id": f"{prefix}:4", "category": "C"},
-    ]
-    index.load(docs)
+    index.load(DOCS, id_field="id")
     yield index
     index.delete(drop=True)
 
@@ -38,54 +52,79 @@ async def async_sample_delete_index(redis_url, redis_test_name):
         redis_url=redis_url,
     )
     await index.create(overwrite=True)
-    docs = [
-        {"id": f"{prefix}:1", "category": "A"},
-        {"id": f"{prefix}:2", "category": "B"},
-        {"id": f"{prefix}:3", "category": "A"},
-        {"id": f"{prefix}:4", "category": "C"},
-    ]
-    await index.load(docs)
+    await index.load(DOCS, id_field="id")
     yield index
     await index.delete(drop=True)
 
 
-def test_sync_delete_where(sample_delete_index):
-    # Delete category A
+def test_delete_where_removes_only_matching_documents(sample_delete_index):
+    """A filtered delete must remove matches and leave everything else in place."""
     deleted = sample_delete_index.delete_where(Tag("category") == "A")
-    assert deleted == 2
 
-    remaining = list(sample_delete_index.iter())
-    assert len(remaining) == 2
-    assert set(remaining) == {
+    assert deleted == 2
+    assert _all_keys(sample_delete_index) == {
         f"{sample_delete_index.prefix}:2",
         f"{sample_delete_index.prefix}:4",
     }
 
-    # Clear remaining
+
+def test_delete_where_with_no_matches_is_a_noop(sample_delete_index):
+    """A filter matching nothing must delete nothing and report zero."""
+    before = _all_keys(sample_delete_index)
+
+    deleted = sample_delete_index.delete_where(Tag("category") == "no_such_value")
+
+    assert deleted == 0
+    assert _all_keys(sample_delete_index) == before
+
+
+def test_clear_still_removes_everything(sample_delete_index):
+    """clear() must keep its contract after delegating to the shared internals."""
     cleared = sample_delete_index.clear()
-    assert cleared == 2
-    assert len(list(sample_delete_index.iter())) == 0
+
+    assert cleared == 4
+    assert _all_keys(sample_delete_index) == set()
+
+
+def test_delete_where_pages_below_batch_size(sample_delete_index):
+    """A batch_size smaller than the match count must still delete every match."""
+    deleted = sample_delete_index.delete_where(FilterExpression("*"), batch_size=2)
+
+    assert deleted == 4
+    assert _all_keys(sample_delete_index) == set()
 
 
 @pytest.mark.asyncio
-async def test_async_adelete_where(async_sample_delete_index):
-    # Delete category A asynchronously
+async def test_adelete_where_removes_only_matching_documents(
+    async_sample_delete_index,
+):
+    """The async client must behave identically to the sync one."""
     deleted = await async_sample_delete_index.adelete_where(Tag("category") == "A")
-    assert deleted == 2
 
-    remaining = []
-    async for key in async_sample_delete_index.aiter():
-        remaining.append(key)
-    assert len(remaining) == 2
-    assert set(remaining) == {
+    assert deleted == 2
+    assert await _all_keys_async(async_sample_delete_index) == {
         f"{async_sample_delete_index.prefix}:2",
         f"{async_sample_delete_index.prefix}:4",
     }
 
-    # Clear remaining asynchronously
+
+@pytest.mark.asyncio
+async def test_adelete_where_with_no_matches_is_a_noop(async_sample_delete_index):
+    """An async filter matching nothing must delete nothing and report zero."""
+    before = await _all_keys_async(async_sample_delete_index)
+
+    deleted = await async_sample_delete_index.adelete_where(
+        Tag("category") == "no_such_value"
+    )
+
+    assert deleted == 0
+    assert await _all_keys_async(async_sample_delete_index) == before
+
+
+@pytest.mark.asyncio
+async def test_async_clear_still_removes_everything(async_sample_delete_index):
+    """The async clear() must keep its contract after the refactor."""
     cleared = await async_sample_delete_index.clear()
-    assert cleared == 2
-    remaining_after = []
-    async for key in async_sample_delete_index.aiter():
-        remaining_after.append(key)
-    assert len(remaining_after) == 0
+
+    assert cleared == 4
+    assert await _all_keys_async(async_sample_delete_index) == set()

--- a/tests/integration/test_delete_where.py
+++ b/tests/integration/test_delete_where.py
@@ -1,0 +1,91 @@
+import pytest
+from redisvl.index import SearchIndex, AsyncSearchIndex
+from redisvl.query.filter import Tag
+
+
+@pytest.fixture
+def sample_delete_index(redis_url, redis_test_name):
+    index_name = redis_test_name("delete_where_index")
+    prefix = redis_test_name("delete_where_doc")
+    index = SearchIndex.from_dict(
+        {
+            "index": {"name": index_name, "prefix": prefix, "storage_type": "hash"},
+            "fields": [{"name": "category", "type": "tag"}],
+        },
+        redis_url=redis_url,
+    )
+    index.create(overwrite=True)
+    docs = [
+        {"id": f"{prefix}:1", "category": "A"},
+        {"id": f"{prefix}:2", "category": "B"},
+        {"id": f"{prefix}:3", "category": "A"},
+        {"id": f"{prefix}:4", "category": "C"},
+    ]
+    index.load(docs)
+    yield index
+    index.delete(drop=True)
+
+
+@pytest.fixture
+async def async_sample_delete_index(redis_url, redis_test_name):
+    index_name = redis_test_name("async_delete_where_index")
+    prefix = redis_test_name("async_delete_where_doc")
+    index = AsyncSearchIndex.from_dict(
+        {
+            "index": {"name": index_name, "prefix": prefix, "storage_type": "hash"},
+            "fields": [{"name": "category", "type": "tag"}],
+        },
+        redis_url=redis_url,
+    )
+    await index.create(overwrite=True)
+    docs = [
+        {"id": f"{prefix}:1", "category": "A"},
+        {"id": f"{prefix}:2", "category": "B"},
+        {"id": f"{prefix}:3", "category": "A"},
+        {"id": f"{prefix}:4", "category": "C"},
+    ]
+    await index.load(docs)
+    yield index
+    await index.delete(drop=True)
+
+
+def test_sync_delete_where(sample_delete_index):
+    # Delete category A
+    deleted = sample_delete_index.delete_where(Tag("category") == "A")
+    assert deleted == 2
+
+    remaining = list(sample_delete_index.iter())
+    assert len(remaining) == 2
+    assert set(remaining) == {
+        f"{sample_delete_index.prefix}:2",
+        f"{sample_delete_index.prefix}:4",
+    }
+
+    # Clear remaining
+    cleared = sample_delete_index.clear()
+    assert cleared == 2
+    assert len(list(sample_delete_index.iter())) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_adelete_where(async_sample_delete_index):
+    # Delete category A asynchronously
+    deleted = await async_sample_delete_index.adelete_where(Tag("category") == "A")
+    assert deleted == 2
+
+    remaining = []
+    async for key in async_sample_delete_index.aiter():
+        remaining.append(key)
+    assert len(remaining) == 2
+    assert set(remaining) == {
+        f"{async_sample_delete_index.prefix}:2",
+        f"{async_sample_delete_index.prefix}:4",
+    }
+
+    # Clear remaining asynchronously
+    cleared = await async_sample_delete_index.clear()
+    assert cleared == 2
+    remaining_after = []
+    async for key in async_sample_delete_index.aiter():
+        remaining_after.append(key)
+    assert len(remaining_after) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -4841,7 +4841,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.25.1"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },

--- a/uv.lock
+++ b/uv.lock
@@ -4841,7 +4841,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },


### PR DESCRIPTION
Fixes #488

Adds `delete_where()` / `adelete_where()` for deleting a filtered subset of an index, and refactors `clear()` onto the same internals.

Before this there was no public way to delete by filter: `clear()` removes everything, and `drop_documents()` / `drop_keys()` need ids or keys you already hold.

`clear()` and `_delete_where()` were the same batch loop with a different filter expression, so the loop now lives once in `_delete_where()` (and `_adelete_where()`), and `clear()` is a call to it with the match-all expression.

Two details from the original `clear()` are preserved deliberately:

- **The `max_ratio = 1.01` overshoot guard.** It stops the loop running forever against concurrent inserts. It is now computed from a `CountQuery` on the supplied filter rather than `info()["num_docs"]`, so the bound tracks the documents actually being deleted instead of the whole index — which matters once the filter is not match-all.
- **`invalidate_sql_schema_cache()`** still runs at the end of every deletion path.

`_delete_batch()` is untouched, so the cluster-specific key-at-a-time behaviour is unchanged.

`tests/integration/test_delete_where.py` covers a filtered delete leaving non-matching documents in place, a filter matching nothing returning `0` and deleting nothing, `clear()` keeping its existing contract, and a `batch_size` below the match count so the paging loop is exercised. Sync and async both covered. 7 passed.

For regression cover on the `clear()` change I also ran `tests/integration/test_search_index.py` and `test_async_search_index.py` on this branch: 95 passed.

One gap I would rather state than paper over: **I have not run the cluster suite.** `clear()` is public API with cluster-specific behaviour underneath, and while `_delete_batch()` is unchanged I would not call that fully verified. If you have a cluster CI job, that is the one to watch here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors public clear() and introduces destructive delete-by-filter on index data; cluster behavior relies on unchanged _delete_batch and is not covered by new cluster tests.
> 
> **Overview**
> Adds **`delete_where()`** and **`adelete_where()`** on sync/async search indexes so callers can remove documents by filter without pre-fetching ids or keys.
> 
> The shared **`_delete_where` / `_adelete_where`** path counts matches with **`CountQuery`**, pages ids with **`FilterQuery`**, deletes via existing **`_delete_batch`** ( **`DEL`** ), applies the **`1.01`** runaway cap from that count, and still calls **`invalidate_sql_schema_cache()`**. **`clear()`** now delegates to the same helper with a match-all filter instead of duplicating the loop; the overshoot bound is tied to the filter’s match count rather than **`info()["num_docs"]`**.
> 
> Integration tests cover filtered delete, no-op filters, **`clear()`** behavior, small **`batch_size`** paging, and async parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0592f2c6647793e4fb3f5271953a56fdc764ce38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->