### PR TITLE
fix: replace shared mutable connection_kwargs defaults with None sentinels

### DIFF
--- a/redisvl/extensions/cache/base.py
+++ b/redisvl/extensions/cache/base.py
@@ -31,7 +31,7 @@ class BaseCache:
         redis_client: SyncRedisClient | None = None,
         async_redis_client: AsyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] | None = None,
     ):
         """Initialize a base cache.
 
@@ -45,6 +45,7 @@ class BaseCache:
             connection_kwargs (Dict[str, Any]): The connection arguments
                 for the redis client. Defaults to empty {}.
         """
+        connection_kwargs = connection_kwargs or {}
         self.name = name
         self._ttl: int | None = None
         self.set_ttl(ttl)

--- a/redisvl/extensions/cache/embeddings/embeddings.py
+++ b/redisvl/extensions/cache/embeddings/embeddings.py
@@ -23,7 +23,7 @@ class EmbeddingsCache(BaseCache):
         redis_client: SyncRedisClient | None = None,
         async_redis_client: AsyncRedisClient | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] | None = None,
     ):
         """Initialize an embeddings cache.
 
@@ -45,6 +45,7 @@ class EmbeddingsCache(BaseCache):
                 redis_url="redis://localhost:6379"
             )
         """
+        connection_kwargs = connection_kwargs or {}
         super().__init__(
             name=name,
             ttl=ttl,

--- a/redisvl/extensions/cache/llm/semantic.py
+++ b/redisvl/extensions/cache/llm/semantic.py
@@ -67,7 +67,7 @@ class SemanticCache(BaseLLMCache):
         filterable_fields: list[dict[str, Any]] | None = None,
         redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] | None = None,
         overwrite: bool = False,
         create_index: bool = True,
         **kwargs,
@@ -127,6 +127,7 @@ class SemanticCache(BaseLLMCache):
                 create_index=False,
             )
         """
+        connection_kwargs = connection_kwargs or {}
         if not create_index and overwrite:
             raise ValueError(CREATE_INDEX_OVERWRITE_CONFLICT)
 

--- a/redisvl/extensions/message_history/message_history.py
+++ b/redisvl/extensions/message_history/message_history.py
@@ -32,7 +32,7 @@ class MessageHistory(BaseMessageHistory):
         prefix: str | None = None,
         redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] | None = None,
         create_index: bool = True,
         **kwargs,
     ):
@@ -66,6 +66,7 @@ class MessageHistory(BaseMessageHistory):
                 Defaults to True.
 
         """
+        connection_kwargs = connection_kwargs or {}
         super().__init__(name, session_tag)
 
         prefix = prefix or name
@@ -182,7 +183,7 @@ class MessageHistory(BaseMessageHistory):
             ValueError: if top_k is not an integer greater than or equal to 0,
                 or if role contains invalid values.
         """
-        if type(top_k) != int or top_k < 0:
+        if type(top_k) is not int or top_k < 0:
             raise ValueError("top_k must be an integer greater than or equal to 0")
 
         # Validate and normalize role parameter

--- a/redisvl/extensions/message_history/semantic_history.py
+++ b/redisvl/extensions/message_history/semantic_history.py
@@ -41,7 +41,7 @@ class SemanticMessageHistory(BaseMessageHistory):
         distance_threshold: float = 0.3,
         redis_client: Redis | None = None,
         redis_url: str = "redis://localhost:6379",
-        connection_kwargs: dict[str, Any] = {},
+        connection_kwargs: dict[str, Any] | None = None,
         overwrite: bool = False,
         create_index: bool = True,
         **kwargs,
@@ -84,6 +84,7 @@ class SemanticMessageHistory(BaseMessageHistory):
         The proposed schema will support a single vector embedding constructed
         from either the prompt or response in a single string.
         """
+        connection_kwargs = connection_kwargs or {}
         if not create_index and overwrite:
             raise ValueError(CREATE_INDEX_OVERWRITE_CONFLICT)
 


### PR DESCRIPTION
## Summary

All five extension constructors declare `connection_kwargs: dict[str, Any] = {}` (ruff B006). Python evaluates defaults once at import, so a single dict object is shared by every cache/history instance created without explicit kwargs — a latent cross-instance state-leak hazard for anything that mutates or stores it:

- `extensions/cache/base.py` (`BaseCache`)
- `extensions/cache/embeddings/embeddings.py`
- `extensions/cache/llm/semantic.py`
- `extensions/message_history/message_history.py`
- `extensions/message_history/semantic_history.py`

Each becomes `dict[str, Any] | None = None` with `connection_kwargs = connection_kwargs or {}` as the first statement after the docstring, so every existing caller — including ones passing `None` or `{}` explicitly — behaves identically.

Also included: `type(top_k) != int` → `type(top_k) is not int` in `message_history.py` (E721; identity is the intended semantics, and this preserves the exact-type check that rejects `bool`).

## Testing
`python -m py_compile` passes on all five files; `ruff check --select B006,E721` on the touched files goes clean. Scoped deliberately to the extension constructors — other B006 instances elsewhere in the repo are left for a follow-up if maintainers want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constructor default and type-check cleanup only; behavior for existing callers is unchanged. No auth, data-path, or Redis protocol changes.
> 
> **Overview**
> Stops cache and message-history constructors from sharing one default `connection_kwargs` dict (B006). `BaseCache`, `EmbeddingsCache`, `SemanticCache`, `MessageHistory`, and `SemanticMessageHistory` now take `None` and assign `connection_kwargs = connection_kwargs or {}` so each instance gets its own dict.
> 
> Also switches `MessageHistory.get_recent` from `type(top_k) != int` to `type(top_k) is not int` (E721), keeping the exact-type check that rejects `bool`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6039d82c81241792252ed0d05b940d5a19a31a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->