### PR TITLE
ci: bump pinned uv to 0.12.3 and setup-uv to v10.0.0

### DIFF
--- a/.github/actions/run-service-tests/action.yml
+++ b/.github/actions/run-service-tests/action.yml
@@ -30,7 +30,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v10.0.0
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: true

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.7.13"
+  UV_VERSION: "0.12.3"
   AUTO_VERSION: "11.3.6"
   RELEASE_BOT_NAME: "applied-ai-releases[bot]"
   RELEASE_BOT_EMAIL: "applied-ai-releases[bot]@users.noreply.github.com"
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -268,7 +268,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  UV_VERSION: "0.7.13"
+  UV_VERSION: "0.12.3"
 
 jobs:
   check:
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v10.0.0
       with:
         version: ${{ env.UV_VERSION }}
         enable-cache: true

--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.7.13"
+  UV_VERSION: "0.12.3"
 
 jobs:
   setup:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.7.13"
+  UV_VERSION: "0.12.3"
 
 jobs:
   service-tests:
@@ -87,7 +87,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -144,7 +144,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -214,7 +214,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/uv.lock
+++ b/uv.lock
@@ -4841,7 +4841,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },


### PR DESCRIPTION
# ci: bump pinned uv 0.7.13 → 0.12.3, setup-uv → v10.0.0, and relock

> **Stacked on #689.** Base this against `fix/ci-redis-py-matrix-pin`, not `main`. Review #689 first; this PR's diff is the six files below.

## What

- `UV_VERSION: "0.7.13"` → `"0.12.3"` in all four workflows that define it: `test.yml`, `lint.yml`, `test-fork-pr.yml`, `auto-release.yml`. They stay identical — the drift risk is per-workflow.
- `astral-sh/setup-uv@v6` → `@v10.0.0` at all **seven** call sites. Two are easy to miss: `.github/actions/run-service-tests/action.yml` (the composite action shared by `test.yml` and `test-fork-pr.yml`), and the `notebooks` job that #689 adds.
- `uv.lock` regenerated with uv 0.12.3. The diff is **one line**.

No changes to `pyproject.toml`, the `redis` dependency specifier, the `Makefile`, or `README.md`.

## Why

uv 0.7.13 shipped in June 2025; 0.12.3 is current. The concrete symptom was that `uv lock --check` failed against the committed lockfile on any modern uv, so a contributor who ran `uv lock` produced a file CI's uv had not generated. That matters because `--frozen` is used in `lint.yml`, the docs job in `test.yml`, and both `auto-release.yml` sync steps — those jobs consume whatever lock is committed without re-resolving.

`.readthedocs.yaml` is worth noting here: it installs *unpinned latest* uv and then runs `uv sync --frozen --group docs`, so the docs build has been running a modern uv against a stale lock all along.

### The lockfile diff is smaller than expected, and that's the interesting part

The prior investigation measured a ~336-line diff on relock, mostly marker rewrites like `{ name = "caio" }` gaining `python_full_version < '3.11'` and the `nvidia-*` markers gaining `sys_platform` clauses. That churn turns out to be **uv 0.9.x-specific**, not a permanent tightening:

| | markers vs. committed lock | `uv lock --check` on committed lock |
|---|---|---|
| uv 0.9.10 | rewrites them (verbose form) | fails |
| uv 0.12.3 | **identical** | fails |

Both versions failed `--check` for the same single reason: the lock said `redisvl 0.25.0` while `pyproject.toml` says `0.25.1`. The release automation bumps `pyproject.toml` via `sed` without relocking, so the lock is permanently one release behind. uv 0.9.10 only rewrote the markers as collateral once that mismatch forced it to rewrite the file at all; uv 0.12.3 writes the markers exactly as committed.

So the entire lockfile diff here is:

```diff
 name = "redisvl"
-version = "0.25.0"
+version = "0.25.1"
```

And verified: with that line fixed, **uv 0.9.10 also passes `uv lock --check`** on the 0.12.3-generated lock. The relock satisfies both old and new uv, so this does not strand anyone mid-upgrade.

## uv 0.8 → 0.12 behaviour changes, assessed against this repo

Read from uv's release notes for 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0 and the 0.12.1–0.12.3 patches.

- **0.12.0 — rejects unsupported sdist/wheel archive formats**, *including when referenced by an existing lockfile* (`.tar.bz2`, `.tar.xz`, legacy `.zip` sdists). Verified non-issue: zero such archives across all 303 packages in `uv.lock`.
- **0.12.0 — rejects MD5-only hashes in hash-checking mode.** Verified non-issue: zero `md5:` entries in `uv.lock`.
- **0.12.0 — prefers stable releases before falling back to pre-releases.** A resolution change; this repo pins no pre-releases, and the relock confirms no effect.
- **0.9.0 — Python 3.14 is the default stable version.** The matrix already covers 3.14 and `requires-python` is `>=3.10,<3.15`. Every job passes an explicit `python-version` to `setup-uv` (which sets `UV_PYTHON`), so no interpreter selection floats.
- **0.8.0 — `--check` now exits 1.** Affects `uv lock --check`, which CI doesn't run today; used only in this PR's verification.
- **0.8.0 — `--python-platform linux` bumped to `manylinux_2_28`.** Install-time wheel selection, not lock content; `ubuntu-latest` satisfies it.
- **0.11.0 — TLS stack change** (`rustls-platform-verifier`, `aws-lc`). Only bites `--native-tls` / custom CA configurations; neither is used.
- 0.12.1–0.12.3 are performance and preview-only.

Confirmed unaffected: `uv sync --frozen`, `uv sync --all-extras`, `uv build` (hatchling backend — the `uv_build` upper-bound advice in the 0.12.0 notes does not apply here), and `[tool.uv] default-groups`.

### The `UV_NO_SYNC` fix from #689 still works on 0.12.3

Since this PR swaps uv out from under #689's fix, I verified that mechanism directly on 0.12.3 rather than assuming it:

- With `UV_NO_SYNC=1`, a `uv pip install "redis>=6,<7"` pin **survives** `uv run` — reports `redis-py: 6.4.0`.
- Without it, uv 0.12.3 still uninstalls 6.4.0 and reinstalls the locked 7.4.0, exactly as 0.7.13 did.

So #689's fix remains both necessary and effective on the new pin, and the matrix axis is genuinely honest once both land. #689 also converts the test job's `uv sync --all-extras` to `--frozen`, which makes this PR's relock load-bearing for that job too.

## setup-uv v6 → v10.0.0

`setup-uv` v8.0.0 stopped publishing major and minor tags (their stated rationale is supply-chain attacks like tj-actions). `@v6` is therefore a frozen leftover tag that will never learn uv 0.12.3's checksum, so it installs uv without checksum verification. There is no `@v10`; `@v10.0.0` is the pin. Exact-tag pinning matches this repo's existing style (`actions/checkout@v6`, `actions/cache@v5`).

All four inputs used here — `version`, `python-version`, `enable-cache`, `cache-dependency-glob` — still exist unchanged in v10.0.0's `action.yml`, so this is a drop-in. Breaking changes across v7–v10:

- **v7.0.0** — node20 → node24. Fine on GitHub-hosted runners; every job is `ubuntu-latest`. Removes the `server-url` input, unused here.
- **v8.0.0** — no more major/minor tags (the reason for the exact pin). New `manifest-file` format, unused here.
- **v9.0.0** — `prune-cache` default flips to `false`. Effect is larger Actions cache entries, not behaviour.
- **v10.0.0** — `enable-cache: auto` now disables the cache for `pull_request_target` / `workflow_run` / `release`. **Does not apply**: all six sites set `enable-cache: true` explicitly, and `auto-release.yml` triggers on `push: [main]` + `workflow_dispatch` — not `release` or `workflow_run`.

v10.0.0 also ships a known checksum for uv 0.12.3, so the install is now verified rather than skipped.

## Risk: `auto-release.yml` is the publish pipeline

It can't be smoke-tested on a branch, so here is the explicit reasoning for both uv sites.

Both are minimal and, crucially, **do not resolve**:

- `canary-build`: `uv sync --frozen` → `uv build`
- `build-and-publish`: `uv sync --frozen` → `uv build` → `pypa/gh-action-pypi-publish`

`--frozen` means uv installs exactly the locked set with no resolution, so the only new exposure is uv's installer and hatchling's build — both exercised locally on 0.12.3 (`uv build` produced `redisvl-0.25.1.tar.gz` and the wheel). `canary-build` runs before and gates the release, so a uv-caused build failure blocks the publish rather than shipping a bad artifact. Publishing itself is Trusted Publishing via the `pypa` action and is untouched.

`test-fork-pr.yml` is `workflow_dispatch`-only and harder to exercise, but it shares the `run-service-tests` composite action with `test.yml`, so a green `service-tests` job covers the same uv code path. Its pin is consistent with the other three.

## Verification

All run locally with uv 0.12.3 first on `PATH` (important: every `make` target shells out to `uv run`, which implicitly re-locks, so running them under an older uv after relocking would silently rewrite `uv.lock`).

- `uv lock --check` — passes (this is the condition that fails on `main`)
- `uv lock --check` under uv 0.9.10 — also passes, confirming no one is stranded
- `uv sync --all-extras --frozen` — succeeds (the `lint.yml` path)
- `make check-types` — no issues in 119 source files
- `make check-format` — 119 files unchanged
- `make check-sort-imports` — clean
- `make test` — 1952 passed, 257 skipped, 2 xfailed (9m40s). No resolution-driven failures.
- `make docs-build` — build succeeded, 11 pre-existing warnings (the `uv sync --group docs --frozen` path)
- `uv build` — sdist + wheel built
- `git diff --stat` — exactly six files: four workflows, the composite action, `uv.lock`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions pins and a one-line lockfile version sync; runtime code and dependency constraints in pyproject.toml are untouched.
> 
> **Overview**
> **CI tooling upgrade:** `UV_VERSION` moves from `0.7.13` to `0.12.3` in `test.yml`, `lint.yml`, `test-fork-pr.yml`, and `auto-release.yml`. Every **Install uv** step now uses `astral-sh/setup-uv@v10.0.0` instead of `@v6`, including the shared `.github/actions/run-service-tests` composite action.
> 
> **Lockfile:** `uv.lock` is regenerated under uv 0.12.3 with a single substantive change—the editable `redisvl` entry is bumped from `0.25.0` to `0.25.1` so `uv lock --check` and `uv sync --frozen` jobs align with `pyproject.toml`. No application or dependency-spec changes beyond that.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348f14b87f59947d299aa807619e98c20bb1b15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->