### PR TITLE
fix(ci): make the redis-py matrix axis actually test redis-py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,16 @@ jobs:
     needs: service-tests
     env:
       HF_HOME: ${{ github.workspace }}/hf_cache
+      REDIS_IMAGE: ${{ matrix.redis-image }}
+      REDIS_PY_VERSION: ${{ matrix.redis-py-version }}
+      # Required: without it `uv run` re-syncs the venv to uv.lock and reverts
+      # the redis-py pin set below.
+      UV_NO_SYNC: "1"
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        redis-py-version: ["5.x", "6.x", "7.x"]
+        redis-py-version: ["6.x", "7.x"]
         redis-image: ["redis:8.2", "redis:8.4", "redis:latest"]
     steps:
       - name: Check out repository
@@ -93,50 +98,97 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras
+          set -euo pipefail
 
-          # Install right redis version based on redis py
-          if [[ "${{ matrix.redis-py-version }}" == "5.x" ]]; then
-            uv pip install "redis>=5,<6"
-          elif [[ "${{ matrix.redis-py-version }}" == "6.x" ]]; then
-            uv pip install "redis>=6,<7"
-          else
-            uv pip install "redis>=7,<8"
-          fi
+          uv sync --all-extras --frozen
 
-      - name: Set Redis image name
-        run: |
-          echo "REDIS_IMAGE=${{ matrix.redis-image }}" >> $GITHUB_ENV
+          # Must cover every redis-py-version matrix value; unhandled values fail.
+          case "$REDIS_PY_VERSION" in
+            "6.x") spec="redis>=6,<7" ;;
+            "7.x") spec="redis>=7,<8" ;;
+            *)
+              echo "::error title=Unhandled redis-py-version::Matrix value '${REDIS_PY_VERSION}' has no install rule -- add a case branch in .github/workflows/test.yml."
+              exit 1
+              ;;
+          esac
+
+          uv pip install "$spec"
+          uv run python -c 'import redis; print("redis-py:", redis.__version__)'
 
       - name: Run tests
-        env:
-          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           make test
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
-        if: (
-            matrix.redis-py-version == '7.x' &&
-            matrix.redis-image == 'redis:8.4' &&
-            matrix.python-version == '3.11' &&
-            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-          )
+  notebooks:
+    name: Notebook Validation
+    runs-on: ubuntu-latest
+    needs: service-tests
+    # Needs API-key secrets, unavailable to fork PRs. Keep in sync with
+    # service-tests.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      HF_HOME: ${{ github.workspace }}/hf_cache
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Cache HuggingFace Models
+        uses: actions/cache@v4
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          path: hf_cache
+          key: ${{ runner.os }}-hf-cache
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}   # sets UV_PYTHON
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install dependencies
+        run: |
+          uv sync --all-extras --frozen
+
+      - name: Start Redis
+        run: |
+          set -euo pipefail
+          # Wait for readiness: `make test-notebooks` probes Redis for SVS
+          # support and silently skips 09_svs_vamana.ipynb if it can't connect.
+          # Probe over the same host-to-published-port path the notebooks use.
+          docker run -d --name redis -p 6379:6379 redis:8.4
+          probe() {
+            uv run --no-sync python -c "import redis; redis.Redis.from_url('redis://localhost:6379').ping()"
+          }
+          ready=0
+          for _ in $(seq 1 30); do
+            if probe 2>/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" -ne 1 ]; then
+            # Unsuppressed retry: distinguishes an unreachable server from a
+            # broken venv or import.
+            echo "Final probe attempt, stderr shown:"
+            probe || true
+            echo "::error title=Redis not ready::redis:8.4 never accepted a connection on localhost:6379 after 30 attempts"
+            docker logs redis || true
+            exit 1
+          fi
+          docker exec redis redis-cli INFO server | grep redis_version
 
       - name: Run notebooks
-        if: (
-            matrix.redis-py-version == '7.x' &&
-            matrix.redis-image == 'redis:8.4' &&
-            matrix.python-version == '3.11' &&
-            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-          )
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
@@ -148,7 +200,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          docker run -d --name redis -p 6379:6379 redis:8.4
           make test-notebooks
 
   docs:

--- a/docs/user_guide/04_vectorizers.ipynb
+++ b/docs/user_guide/04_vectorizers.ipynb
@@ -395,6 +395,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "# NBVAL_SKIP\n",
+        "# Deprecated vectorizer; not executed in CI so notebook validation makes no API calls.\n",
         "from redisvl.utils.vectorize import VertexAIVectorizer\n",
         "\n",
         "\n",

--- a/tests/unit/test_google_genai_vectorizer.py
+++ b/tests/unit/test_google_genai_vectorizer.py
@@ -7,9 +7,9 @@ import pytest
 from redisvl.utils.vectorize.base import BaseVectorizer
 from redisvl.utils.vectorize.googlegenai import GoogleGenAIVectorizer
 
-# Environment variables that would otherwise steer backend auto-detection. CI's
-# `make test` job exports GCP_* and tests run under xdist, so scrub them and let
-# each test set only what it exercises.
+# Environment variables that would otherwise steer backend auto-detection.
+# Scrubbed so each test sets only what it exercises, rather than inheriting
+# GCP_* from a developer's shell or .env.
 _GOOGLE_ENV_VARS = (
     "GCP_PROJECT_ID",
     "GCP_LOCATION",


### PR DESCRIPTION
## Problem

The `redis-py-version` axis of the test matrix was inert. All 45 jobs ran redis-py 7.4.0, regardless of the version in their name.

The job pinned a version with `uv pip install "redis>=6,<7"`, then ran `make test`, which reaches pytest through `uv run`. `uv run` re-syncs the environment to `uv.lock` before executing, silently reverting the pin.

The signature is visible in [run 31662019515](https://github.com/redis/redis-vl-python/actions/runs/31662019515): the 5.x, 6.x and 7.x cells for the same Python and Redis image returned byte-identical results — `2070 passed, 143 skipped, 2 xfailed, 210 warnings` — which cannot happen when 48 tests are gated on `redis-py >= 7.1.0`.

The other two axes were unaffected. `REDIS_IMAGE` is read by `tests/docker-compose.yml` and the Python version comes from `setup-python`; neither passes through uv.

## Fix

- `UV_NO_SYNC: "1"` on the `test` job, so `uv run` uses the environment as installed. Scoped to that job because it is the only one that pins a redis-py version. `make test` is unchanged, so local runs keep auto-sync.
- The install `if/elif/else` becomes a `case` that fails on an unhandled matrix value. The previous `else` was a catch-all installing 7.x for anything unrecognised, so a typo passed for the wrong reason.
- Each cell logs the redis-py version it resolved.
- `--frozen` on `uv sync --all-extras`, matching `lint.yml` and the `docs` job.
- Notebook validation moves into its own `notebooks` job. It was two steps constrained to one matrix cell by duplicated `if:` conditions, so any matrix rename would have silently disabled it.

## Dropping redis-py 5.x

The matrix goes from 45 to 30 cells. redis-py's `VectorField` rejects `SVS-VAMANA` before 6.3.0, so `tests/unit/test_fields.py` fails on 5.x — 10 failures on 5.3.1 locally, all in that file.

We're adding redis-py 8.x support shortly and view dropping 5.x as part of that transition, so removing the cells is preferable to gating the tests around a version we're retiring.

`pyproject.toml` still declares `redis>=5.0,<8.0`; that range belongs to the 8.x work and isn't touched here. Note the effective floor is **6.3.0**, not 6.0 — the `6.x` cells pass only because the range resolves to the latest 6.x, and 6.0–6.2 remain untested.

## Notebook job

Cell 20 of `04_vectorizers.ipynb` is now `NBVAL_SKIP`, which let the Google Cloud auth step and the `GOOGLE_CREDENTIALS` / `GCP_LOCATION` / `GCP_PROJECT_ID` secrets come out of the job. That cell made a live Vertex AI call through `VertexAIVectorizer` — deprecated in code — while its supported replacement (`GoogleGenAIVectorizer`, cell 22) was already skipped. The VertexAI integration tests still run in `service-tests` under `--run-api-tests`, so no coverage is lost.

The job now waits for Redis to accept connections before running nbval. `docker run -d` returns before the server is ready, and the SVS probe in `make test-notebooks` suppresses errors, so an unready server was indistinguishable from "Redis < 8.2" and silently dropped `09_svs_vamana.ipynb`.

Two behavioural changes: notebooks are no longer gated on `make test` passing, since they now run in parallel with the matrix; and the job pins no redis-py version, because notebooks only need to work against a default install.

## Verification

All 33 jobs pass, including the 15 `6.x` cells that had never actually executed. Every cell logs the major it advertises — `6.x` cells resolve to 6.4.0, `7.x` to 7.4.0.

The skip counts now diverge by axis, with no overlap:

| redis-py | `redis:8.2` | `redis:8.4` / `latest` |
|---|---|---|
| 6.x | 1896 passed / 199 skipped | 1895 / 200 |
| 7.x | 1936 / 159 | 1952 / 143 |

(Python 3.10–3.13; 3.14 skips ~114 more via the existing HF gate.) If 6.x and 7.x ever report the same counts again, the axis has regressed.

Two useful corroborations: `7.x [redis:8.4]` on 3.11 reproduces `2070 passed / 143 skipped` — exactly the figure every cell used to report — and `6.x [redis:8.4]` matches a local run at 6.4.0 to the test.

**Cost went down, not up.** Wall clock 9.5 → 9.2 min; total compute 153 → 110 job-minutes across 47 → 33 jobs. Per-cell time is unchanged, because the old cells were already running the full suite, just at the wrong version. The critical path is now `Service Tests` (3.8 min) plus the slowest cell (5.2 min); moving nbval into a parallel job took ~2.3 min off the longest cell.

## Follow-ups

- Raise the `pyproject.toml` floor to `redis>=6.3.0` (part of the 8.x work).
- `Makefile:73`'s SVS probe hides errors with `2>/dev/null`, so local `make test-notebooks` can still drop a notebook silently.
- No lockfile freshness check in CI. `--locked` isn't a drop-in: it fails on release-bump commits that don't relock.
- Fork PRs run no unit tests — `test` and `notebooks` both `needs: service-tests`, which is fork-gated. The `test` job now uses no secrets, which is the precondition for changing that.
- `google-github-actions/auth@v1` is EOL, and action versions drift between workflows.
