### PR TITLE
fix(ci): keep uv.lock in step with the release version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -183,26 +183,75 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
 
-      - name: Apply release version to pyproject.toml
+      # Only the bump needs uv. Kept after the `auto` calls, which resolve the
+      # release version today without the env setup-python/setup-uv export.
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Apply release version to pyproject.toml and uv.lock
         run: |
           set -euo pipefail
           VERSION="${{ steps.latest_release.outputs.version }}"
           sed -i "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
+          # uv.lock carries the project's own version. Edit that one field rather
+          # than running `uv lock`, which re-serializes the whole file.
+          sed -i "/^name = \"redisvl\"$/{n;s/^version = \".*\"$/version = \"${VERSION}\"/;}" uv.lock
           grep '^version = ' pyproject.toml
+          grep -A1 '^name = "redisvl"$' uv.lock
+
+      - name: Verify the version bump
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.latest_release.outputs.version }}"
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          # Catch a sed that matched the wrong line, before anything is pushed or
+          # published. No change is fine: a re-run of an already-bumped commit.
+          for f in pyproject.toml uv.lock; do
+            stat="$(git diff --numstat -- "$f" | cut -f1,2)"
+            if [ -n "$stat" ] && [ "$stat" != "$(printf '1\t1')" ]; then
+              fail "$f: expected a single-line version change, got $(git diff --shortstat -- "$f")"
+            fi
+            other="$(git diff -U0 -- "$f" | grep -E '^[-+][^-+]' | grep -vE '^[-+]version = "' || true)"
+            if [ -n "$other" ]; then
+              fail "$f: changed something other than a version line: $other"
+            fi
+          done
+
+          # In uv.lock it has to be the project's own entry, not a dependency's pin.
+          grep -qx "version = \"${VERSION}\"" pyproject.toml \
+            || fail "pyproject.toml does not carry ${VERSION}"
+          grep -A1 '^name = "redisvl"$' uv.lock | grep -qx "version = \"${VERSION}\"" \
+            || fail "uv.lock: the redisvl entry does not carry ${VERSION}"
+
+          uv lock --check
 
       - name: Commit and push version bump
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- pyproject.toml; then
-            echo "No pyproject version change to commit."
+          if git diff --quiet -- pyproject.toml uv.lock; then
+            echo "No version change to commit."
           else
             git config user.name "${RELEASE_BOT_NAME}"
             git config user.email "${RELEASE_BOT_EMAIL}"
-            git add pyproject.toml
+            git add pyproject.toml uv.lock
             # Include [skip ci] to avoid running the workflow again on this bot commit.
-            git commit -m "chore(release): set pyproject version to ${{ steps.latest_release.outputs.version }} [skip ci]"
+            git commit -m "chore(release): set version to ${{ steps.latest_release.outputs.version }} [skip ci]"
             git push origin HEAD:main
           fi
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,28 @@ env:
   UV_VERSION: "0.12.3"
 
 jobs:
+  lock:
+    name: Check uv.lock is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v10.0.0
+      with:
+        version: ${{ env.UV_VERSION }}
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+
+    # Fails a pyproject.toml change that was never locked, before the drift
+    # lands on main and dirties the next contributor's tree.
+    - name: Check lockfile
+      run: uv lock --check
+
   check:
     name: Style-check ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,14 @@ uv sync --all-extras
 
 This will create a virtual environment and install all necessary dependencies for development.
 
+### Changing Dependencies
+
+`uv.lock` is checked in, and CI verifies it matches `pyproject.toml`. If you add, remove, or re-bound a dependency, re-lock and commit the result:
+
+```bash
+uv lock
+```
+
 ## Using the Makefile
 
 We provide a comprehensive Makefile to streamline common development tasks. Here are the available commands:

--- a/uv.lock
+++ b/uv.lock
@@ -4855,7 +4855,7 @@ wheels = [
 
 [[package]]
 name = "redisvl"
-version = "0.25.1"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpath-ng" },


### PR DESCRIPTION
The release job bumps `version` in `pyproject.toml` but commits only that file, so `uv.lock` — which carries the project's own version — goes stale after every release, and the next contributor to run `make install` picks up an unrelated bump in their PR. Nothing caught it: `uv sync --frozen` takes the lock as-is, and at tag `v0.26.0` it installed `redisvl==0.26.0` from a lock that still said `0.25.1`.

The release job now bumps both files and verifies the edit before anything is committed or pushed: one changed line per file, and the new version on the `redisvl` entry specifically. It edits that one field rather than running `uv lock`, which re-serializes the whole file (258 lines of marker churn here) right after `canary-build` validated the old one. A new `lock` job in `lint.yml` runs `uv lock --check` so drift fails on the PR — note that a PR editing dependency specifiers without re-locking will now fail it; fix is `uv lock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the auto-release job that commits to main and tags/publishes, so a bad sed or check could stall or mis-bump a release. Lock-check is otherwise low-risk CI.
> 
> **Overview**
> Stops the release bot from leaving `uv.lock` stale after it bumps `pyproject.toml`. The project's own version in the lock is edited in place (not a full `uv lock` re-serialize), then checked: one version line per file, the `redisvl` entry specifically, and `uv lock --check`. Both files are committed together.
> 
> Lint CI gains a `lock` job that runs `uv lock --check` so dependency-spec changes without a re-lock fail on the PR. CONTRIBUTING notes that contributors should run `uv lock` when changing deps. This PR also aligns the lock's `redisvl` version to `0.26.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53aa941331d3b4771ff05ee3a8e52893a551fd48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->