### PR TITLE
docs: explain post-write search visibility

### DIFF
--- a/docs/concepts/search-and-indexing.md
+++ b/docs/concepts/search-and-indexing.md
@@ -84,6 +84,19 @@ index = SearchIndex.from_existing("my-index", redis_url="redis://localhost:6379"
 
 **Clearing data** with `clear()` removes all documents from the index without deleting the index itself. The schema remains intact, ready for new data.
 
+## Search Visibility After Writes
+
+On Redis 8.8 and later, deployments with a nonzero `search-workers` setting use background workers for search indexing. Under concurrent write and query load, a document can already exist in the Redis keyspace but not yet be visible to a search issued immediately after the write. For example, a query directly after `load()` can temporarily return fewer documents than were loaded:
+
+```python
+index.load(records)
+results = index.query(query)  # may not include every newly loaded document yet
+```
+
+This is a short indexing delay, not data loss. A later query sees the documents after the index catches up. The measurements reported in [Issue #662](https://github.com/redis/redis-vl-python/issues/662) typically converged within 1–3 ms, but that observation is not a latency guarantee and the window can vary with workload and server capacity.
+
+Applications that require strict search read-after-write behavior can start Redis with `--search-workers 0`. This is a Redis server setting, not a RedisVL option: it keeps indexing in the foreground but gives up the throughput benefits of multithreaded background indexing.
+
 ## Bulk Delete and Update
 
 Redis has no server-side "delete/update by query", so mutating many documents traditionally means scanning for keys and issuing writes yourself. RedisVL wraps that pattern behind two filter-driven methods (available on both `SearchIndex` and `AsyncSearchIndex`).


### PR DESCRIPTION
## Summary

- Explain the Redis 8.8+ search visibility window under concurrent writes and queries when background search workers are enabled.
- Clarify that the data remains in the keyspace and that the reported 1–3 ms convergence is an observation, not a latency guarantee.
- Document the Redis server-side `--search-workers 0` option and its indexing-throughput trade-off.

## Validation

- `uv run --frozen sphinx-build -b html docs docs/_build/html --keep-going` (passed; 12 pre-existing warnings in untouched files)
- `uv run --frozen codespell docs/concepts/search-and-indexing.md`
- `git diff --check`

Documentation-only (`auto:documentation`).

Fixes #662.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Search Visibility After Writes** section to the search-and-indexing concept doc, describing how Redis 8.8+ with background `search-workers` can briefly hide newly written documents from immediate queries (e.g. right after `load()`).
> 
> The new text frames this as indexing lag rather than data loss, cites issue #662’s ~1–3 ms observations without treating them as an SLA, and documents the Redis server flag `--search-workers 0` for strict read-after-write at the cost of background indexing throughput.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e158fbbe3900257aadb2f1957e0f640acf79e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->