### PR TITLE
Fix reranked scores not matching reranked document order in HFCrossEncoderReranker

### DIFF
--- a/redisvl/utils/rerank/hf_cross_encoder.py
+++ b/redisvl/utils/rerank/hf_cross_encoder.py
@@ -120,8 +120,8 @@ class HFCrossEncoderReranker(BaseReranker):
         scores = [float(score) for score in scores]
         docs_with_scores = list(zip(doc_subset, scores))
         docs_with_scores.sort(key=lambda x: x[1], reverse=True)
-        reranked_docs = [doc for doc, _ in docs_with_scores[:limit]]
-        scores = [score for _, score in docs_with_scores[:limit]]
+        reranked_docs_tuple, scores_tuple = zip(*docs_with_scores[:limit])
+        reranked_docs, scores = list(reranked_docs_tuple), list(scores_tuple)
 
         if return_score:
             return reranked_docs, scores  # type: ignore

--- a/redisvl/utils/rerank/hf_cross_encoder.py
+++ b/redisvl/utils/rerank/hf_cross_encoder.py
@@ -121,7 +121,7 @@ class HFCrossEncoderReranker(BaseReranker):
         docs_with_scores = list(zip(doc_subset, scores))
         docs_with_scores.sort(key=lambda x: x[1], reverse=True)
         reranked_docs = [doc for doc, _ in docs_with_scores[:limit]]
-        scores = scores[:limit]
+        scores = [score for _, score in docs_with_scores[:limit]]
 
         if return_score:
             return reranked_docs, scores  # type: ignore

--- a/tests/integration/test_cross_encoder_reranker.py
+++ b/tests/integration/test_cross_encoder_reranker.py
@@ -33,6 +33,23 @@ async def test_async_rank_documents(reranker):
     assert all(isinstance(score, float) for score in scores)
 
 
+def test_rank_scores_align_with_reranked_docs(reranker):
+    # https://github.com/redis/redis-vl-python/issues/693
+    docs = [
+        "irrelevant document",
+        "highly relevant document",
+        "somewhat relevant document",
+    ]
+    query = "relevant document"
+
+    reranked_docs, scores = reranker.rank(query, docs, limit=len(docs))
+
+    # reranked_docs is sorted by score descending, so scores must be too,
+    # this catches the case where scores are taken from the original
+    # unsorted list instead of the sorted one.
+    assert scores == sorted(scores, reverse=True)
+
+
 def test_bad_input(reranker):
     with pytest.raises(ValueError):
         reranker.rank("", [])  # Empty query

--- a/tests/integration/test_cross_encoder_reranker.py
+++ b/tests/integration/test_cross_encoder_reranker.py
@@ -47,7 +47,7 @@ def test_rank_scores_align_with_reranked_docs(reranker):
     # reranked_docs is sorted by score descending, so scores must be too,
     # this catches the case where scores are taken from the original
     # unsorted list instead of the sorted one.
-    assert scores == sorted(scores, reverse=True)
+    assert list(scores) == sorted(scores, reverse=True)
 
 
 def test_bad_input(reranker):


### PR DESCRIPTION
Fixes #693.

HFCrossEncoderReranker.rank() sorted docs_with_scores by score to build reranked_docs, but then took scores from the original unsorted scores list instead of from the same sorted sequence. So reranked_docs[i] and scores[i] didn't correspond to the same document once the reranking actually changed the order. arank() delegates to rank(), so this fixes both.

Added a regression test that asserts the returned scores are sorted descending, matching the returned docs. Confirmed it fails with the old code (scores come back in the original order, not sorted) and passes with the fix, using a real cross-encoder model against the exact reproduction from the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bugfix in reranker output pairing with a regression test; no auth, data, or API contract changes beyond correcting score alignment.
> 
> **Overview**
> **Fixes misaligned scores in `HFCrossEncoderReranker.rank()`** when reranking changes document order (#693).
> 
> After sorting `(doc, score)` pairs by score, the method now builds both `reranked_docs` and the returned `scores` from that same sorted slice. Previously it sliced the sorted docs but still returned scores from the original prediction order, so index `i` in docs and scores could refer to different hits.
> 
> Adds an integration regression test that checks returned scores are in descending order when `return_score` is true (the failure mode from the old code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919bddc4a9463a36bab90c73aa141e96ea57b16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->