### PR TITLE
fix: preserve Redis client ownership boundaries

### DIFF
--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -964,9 +964,14 @@ class SearchIndex(BaseSearchIndex):
             ModuleNotFoundError: If required Redis modules are not installed.
         """
         self.invalidate_sql_schema_cache()
+        if self._owns_redis_client:
+            self._detach_client_finalizer()
+            if self.__redis_client is not None:
+                self.__redis_client.close()
         self.__redis_client = RedisConnectionFactory.get_redis_connection(
             redis_url=redis_url, **kwargs
         )
+        self._owns_redis_client = True
         self._register_client_finalizer(self.__redis_client)
 
     @deprecated_function("set_client", "Pass connection parameters in __init__.")
@@ -986,7 +991,12 @@ class SearchIndex(BaseSearchIndex):
         """
         RedisConnectionFactory.validate_sync_redis(redis_client)
         self.invalidate_sql_schema_cache()
+        if self._owns_redis_client:
+            self._detach_client_finalizer()
+            if self.__redis_client is not None:
+                self.__redis_client.close()
         self.__redis_client = redis_client
+        self._owns_redis_client = False
         self._register_client_finalizer(redis_client)
         return self
 

--- a/redisvl/index/index.py
+++ b/redisvl/index/index.py
@@ -964,13 +964,14 @@ class SearchIndex(BaseSearchIndex):
             ModuleNotFoundError: If required Redis modules are not installed.
         """
         self.invalidate_sql_schema_cache()
+        new_client = RedisConnectionFactory.get_redis_connection(
+            redis_url=redis_url, **kwargs
+        )
         if self._owns_redis_client:
             self._detach_client_finalizer()
             if self.__redis_client is not None:
                 self.__redis_client.close()
-        self.__redis_client = RedisConnectionFactory.get_redis_connection(
-            redis_url=redis_url, **kwargs
-        )
+        self.__redis_client = new_client
         self._owns_redis_client = True
         self._register_client_finalizer(self.__redis_client)
 

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -7,6 +7,7 @@ from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.extensions.router.semantic import SemanticRouter
 from redisvl.index import AsyncSearchIndex, SearchIndex
 from redisvl.query.sql import SQLQuery
+from redisvl.schema import IndexSchema
 
 
 def _schema_dict(name: str = "idx") -> dict:
@@ -57,6 +58,48 @@ def test_search_index_from_existing_prefers_provided_client():
     mock_get_connection.assert_not_called()
     mock_info.assert_called_once_with("search-index", provided_client)
     assert index.client is provided_client
+
+
+def test_search_index_set_client_releases_owned_client_without_taking_ownership():
+    owned_client = MagicMock()
+    provided_client = MagicMock()
+    with patch(
+        "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+        return_value=owned_client,
+    ):
+        index = SearchIndex(
+            IndexSchema.from_dict(_schema_dict()), redis_url="redis://localhost:6379"
+        )
+        assert index._redis_client is owned_client
+
+    with patch("redisvl.index.index.RedisConnectionFactory.validate_sync_redis"):
+        index.set_client(provided_client)
+
+    owned_client.close.assert_called_once_with()
+    assert index.client is provided_client
+    assert index._owns_redis_client is False
+    index.disconnect()
+    provided_client.close.assert_not_called()
+
+
+def test_search_index_connect_keeps_ownership_after_replacing_owned_client():
+    first_client = MagicMock()
+    second_client = MagicMock()
+    with patch(
+        "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+        side_effect=[first_client, second_client],
+    ):
+        index = SearchIndex(
+            IndexSchema.from_dict(_schema_dict()), redis_url="redis://first:6379"
+        )
+        assert index._redis_client is first_client
+        index.connect("redis://second:6379")
+
+    first_client.close.assert_called_once_with()
+    assert index._redis_client is second_client
+    assert index._owns_redis_client is True
+    index.disconnect()
+    second_client.close.assert_called_once_with()
 
 
 def test_search_index_from_existing_owns_factory_created_client():
@@ -138,6 +181,25 @@ async def test_async_search_index_from_existing_prefers_provided_client():
     mock_get_connection.assert_not_awaited()
     mock_info.assert_awaited_once_with("async-search-index", provided_client)
     assert index.client is provided_client
+
+
+@pytest.mark.asyncio
+async def test_async_search_index_set_client_does_not_take_ownership():
+    provided_client = AsyncMock()
+    index = AsyncSearchIndex(
+        IndexSchema.from_dict(_schema_dict()), redis_client=provided_client
+    )
+
+    replacement = AsyncMock()
+    with patch.object(
+        index, "_validate_client", new=AsyncMock(return_value=replacement)
+    ):
+        await index.set_client(replacement)
+
+    assert index.client is replacement
+    assert index._owns_redis_client is False
+    provided_client.aclose.assert_not_awaited()
+    replacement.aclose.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_connection_normalization.py
+++ b/tests/unit/test_connection_normalization.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from redis.exceptions import ConnectionError
 
 from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.extensions.router.semantic import SemanticRouter
@@ -100,6 +101,28 @@ def test_search_index_connect_keeps_ownership_after_replacing_owned_client():
     assert index._owns_redis_client is True
     index.disconnect()
     second_client.close.assert_called_once_with()
+
+
+def test_search_index_connect_preserves_live_client_when_replacement_fails():
+    first_client = MagicMock()
+    connection_error = ConnectionError("replacement unavailable")
+    with patch(
+        "redisvl.index.index.RedisConnectionFactory.get_redis_connection",
+        side_effect=[first_client, connection_error],
+    ):
+        index = SearchIndex(
+            IndexSchema.from_dict(_schema_dict()), redis_url="redis://first:6379"
+        )
+        assert index._redis_client is first_client
+
+        with pytest.raises(ConnectionError, match="replacement unavailable"):
+            index.connect("redis://unavailable:6379")
+
+    assert index.client is first_client
+    assert index._owns_redis_client is True
+    first_client.close.assert_not_called()
+    index.disconnect()
+    first_client.close.assert_called_once_with()
 
 
 def test_search_index_from_existing_owns_factory_created_client():


### PR DESCRIPTION
## Summary

Fixes #660.

`SearchIndex.set_client()` could keep ownership of a caller-provided Redis client and close it during disconnect or garbage collection. It also left the previously owned client open when replacing it. The sync `connect()` path had the corresponding replacement-lifecycle gap.

This change closes a previously owned client before replacement, marks clients supplied through `set_client()` as unowned, and keeps clients created by `connect()` owned by the index. Async ownership behavior is preserved and covered by a focused regression test.

## Compatibility

Explicitly injected clients are no longer closed by the index, matching constructor injection semantics. Clients created by `connect()` remain index-owned and are closed as before. No Redis protocol or data behavior changes.

## Validation

- `.venv\\Scripts\\python.exe -m pytest tests/unit/test_connection_normalization.py -q --confcutdir=tests/unit -p pytest_asyncio` — 12 passed.
- `.venv\\Scripts\\python.exe -m pytest tests/unit/test_index_gc_finalizer.py -q --confcutdir=tests/unit -p pytest_asyncio` — 11 passed.
- `python -m ruff check redisvl/index/index.py tests/unit/test_connection_normalization.py tests/unit/test_index_gc_finalizer.py` — passed.
- `python -m ruff format --check redisvl/index/index.py tests/unit/test_connection_normalization.py` — passed.
- `git diff --check` — passed.

The repository Docker-based test fixture was attempted, but pulling `redis:8.4` failed with a registry EOF before any service started. The changed paths are covered by service-free unit tests; full Docker-backed integration tests were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection teardown and who may close shared Redis clients; behavior shift for code using `set_client()` with external clients, but no protocol or data-path changes.
> 
> **Overview**
> Fixes incorrect **Redis client lifecycle** when `SearchIndex` swaps connections via deprecated `connect()` or `set_client()`.
> 
> **`set_client()`** now marks injected clients as **not owned** (`_owns_redis_client = False`), so `disconnect()` and GC finalizers no longer close caller-managed clients. When replacing an index-owned client, it **detaches the finalizer and closes** the previous client first.
> 
> **`connect()`** builds the new client before mutating state, so a failed reconnect **leaves the existing client intact**. On success it closes any previously owned client, assigns the new one, and keeps **index ownership** for factory-created clients.
> 
> Unit tests cover sync replacement, failed `connect()`, and async `set_client()` not taking ownership—aligned with constructor-injected client semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19689d4d4c43a7adb7f62c3aa3673a5f652a1976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->