### PR TITLE
docs: explain Redis 8 concurrent search visibility

### DIFF
--- a/docs/concepts/search-and-indexing.md
+++ b/docs/concepts/search-and-indexing.md
@@ -84,6 +84,17 @@ index = SearchIndex.from_existing("my-index", redis_url="redis://localhost:6379"
 
 **Clearing data** with `clear()` removes all documents from the index without deleting the index itself. The schema remains intact, ready for new data.
 
+## Search Visibility Under Concurrent Writes
+
+On Redis 8.8 and later, RediSearch uses a multithreaded background worker pool by default. Under concurrent write and query load, a document can be present in Redis but not yet visible to a search query issued immediately after the write. For example, a query immediately following `load()` may temporarily return fewer documents than were loaded:
+
+```python
+index.load(records)
+results = index.query(query)  # may not include every newly loaded document yet
+```
+
+This is a short indexing window rather than data loss; a later query should observe the documents after the index catches up. It can affect ingestion pipelines and read-after-write checks that query through the index immediately after writing. If an application requires foreground indexing and can accept the associated performance trade-off, configure Redis with `--search-workers 0` to disable the background worker pool. This setting is controlled by the Redis server, not by RedisVL.
+
 ## Bulk Delete and Update
 
 Redis has no server-side "delete/update by query", so mutating many documents traditionally means scanning for keys and issuing writes yourself. RedisVL wraps that pattern behind two filter-driven methods (available on both `SearchIndex` and `AsyncSearchIndex`).


### PR DESCRIPTION
## Summary

Document the temporary search visibility window that Redis 8.8+ can introduce under concurrent write and query load.

## Changes

- Added a Search & Indexing section describing the read-after-write behavior.
- Included a `load()` followed by `query()` example and clarified that this is indexing latency, not data loss.
- Documented the Redis server-side `--search-workers 0` option for workloads that require foreground indexing, including its performance trade-off.

## Validation

- `uv run sphinx-build -b html docs docs/_build/html --keep-going` — passed.
- `uv run black --check redisvl tests` — passed (249 files unchanged).
- `uv run isort --check-only redisvl tests --profile black` — passed.
- `uv run mypy redisvl` — passed.
- `git diff --check` — passed.

The strict documentation build with `-W` still reports two pre-existing cross-reference warnings in `docs/user_guide/how_to_guides/mcp.md` and `mcp_authentication.md`; the normal build completes successfully.

## Compatibility

Documentation-only change. No RedisVL runtime behavior is modified.

Fixes #662.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a **Search Visibility Under Concurrent Writes** section to the Search & Indexing concepts doc, complementing existing Redis 8.8+ notes in `queries.md` about background workers.
> 
> The new text explains that on Redis 8.8+, RediSearch’s default multithreaded worker pool can leave freshly written documents **temporarily invisible** to an immediate `query()` after `load()`—indexing latency, not data loss. It warns ingestion pipelines and read-after-write checks that query the index right after writes, and points operators to the Redis server flag `--search-workers 0` when foreground indexing is required, with the performance trade-off noted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5e070b21213ecbdb763961409fcc212edd3bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->