### PR TITLE
feat(mcp): declarative custom tool profiles over search-records

### DIFF
--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -86,7 +86,7 @@ MCP-reserved score metadata field names for the configured search mode.
 
 ## Read-Only and Read-Write Modes
 
-RedisVL MCP registers `search-records` and `list-indexes` by default (see [Tool Surface](#tool-surface) for turning a built-in off deliberately).
+RedisVL MCP registers `search-records` and `list-indexes` by default (see [Custom Tool Profiles](#custom-tool-profiles) for turning a built-in off deliberately).
 
 Write availability is enforced at two levels:
 
@@ -105,13 +105,13 @@ For configuration and the gateway boundary, see {doc}`/user_guide/how_to_guides/
 
 ## Tool Surface
 
-RedisVL MCP exposes up to three built-in tools:
+RedisVL MCP exposes up to three built-in tools, plus any configured [custom tool profiles](#custom-tool-profiles):
 
 - `list-indexes` enumerates the configured logical indexes for discovery
 - `search-records` searches a selected index using that index's server-owned search mode
 - `upsert-records` validates and upserts records into a selected writable index, embedding them only when that capability is configured
 
-Any of the three can be turned off with `server.builtin_tools` — useful for a server that should only ever read, or one that should not advertise discovery:
+Any of the three can be turned off with `server.builtin_tools`, independently of whether custom tools are configured — useful for a server that should only ever read, or one that serves nothing but curated profiles:
 
 ```yaml
 server:
@@ -130,7 +130,7 @@ A server whose tool set ends up unusable — no tools at all, or discovery disab
 
 Tools register once per process. `builtin_tools` is re-read on restart, but the registered tool set is not rebuilt, so a stop/start against an edited config keeps the previous tools and logs a warning saying so. Start a new process to change the tool surface.
 
-These tools follow a stable contract:
+These built-in tools follow a stable contract (profiles differ where noted in [Custom Tool Profiles](#custom-tool-profiles) — notably they accept the object filter form only):
 
 - request validation happens before query or write execution
 - the resolved logical `index` is echoed in every `search-records` and `upsert-records` response
@@ -153,6 +153,49 @@ The discovery payload is deliberately minimal:
 - the underlying Redis index name (`redis_name`) is **never** exposed
 - the vector field and the configured embed-source text field are **omitted** from `fields`, since they are implementation inputs rather than fields a client filters on
 - `limits` shows only explicitly set values (such as `max_limit` or `max_upsert_records`); defaults are not echoed
+
+## Custom Tool Profiles
+
+The built-in tools expose the index generically, which leaves the model doing query engineering on every call: pick the index, understand the schema, build a filter, choose return fields. A **profile** moves those decisions into config. It is `search-records` with some arguments pre-filled and frozen and the rest still exposed, published under a name and description of your choosing.
+
+Profiles are pure configuration. You add a `custom_tools` entry to the same YAML the server already loads and restart it; there is no Python to write.
+
+```yaml
+custom_tools:
+  - name: search-support-tickets
+    based_on: search-records
+    index: support_tickets
+    description: >
+      Search historical customer support tickets by semantic similarity.
+      Use this to find prior resolutions for a customer problem.
+    lock:
+      return_fields: [subject, resolution, created_at]
+      filter: { field: status, op: eq, value: resolved }
+    params:
+      limit: { expose: true, max: 20 }
+      filter: { expose: true }
+```
+
+`lock` holds what the author decides; `params` holds what the model may still pass. Anything not listed in `params` stays exposed, so a profile that only locks a filter keeps the rest of the built-in's contract. `index` is pinned by the top-level `index:` key rather than exposed as a param, and may be omitted only when exactly one index is configured.
+
+`params.limit.max` bounds the result count. It applies whether the model names a limit or leaves it out — an omitted limit is capped rather than falling through to the binding's default. An explicit request above the cap is rejected. When `limit` is hidden (`expose: false`), the cap becomes the fixed result count instead. The cap must not exceed the binding's own `runtime.max_limit`, which is checked at startup. Note that it bounds page size, not total reachable data: `offset` is a separate argument, so paging is still possible up to the binding's `max_result_window`.
+
+`suppress_schema_hints: true` drops the auto-generated field hints from the tool description. Those hints enumerate filterable and returnable fields, which is noise once those arguments are locked — and by default they are appended only for arguments the model can still use.
+
+Two things about filters are easy to conflate:
+
+- `lock.filter` is an ordinary expression in the JSON filter DSL. Its `and`/`or`/`not` operators describe the locked filter's own content.
+- How the locked filter combines with a model-supplied one is fixed and not configurable: the executed query is always `locked AND caller`. A compound model-supplied expression renders parenthesized, so its `or`/`not` nests *inside* the locked AND and cannot reach the top level — the model can only narrow within the locked scope and never widen past it.
+
+For that reason a profile accepts only the **object** form of a filter from the model. A raw filter string is rejected both by the advertised schema and by the tool itself, because strings bypass the DSL's field validation and have no safe composition with a locked expression.
+
+Structure is only half of it: the nesting guarantee holds only while every filter *value* stays inside its own clause. Text values are escaped at the filter boundary for that reason — unescaped, a value containing a quote or a parenthesis could close its clause and inject query syntax after it, including a `|` that escapes the surrounding AND. Tag values are escaped and numeric values are type-checked. A caller filter that still renders as something able to break out is refused rather than combined.
+
+Profiles resolve to a built-in call and nothing more, so they inherit the concurrency cap, request timeout, read-only policy, auth scoping, and error mapping already applied to `search-records`.
+
+Because adding near-duplicate tools makes tool selection harder rather than easier, built-ins that curated profiles supersede can be turned off with `server.builtin_tools` (see [Tool Surface](#tool-surface)).
+
+Misconfiguration fails at startup rather than at the first call. Among the checks: a name colliding with a built-in or using a reserved `redisvl-`/`redisvl_` prefix; a duplicate tool name; a missing or unknown `index`; a `params` key that is not a real argument; `max` on anything but `limit`, or a cap above the binding's `max_limit`; hiding `query`; locking `return_fields` while also exposing them; and a locked filter or projection naming a field the bound index does not have. Unrecognized keys are rejected too, so a typo in `lock` fails loudly instead of silently producing a tool that reads as locked but enforces nothing.
 
 ## Why Use MCP Instead of Direct RedisVL Calls
 

--- a/docs/user_guide/how_to_guides/mcp.md
+++ b/docs/user_guide/how_to_guides/mcp.md
@@ -286,6 +286,60 @@ On a multi-index server, `search-records` and `upsert-records` take an optional 
 - With multiple indexes configured, omitting `index` returns `invalid_request`; an unknown id also returns `invalid_request`.
 - Clients should call [`list-indexes`](#list-indexes) first to discover the available ids and their filterable fields.
 
+### Custom Tool Profiles
+
+A **profile** publishes `search-records` under your own name and description with some arguments pre-filled and frozen. It is pure config — no Python — and it resolves to a built-in call, so it inherits the same limits, read-only policy, auth scoping, and error contract.
+
+```yaml
+server:
+  redis_url: redis://localhost:6379
+  builtin_tools:
+    search-records: disabled          # the curated tool replaces it
+
+indexes:
+  tickets:
+    redis_name: support-tickets
+    search:
+      type: fulltext
+    runtime:
+      text_field_name: body
+      default_limit: 5
+      max_limit: 20
+
+custom_tools:
+  - name: search-resolved-tickets
+    based_on: search-records
+    index: tickets
+    description: >
+      Search resolved customer support tickets by relevance.
+      Use this to find how a similar problem was fixed before.
+    lock:
+      return_fields: [subject, resolution, created_at]
+      filter: { field: status, op: eq, value: resolved }
+    params:
+      limit: { expose: true, max: 10 }
+      filter: { expose: true }
+```
+
+What the client sees for `search-resolved-tickets`:
+
+- `query` (required), `limit` (≤ 10), `offset`, and `filter` — and nothing else.
+- No `index` argument: the binding is pinned by `index:` in the config.
+- No `return_fields` argument: locking a projection removes it from the contract.
+- `filter` accepts the **object** form only. A raw string filter is refused — by the advertised schema for a compliant client, and by the tool itself otherwise.
+
+Rules worth knowing:
+
+- **Anything not listed under `params` stays exposed.** Locking only a filter keeps the rest of the built-in's contract intact.
+- **Locked and caller filters are AND-combined.** The caller can narrow within the locked scope but never widen past it — an `or` from the caller nests inside the locked AND rather than replacing it.
+- **`params.limit.max` bounds the result count either way.** An omitted `limit` is capped rather than falling through to `default_limit`; an explicit request above the cap returns `invalid_request`. With `expose: false`, the cap becomes the fixed result count. The cap may not exceed the binding's `max_limit`. It bounds page size, not total reachable data — `offset` still pages within `max_result_window`.
+- **`suppress_schema_hints: true`** drops the auto-generated filter/return-field hints from the description. By default they are appended only for arguments the model can still use.
+- **`index` may be omitted only with exactly one index configured.**
+
+`builtin_tools` is independent of profiles: use it to stop advertising any built-in, for example `upsert-records: disabled` on a server that should only read. Disabling `list-indexes` on a multi-index server logs a warning, because `search-records` tells clients to call it to discover index ids.
+
+Misconfiguration fails at startup, not at the first call — a name colliding with a built-in or using a reserved `redisvl-`/`redisvl_` prefix, a duplicate name, a missing or unknown `index`, a cap above `max_limit`, hiding `query`, locking `return_fields` while also exposing them, or a locked filter or projection naming a field the index does not have. Unrecognized keys are rejected too, so a typo in `lock` fails loudly instead of quietly producing a tool that reads as locked but enforces nothing.
+
 ## Tool Contracts
 
 RedisVL MCP exposes a small, implementation-owned contract.

--- a/redisvl/mcp/config.py
+++ b/redisvl/mcp/config.py
@@ -27,6 +27,20 @@ _RESERVED_SCORE_METADATA_FIELDS = frozenset(
 
 
 _BUILTIN_TOOL_NAMES = frozenset({"list-indexes", "search-records", "upsert-records"})
+# Both separators are reserved because the name pattern permits either, so
+# `redisvl_search` must be refused exactly like `redisvl-search`.
+_RESERVED_TOOL_NAME_PREFIXES = ("redisvl-", "redisvl_")
+# MCP clients commonly constrain tool names to this character set, so names that
+# would be unusable on some hosts (dots, spaces, uppercase) are rejected here
+# rather than at invocation time. Hyphens match the built-ins by convention.
+_TOOL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+# Caller-facing arguments a profile may govern. The built-in search tool also
+# exposes `index`, which is deliberately absent here: a profile pins its binding
+# through the top-level `index:` key rather than offering it to the model. Search
+# mode and tuning are binding config and never reach the model at all.
+_PROFILE_PARAM_NAMES = frozenset(
+    {"query", "limit", "offset", "filter", "return_fields"}
+)
 
 
 def reserved_score_metadata_field_names() -> frozenset[str]:
@@ -590,6 +604,162 @@ class MCPIndexBindingConfig(BaseModel):
             )
 
 
+class MCPProfileParamConfig(BaseModel):
+    """Exposure policy for one model-facing argument of a profile tool.
+
+    ``max`` caps the argument when it is exposed. When it is hidden, the cap
+    becomes the fixed value instead -- see ``register_profile_tool``.
+    """
+
+    # Extras are forbidden across the profile models because a misspelled key
+    # would otherwise be dropped in silence, leaving a tool that reads as locked
+    # in config while enforcing nothing.
+    model_config = ConfigDict(extra="forbid")
+
+    expose: bool = True
+    max: int | None = None
+
+    @model_validator(mode="after")
+    def _validate_max(self) -> "MCPProfileParamConfig":
+        """Reject a non-positive cap."""
+        if self.max is not None and self.max <= 0:
+            raise ValueError("custom_tools params max must be greater than 0")
+        return self
+
+
+class MCPProfileLockConfig(BaseModel):
+    """Author-locked arguments that the model cannot override or remove."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    return_fields: list[str] | None = None
+    filter: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _validate_lock(self) -> "MCPProfileLockConfig":
+        """Reject an empty or blank projection.
+
+        The annotations already give the rest: pydantic enforces ``list[str]``
+        and ``dict``, so a locked filter is necessarily the structured DSL form
+        rather than a raw string, which could not be safely AND-combined with a
+        caller filter.
+        """
+        if self.return_fields is not None:
+            if not self.return_fields:
+                raise ValueError(
+                    "custom_tools lock.return_fields must contain at least one field"
+                )
+            if any(not field_name.strip() for field_name in self.return_fields):
+                raise ValueError(
+                    "custom_tools lock.return_fields must contain non-empty strings"
+                )
+        return self
+
+
+class MCPCustomToolConfig(BaseModel):
+    """A declarative custom tool that specializes a built-in.
+
+    A profile is the built-in named by ``based_on`` with some arguments frozen by
+    the author and the rest still exposed to the model. Because it resolves to a
+    built-in call and nothing more, it inherits that built-in's concurrency cap,
+    timeout, read-only policy, auth scoping, and error mapping.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1)
+    kind: Literal["profile"] = "profile"
+    based_on: Literal["search-records"] = "search-records"
+    index: str | None = None
+    description: str = Field(..., min_length=1)
+    suppress_schema_hints: bool = False
+    lock: MCPProfileLockConfig = Field(default_factory=MCPProfileLockConfig)
+    params: dict[str, MCPProfileParamConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_profile(self) -> "MCPCustomToolConfig":
+        """Validate naming, parameter policy, and lock/expose coherence."""
+        if not self.description.strip():
+            # min_length alone lets whitespace through, which would publish a
+            # tool whose description is blank to the model.
+            raise ValueError(
+                f"custom_tools '{self.name}' description must not be blank"
+            )
+        if not _TOOL_NAME_PATTERN.match(self.name):
+            raise ValueError(
+                f"custom_tools name '{self.name}' is invalid; names must start with a "
+                "lowercase letter and contain only lowercase letters, digits, "
+                "hyphens, or underscores (max 64 characters)"
+            )
+        if self.name in builtin_tool_names():
+            raise ValueError(
+                f"custom_tools name '{self.name}' collides with a built-in tool; "
+                "built-in names are reserved"
+            )
+        if self.name.startswith(_RESERVED_TOOL_NAME_PREFIXES):
+            raise ValueError(
+                f"custom_tools name '{self.name}' uses a reserved prefix "
+                f"({', '.join(_RESERVED_TOOL_NAME_PREFIXES)})"
+            )
+
+        unknown_params = sorted(set(self.params) - _PROFILE_PARAM_NAMES)
+        if unknown_params:
+            raise ValueError(
+                f"custom_tools params contains unknown arguments: "
+                f"{', '.join(unknown_params)}; allowed: "
+                f"{', '.join(sorted(_PROFILE_PARAM_NAMES))}"
+            )
+
+        # Only `limit` is a bounded numeric argument, so a cap is meaningless
+        # anywhere else and is more likely a config mistake than an intent.
+        for param_name, policy in self.params.items():
+            if policy.max is not None and param_name != "limit":
+                raise ValueError(
+                    f"custom_tools params.{param_name} does not support 'max'; "
+                    "only params.limit can be capped"
+                )
+
+        query_policy = self.params.get("query")
+        if query_policy is not None and not query_policy.expose:
+            raise ValueError(
+                "custom_tools params.query cannot be hidden; a search profile "
+                "needs query text from the caller"
+            )
+
+        # Locking a projection and letting the model choose one are mutually
+        # exclusive. A filter is the deliberate exception: locked plus exposed is
+        # the narrowing case, where the caller's filter AND-combines with the
+        # locked one.
+        return_fields_policy = self.params.get("return_fields")
+        if self.lock.return_fields is not None and (
+            return_fields_policy is not None and return_fields_policy.expose
+        ):
+            raise ValueError(
+                "custom_tools cannot both lock return_fields and expose them; "
+                "set params.return_fields.expose to false or drop the lock"
+            )
+        return self
+
+    def param_exposed(self, param_name: str) -> bool:
+        """Report whether the model may supply an argument.
+
+        Unlisted arguments stay exposed, so a profile that only locks a filter
+        keeps the rest of the built-in's contract. A locked projection is the
+        exception: locking it implies the model cannot also pass one.
+        """
+        policy = self.params.get(param_name)
+        if policy is not None:
+            return policy.expose
+        if param_name == "return_fields" and self.lock.return_fields is not None:
+            return False
+        return True
+
+    def param_max(self, param_name: str) -> int | None:
+        """Return the author-declared cap for an argument, if any."""
+        policy = self.params.get(param_name)
+        return None if policy is None else policy.max
+
+
 class MCPConfig(BaseModel):
     """Validated MCP server configuration loaded from YAML.
 
@@ -600,6 +770,7 @@ class MCPConfig(BaseModel):
 
     server: MCPServerConfig
     indexes: dict[str, MCPIndexBindingConfig]
+    custom_tools: list[MCPCustomToolConfig] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _validate_bindings(self) -> "MCPConfig":
@@ -611,6 +782,60 @@ class MCPConfig(BaseModel):
             if not binding_id.strip():
                 raise ValueError("indexes binding id must be non-blank")
         return self
+
+    @model_validator(mode="after")
+    def _validate_custom_tools(self) -> "MCPConfig":
+        """Validate custom tool names and index pinning against the bindings.
+
+        Field-level checks that need the inspected schema (locked filter fields,
+        locked projections) run at startup once each binding's schema is known.
+        """
+        seen: set[str] = set()
+        for profile in self.custom_tools:
+            if profile.name in seen:
+                raise ValueError(
+                    f"custom_tools contains duplicate tool name '{profile.name}'"
+                )
+            seen.add(profile.name)
+
+            if profile.index is None:
+                # A profile freezes its index, so it can only default when there
+                # is exactly one binding to default to.
+                if len(self.indexes) > 1:
+                    available = ", ".join(sorted(self.indexes))
+                    raise ValueError(
+                        f"custom_tools '{profile.name}' must set 'index' when "
+                        f"multiple indexes are configured; available: {available}"
+                    )
+            elif profile.index not in self.indexes:
+                available = ", ".join(sorted(self.indexes))
+                raise ValueError(
+                    f"custom_tools '{profile.name}' references unknown index "
+                    f"'{profile.index}'; available: {available}"
+                )
+
+            # A cap above the binding's own ceiling can never be satisfied. With
+            # `limit` hidden the cap becomes the fixed request size, so every
+            # call would fail; with it exposed the cap is simply unreachable.
+            # Either way it is a config mistake, catchable before startup.
+            limit_cap = profile.param_max("limit")
+            if limit_cap is not None:
+                binding_max = self.indexes[
+                    self.resolved_profile_index(profile)
+                ].runtime.max_limit
+                if limit_cap > binding_max:
+                    raise ValueError(
+                        f"custom_tools '{profile.name}' params.limit.max "
+                        f"({limit_cap}) exceeds the bound index's "
+                        f"runtime.max_limit ({binding_max})"
+                    )
+        return self
+
+    def resolved_profile_index(self, profile: MCPCustomToolConfig) -> str:
+        """Return the binding id a profile is pinned to."""
+        if profile.index is not None:
+            return profile.index
+        return next(iter(self.indexes))
 
 
 def _substitute_env(value: Any) -> Any:

--- a/redisvl/mcp/server.py
+++ b/redisvl/mcp/server.py
@@ -16,6 +16,10 @@ from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.runtime import BindingRuntime
 from redisvl.mcp.settings import MCPSettings
 from redisvl.mcp.tools.list_indexes import register_list_indexes_tool
+from redisvl.mcp.tools.profiles import (
+    register_profile_tools,
+    validate_profile_against_schema,
+)
 from redisvl.mcp.tools.search import register_search_tool
 from redisvl.mcp.tools.upsert import register_upsert_tool
 from redisvl.mcp.transport_security import (
@@ -271,30 +275,56 @@ class RedisVLMCPServer(FastMCP):
 
         return hasattr(client.ft(index.schema.index.name), "hybrid_search")
 
+    def _validate_custom_tools(self) -> None:
+        """Fail startup on profiles that do not fit their bound index schema.
+
+        Config load already checked naming, parameter policy, and that a pinned
+        index exists. What it could not check is the schema, which is only known
+        once the binding has been inspected -- so a locked projection or filter
+        naming a missing field is caught here rather than silently matching
+        nothing at request time.
+        """
+        config = getattr(self, "config", None)
+        if config is None or not config.custom_tools:
+            return
+
+        for profile in config.custom_tools:
+            binding_id = config.resolved_profile_index(profile)
+            runtime = self._bindings[binding_id]
+            validate_profile_against_schema(profile, runtime.schema)
+
     @staticmethod
     def _tool_surface_fingerprint(config: Any) -> str:
         """Summarize the config that a registered tool set baked in."""
         if config is None:
             return ""
-        return repr(sorted(config.server.builtin_tools.items()))
+        return repr(
+            (
+                sorted(config.server.builtin_tools.items()),
+                [profile.model_dump(mode="json") for profile in config.custom_tools],
+            )
+        )
 
     def _register_tools(self) -> None:
         """Register MCP tools once every binding is ready."""
         if self._tools_registered or not hasattr(self, "tool"):
             # Registration is deliberately once-per-process, since re-registering
-            # the same names on the FastMCP object is not valid. Built-in tool
-            # closures resolve their binding per call, so they survive a restart
-            # unchanged -- but which built-ins exist is now a function of config,
-            # and `startup()` re-reads that file. A stop/start against an edited
-            # config therefore keeps the old tool set, and the dangerous direction
-            # is an operator disabling a tool and believing the restart applied it.
+            # the same names on the FastMCP object is not valid. Built-in closures
+            # resolve their binding per call, so they survive a restart unchanged --
+            # but *which* built-ins exist is a function of config, and a profile is
+            # worse off still: its locked filter, projection, and signature are
+            # fixed at registration. `startup()` re-reads the config file, so a
+            # stop/start against an edited one keeps the old tool set either way.
+            # The dangerous direction is an operator disabling a tool or tightening
+            # a lock and believing the restart applied it.
             if self._tools_registered:
                 current = self._tool_surface_fingerprint(getattr(self, "config", None))
                 if current != self._registered_tool_fingerprint:
                     logger.warning(
-                        "MCP built-in tool configuration changed since tools were "
-                        "registered, but tools register once per process. The "
-                        "previously registered tool set is still in effect; "
+                        "MCP tool configuration (built-in or custom) changed "
+                        "since tools were registered, but tools register once per "
+                        "process. The previously registered tool set is still in "
+                        "effect; "
                         "restart the process to apply the new configuration."
                     )
             return
@@ -306,9 +336,9 @@ class RedisVLMCPServer(FastMCP):
         if len(self._bindings) == 1:
             search_schema = next(iter(self._bindings.values())).schema
 
-        # An operator can turn off a built-in whose capability the server should
-        # not offer at all -- a read-only deployment, or one that should not
-        # advertise discovery.
+        # An operator can disable a built-in whose curated profiles supersede it;
+        # adding near-duplicate tools otherwise degrades the model's ability to
+        # pick the right one.
         config = getattr(self, "config", None)
         enabled = (
             config.server.builtin_tool_enabled
@@ -318,7 +348,8 @@ class RedisVLMCPServer(FastMCP):
 
         registered: list[str] = []
 
-        # Discovery is on by default so clients can enumerate indexes.
+        # Discovery is on by default so clients can enumerate indexes; an
+        # operator serving only curated profiles may still turn it off.
         discovery_enabled = enabled("list-indexes")
         if discovery_enabled:
             register_list_indexes_tool(self)
@@ -346,6 +377,7 @@ class RedisVLMCPServer(FastMCP):
         ):
             register_upsert_tool(self, index_ids=unlisted_index_ids)
             registered.append("upsert-records")
+        registered.extend(register_profile_tools(self))
 
         self._warn_on_unusable_tool_surface(registered)
         self._registered_tool_fingerprint = self._tool_surface_fingerprint(config)
@@ -364,7 +396,8 @@ class RedisVLMCPServer(FastMCP):
             # `builtin_tools` disabled it.
             logger.warning(
                 "MCP server registered no tools, so clients will see an empty "
-                "tool list. Check server.builtin_tools and read-only settings."
+                "tool list. Check server.builtin_tools, custom_tools, and "
+                "read-only settings."
             )
             return
 
@@ -536,6 +569,9 @@ class RedisVLMCPServer(FastMCP):
             self._bindings[binding_id] = await self._initialize_binding(
                 binding_id, binding
             )
+        # Validate before registering so a bad profile fails startup rather than
+        # leaving a half-registered tool set behind.
+        self._validate_custom_tools()
         self._register_tools()
 
     async def _initialize_binding(

--- a/redisvl/mcp/tools/list_indexes.py
+++ b/redisvl/mcp/tools/list_indexes.py
@@ -97,8 +97,8 @@ def list_indexes(server: "RedisVLMCPServer") -> dict[str, Any]:
 def register_list_indexes_tool(server: "RedisVLMCPServer") -> None:
     """Register the read-only `list-indexes` MCP tool.
 
-    Registered by default; an operator can turn it off through
-    ``server.builtin_tools``.
+    Registered by default; an operator serving only curated custom tool profiles
+    can turn it off through ``server.builtin_tools``.
     """
 
     async def list_indexes_tool():

--- a/redisvl/mcp/tools/profiles.py
+++ b/redisvl/mcp/tools/profiles.py
@@ -1,0 +1,315 @@
+"""Declarative custom tool profiles layered over the built-in MCP tools.
+
+A profile is the built-in named by ``based_on`` with some of its arguments
+pre-filled and frozen by the author and the rest still exposed to the model. It
+resolves to a built-in call and nothing more, so it inherits that built-in's
+concurrency cap, request timeout, read-only policy, auth scoping, and error
+mapping without restating any of it here.
+
+The frozen arguments are omitted from the wrapper's signature, which is what
+FastMCP derives the advertised schema from -- so a locked argument is not merely
+ignored when supplied, it is not offered to the model at all.
+"""
+
+import inspect
+from typing import Annotated, Any, Optional
+
+from pydantic import Field
+
+from redisvl.mcp.auth import ensure_tool_scope
+from redisvl.mcp.config import MCPCustomToolConfig
+from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
+from redisvl.mcp.filters import parse_filter
+from redisvl.mcp.tools.search import (
+    _build_filter_hint,
+    _build_return_fields_hint,
+    search_records,
+)
+from redisvl.query.filter import FilterExpression
+from redisvl.schema import IndexSchema
+
+# Ordered so the generated signature reads like the built-in's: required query
+# first, then the optional narrowing arguments. Real type objects rather than
+# string annotations, so schema generation never depends on resolving a forward
+# reference in this module's namespace.
+_PROFILE_PARAM_SPECS: tuple[tuple[str, Any, Any], ...] = (
+    ("query", str, inspect.Parameter.empty),
+    ("limit", Optional[int], None),
+    ("offset", int, 0),
+    # Deliberately `dict` and not `str | dict`: the DSL object form is the only
+    # caller filter a profile accepts, so a raw string is refused by the
+    # advertised schema rather than relying on a runtime guard alone.
+    ("filter", Optional[dict[str, Any]], None),
+    ("return_fields", Optional[list[str]], None),
+)
+
+
+def build_profile_description(profile: MCPCustomToolConfig, schema: IndexSchema) -> str:
+    """Build a profile's model-facing description.
+
+    Schema hints are appended only for arguments the model can actually use, and
+    are dropped entirely when the author suppresses them -- the built-in's hints
+    enumerate filterable and returnable fields, which is noise or, worse,
+    misleading once those arguments are locked.
+    """
+    description = profile.description.strip()
+    if profile.suppress_schema_hints:
+        return description
+
+    parts = [description]
+    if profile.param_exposed("filter"):
+        parts.append(_build_filter_hint(schema))
+    if profile.param_exposed("return_fields"):
+        parts.append(_build_return_fields_hint(schema))
+    return " ".join(parts)
+
+
+def resolve_locked_filter(
+    profile: MCPCustomToolConfig, schema: IndexSchema
+) -> FilterExpression | None:
+    """Parse a profile's locked filter against the bound schema.
+
+    Parsing at registration rather than per call means an unknown or wrongly
+    typed field fails startup instead of every request, and the resulting
+    expression is reused for the life of the tool.
+    """
+    if profile.lock.filter is None:
+        return None
+
+    try:
+        parsed = parse_filter(profile.lock.filter, schema)
+    except RedisVLMCPError as exc:
+        # parse_filter reports the offending field but not which profile owns it,
+        # which is useless with several profiles configured.
+        raise RedisVLMCPError(
+            f"custom_tools '{profile.name}' lock.filter is invalid: {exc}",
+            code=exc.code,
+            retryable=False,
+        ) from exc
+
+    if not isinstance(parsed, FilterExpression):
+        # Unreachable through config validation, which requires an object, but
+        # keep the invariant explicit: a locked filter must be composable.
+        raise ValueError(
+            f"custom_tools '{profile.name}' lock.filter must be an object in the "
+            "JSON filter DSL"
+        )
+    return parsed
+
+
+def validate_profile_against_schema(
+    profile: MCPCustomToolConfig, schema: IndexSchema
+) -> None:
+    """Fail fast when a profile names fields the bound index does not have.
+
+    Config validation cannot do this: the schema is only known once the binding
+    has been inspected at startup. Without it a locked projection or filter would
+    silently match nothing, which looks like scoping but is not.
+    """
+    field_names = set(schema.field_names)
+    vector_field_names = {
+        field_name
+        for field_name, field in schema.fields.items()
+        if field.type == "vector"
+    }
+
+    for field_name in profile.lock.return_fields or []:
+        if field_name not in field_names:
+            raise ValueError(
+                f"custom_tools '{profile.name}' lock.return_fields references "
+                f"unknown field '{field_name}' on index "
+                f"'{schema.index.name}'; available: "
+                f"{', '.join(sorted(field_names))}"
+            )
+        if field_name in vector_field_names:
+            raise ValueError(
+                f"custom_tools '{profile.name}' lock.return_fields cannot return "
+                f"vector field '{field_name}'"
+            )
+
+    _validate_locked_exists_fields(profile, schema, vector_field_names)
+
+    # Raises RedisVLMCPError(INVALID_FILTER) naming the offending field.
+    resolve_locked_filter(profile, schema)
+
+
+def _iter_filter_clauses(node: Any) -> Any:
+    """Yield every leaf clause of a JSON filter DSL expression."""
+    if not isinstance(node, dict):
+        return
+    for operator in ("and", "or"):
+        if operator in node:
+            for child in node[operator] or []:
+                yield from _iter_filter_clauses(child)
+            return
+    if "not" in node:
+        yield from _iter_filter_clauses(node["not"])
+        return
+    yield node
+
+
+def _validate_locked_exists_fields(
+    profile: MCPCustomToolConfig,
+    schema: IndexSchema,
+    vector_field_names: set[str],
+) -> None:
+    """Reject a locked ``exists`` clause the index cannot actually answer.
+
+    ``exists`` compiles to ``ismissing``, which Redis refuses unless the field was
+    declared with ``INDEXMISSING``. The DSL also lets ``exists`` through for vector
+    fields, which no other operator allows. Either way the profile parses fine and
+    then fails every single call as a *retryable* backend error, so a model retries
+    a permanently broken tool forever. Catching it here turns that into a startup
+    failure the operator sees once.
+    """
+    if profile.lock.filter is None:
+        return
+
+    for clause in _iter_filter_clauses(profile.lock.filter):
+        if str(clause.get("op", "")).lower() != "exists":
+            continue
+        field_name = clause.get("field")
+        field = schema.fields.get(field_name)
+        if field is None:
+            continue  # resolve_locked_filter reports unknown fields.
+
+        if field_name in vector_field_names:
+            raise ValueError(
+                f"custom_tools '{profile.name}' lock.filter cannot use 'exists' on "
+                f"vector field '{field_name}'"
+            )
+        if not getattr(field.attrs, "index_missing", False):
+            raise ValueError(
+                f"custom_tools '{profile.name}' lock.filter uses 'exists' on field "
+                f"'{field_name}', which is not indexed with INDEXMISSING; every "
+                "call would fail. Declare the field with INDEXMISSING or drop the "
+                "'exists' clause."
+            )
+
+
+def _build_signature(
+    profile: MCPCustomToolConfig,
+) -> tuple[inspect.Signature, dict[str, Any]]:
+    """Build the wrapper signature from the arguments a profile exposes."""
+    limit_cap = profile.param_max("limit")
+
+    parameters = []
+    annotations: dict[str, Any] = {}
+    for name, annotation, default in _PROFILE_PARAM_SPECS:
+        if not profile.param_exposed(name):
+            continue
+        if name == "limit" and limit_cap is not None:
+            # Publish the cap in the schema rather than only enforcing it. Left
+            # off, the model's only way to discover the ceiling is to exceed it
+            # and read the error.
+            annotation = Annotated[Optional[int], Field(le=limit_cap)]
+        parameters.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=annotation,
+            )
+        )
+        annotations[name] = annotation
+    return inspect.Signature(parameters), annotations
+
+
+def register_profile_tool(
+    server: Any,
+    profile: MCPCustomToolConfig,
+    binding_id: str,
+    schema: IndexSchema,
+) -> None:
+    """Register one declarative profile as an MCP tool.
+
+    Three things are settled here rather than per call: the locked filter is
+    parsed once against the bound schema, the wrapper's signature is narrowed to
+    the exposed arguments (which is what FastMCP advertises), and a hidden
+    ``limit`` collapses its cap into a fixed result count. The wrapper then
+    ignores anything the profile does not expose, so a lock holds even if a
+    caller reaches it without schema validation.
+    """
+    locked_filter = resolve_locked_filter(profile, schema)
+    locked_return_fields = profile.lock.return_fields
+    limit_cap = profile.param_max("limit")
+    exposes_limit = profile.param_exposed("limit")
+    exposed = {
+        name for name, _, _ in _PROFILE_PARAM_SPECS if profile.param_exposed(name)
+    }
+    signature, annotations = _build_signature(profile)
+
+    async def profile_tool(**kwargs: Any) -> dict[str, Any]:
+        auth_config = getattr(server, "auth_config", None)
+        read_scope = auth_config.read_scope if auth_config is not None else None
+        ensure_tool_scope(server, read_scope)
+
+        # A hidden argument is already absent from the advertised schema, so a
+        # compliant client cannot send one. Ignoring it here too means the lock
+        # does not depend on the client or the schema layer holding up.
+        def supplied(name: str, default: Any = None) -> Any:
+            return kwargs.get(name, default) if name in exposed else default
+
+        caller_filter = supplied("filter")
+        if caller_filter is not None and not isinstance(caller_filter, dict):
+            # A profile advertises `filter` as an object, so a string can only
+            # arrive from a client that ignored the schema. Refuse it here rather
+            # than passing raw RediSearch syntax through: with no locked filter
+            # `merge_locked_filter` has nothing to combine and would forward it
+            # verbatim.
+            raise RedisVLMCPError(
+                "filter must be an object; this tool does not accept raw string "
+                "filters",
+                code=MCPErrorCode.INVALID_FILTER,
+                retryable=False,
+            )
+
+        limit = supplied("limit")
+        if not exposes_limit:
+            # With the argument hidden, a declared cap becomes the fixed result
+            # count; without one, the binding's default applies.
+            limit = limit_cap
+
+        return await search_records(
+            server,
+            query=supplied("query", ""),
+            index=binding_id,
+            limit=limit,
+            offset=supplied("offset", 0),
+            filter=caller_filter,
+            return_fields=(
+                locked_return_fields
+                if locked_return_fields is not None
+                else supplied("return_fields")
+            ),
+            locked_filter=locked_filter,
+            # Passed down rather than checked here: an omitted limit resolves to
+            # the binding default inside search_records, so that is the only
+            # place able to bound both paths.
+            limit_cap=limit_cap,
+        )
+
+    profile_tool.__name__ = profile.name.replace("-", "_")
+    profile_tool.__doc__ = profile.description.strip()
+    profile_tool.__signature__ = signature  # type: ignore[attr-defined]
+    profile_tool.__annotations__ = {**annotations, "return": dict[str, Any]}
+
+    server.tool(
+        name=profile.name,
+        description=build_profile_description(profile, schema),
+    )(profile_tool)
+
+
+def register_profile_tools(server: Any) -> list[str]:
+    """Register every configured profile, returning the names registered."""
+    config = getattr(server, "config", None)
+    if config is None or not config.custom_tools:
+        return []
+
+    registered: list[str] = []
+    for profile in config.custom_tools:
+        binding_id = config.resolved_profile_index(profile)
+        runtime = server.resolve_binding(binding_id)
+        register_profile_tool(server, profile, binding_id, runtime.schema)
+        registered.append(profile.name)
+    return registered

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -7,6 +7,7 @@ from redisvl.mcp.config import reserved_score_metadata_field_names
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError, map_exception
 from redisvl.mcp.filters import parse_filter
 from redisvl.query import AggregateHybridQuery, HybridQuery, TextQuery, VectorQuery
+from redisvl.query.filter import FilterExpression
 from redisvl.schema import IndexSchema
 
 DEFAULT_SEARCH_DESCRIPTION = "Search records in the configured Redis index."
@@ -106,12 +107,18 @@ def _validate_request(
     return_fields: list[str] | None,
     runtime: Any,
     schema: Any,
+    limit_cap: int | None = None,
 ) -> tuple[int, list[str]]:
     """Validate a `search-records` request and resolve default projection.
 
     The MCP caller can only supply query text, pagination, filters, and return
     fields. Search mode and tuning are sourced from the selected binding's
     config, so this validation step focuses only on the public request contract.
+
+    ``limit_cap`` is a server-supplied ceiling from a custom tool profile. It has
+    to be applied here rather than in the caller, because an omitted ``limit``
+    resolves to the binding default at this point -- capping only the explicit
+    value would let the default sail past the cap.
     """
 
     if not isinstance(query, str) or not query.strip():
@@ -121,7 +128,20 @@ def _validate_request(
             retryable=False,
         )
 
-    effective_limit = runtime.default_limit if limit is None else limit
+    if limit is None:
+        # An unspecified limit is bounded silently: the caller never named a
+        # number, so there is nothing to reject.
+        effective_limit = runtime.default_limit
+        if limit_cap is not None:
+            effective_limit = min(effective_limit, limit_cap)
+    else:
+        effective_limit = limit
+        if limit_cap is not None and effective_limit > limit_cap:
+            raise RedisVLMCPError(
+                f"limit must be less than or equal to {limit_cap}",
+                code=MCPErrorCode.INVALID_REQUEST,
+                retryable=False,
+            )
     if not isinstance(effective_limit, int) or effective_limit <= 0:
         raise RedisVLMCPError(
             "limit must be greater than 0",
@@ -350,6 +370,148 @@ def _build_fallback_hybrid_kwargs(
     }
 
 
+def _find_range_end(rendered: str, position: int) -> int | None:
+    """Return the index of the `]` closing a numeric range, or None if unclosed."""
+    while position < len(rendered):
+        if rendered[position] == "\\":
+            position += 2
+            continue
+        if rendered[position] == "]":
+            return position
+        position += 1
+    return None
+
+
+def _span_holds_unescaped_pipe(rendered: str, start: int, end: int) -> bool:
+    """Report whether `rendered[start:end]` holds a `|` that is not escaped."""
+    position = start
+    while position < end:
+        if rendered[position] == "\\":
+            position += 2
+            continue
+        if rendered[position] == "|":
+            return True
+        position += 1
+    return False
+
+
+def _reject_escapable_filter(caller: FilterExpression) -> None:
+    """Refuse a caller filter whose rendering could break out of a locked AND.
+
+    A well-formed expression built from escaped values cannot escape, so anything
+    this rejects means a value reached the query string unescaped. It is a
+    backstop, not the primary defense -- see ``merge_locked_filter``.
+    """
+    # Braces scope as much as parens do: a tag clause holds its alternatives in
+    # braces, so `@category:{sports|health}` is one scoped clause rather than a
+    # union. Counting parens alone would reject the most ordinary narrowing
+    # filter a caller can send.
+    openers = {"(", "{"}
+    closers = {")", "}"}
+
+    rendered = str(caller)
+    position = 0
+    depth = 0
+    escaped = False
+
+    while position < len(rendered):
+        character = rendered[position]
+
+        if character == "\\":
+            # Consume the pair. Checking whether the *previous* character was a
+            # backslash instead would misread `\\` -- a literal backslash -- as
+            # protecting whatever follows it, and a real delimiter after one
+            # would slip through unnoticed.
+            position += 2
+            continue
+
+        if character == "[":
+            # A numeric range is bounds, not structure: an exclusive bound
+            # renders as `[(5 +inf]`, where `(` is a marker rather than a group.
+            # Skipping the span keeps those parens out of the depth count -- but
+            # suppressing paren depth is the *only* reason to skip, so `|`
+            # detection has to stay active inside it. A legitimate numeric or geo
+            # range holds numbers, so a `|` in here means a value reached the
+            # query string raw, which is exactly the case this backstop exists
+            # to catch; skipping past it would let a union hide behind brackets.
+            end = _find_range_end(rendered, position + 1)
+            if end is None:
+                escaped = True
+                break
+            if _span_holds_unescaped_pipe(rendered, position + 1, end):
+                escaped = True
+                break
+            position = end + 1
+            continue
+
+        if character in openers:
+            depth += 1
+        elif character in closers:
+            depth -= 1
+            if depth < 0:
+                # Closed more than was opened, which would terminate the locked
+                # group early and leave the rest as bare syntax.
+                escaped = True
+                break
+        elif character == "]":
+            # Only reachable outside a range span, so the brackets are unbalanced.
+            escaped = True
+            break
+        elif character == "|" and depth == 0:
+            # Under DIALECT 2, `|` binds looser than the implicit intersection,
+            # so one at the top level turns `locked AND caller` into a union and
+            # the lock stops constraining anything.
+            escaped = True
+            break
+
+        position += 1
+
+    # Leftover depth means an unclosed group, which would swallow whatever the
+    # AND appends after it.
+    if escaped or depth != 0:
+        raise RedisVLMCPError(
+            "filter could not be safely combined with this tool's locked filter",
+            code=MCPErrorCode.INVALID_FILTER,
+            retryable=False,
+        )
+
+
+def merge_locked_filter(
+    locked: FilterExpression | None,
+    caller: str | FilterExpression | None,
+) -> str | FilterExpression | None:
+    """AND-combine an author-locked filter with a caller-supplied one.
+
+    The locked expression always applies, so a caller can only narrow within it
+    and never widen past it. That rests on two things: the caller's expression
+    rendering nested inside the AND, and every value staying inside its own
+    clause (which ``_parse_text_expression`` escaping provides).
+    """
+    if locked is None:
+        return caller
+    if caller is None:
+        return locked
+
+    if not isinstance(caller, FilterExpression):
+        # Strings skip the DSL's field validation and have no safe composition
+        # with an expression -- combining them means concatenation, where a
+        # crafted value can close the locked group and escape it.
+        raise RedisVLMCPError(
+            "filter must be an object when this tool locks a filter; "
+            "raw string filters cannot be combined with a locked filter",
+            code=MCPErrorCode.INVALID_FILTER,
+            retryable=False,
+        )
+
+    # Structure is necessary but not sufficient, so check the rendering too.
+    _reject_escapable_filter(caller)
+
+    # `__and__` wraps the pair and parenthesizes each compound side, so a
+    # caller's `or`/`not` cannot hoist itself to the top level. (Single clauses
+    # render bare; only compound sides could otherwise escape.)
+    return locked & caller
+
+
 async def _build_query(
     *,
     rt: Any,
@@ -358,6 +520,7 @@ async def _build_query(
     offset: int,
     filter_value: str | dict[str, Any] | None,
     return_fields: list[str],
+    locked_filter: FilterExpression | None = None,
 ) -> tuple[Any, str, str, str]:
     """Build the RedisVL query object from the binding's search mode and params.
 
@@ -367,7 +530,9 @@ async def _build_query(
     runtime = rt.binding.runtime
     search_type, search_params = _get_configured_search(rt)
     num_results = limit + offset
-    filter_expression = parse_filter(filter_value, rt.schema)
+    filter_expression = merge_locked_filter(
+        locked_filter, parse_filter(filter_value, rt.schema)
+    )
 
     if search_type == "vector":
         if runtime.vector_field_name is None:
@@ -461,6 +626,8 @@ async def search_records(
     offset: int = 0,
     filter: str | dict[str, Any] | None = None,
     return_fields: list[str] | None = None,
+    locked_filter: FilterExpression | None = None,
+    limit_cap: int | None = None,
 ) -> dict[str, Any]:
     """Execute `search-records` against the selected Redis index binding.
 
@@ -468,6 +635,12 @@ async def search_records(
     one binding is configured (preserving single-index behavior) and required
     when multiple bindings exist. The resolved logical id is echoed back in the
     response so multi-index clients can confirm routing.
+
+    ``locked_filter`` and ``limit_cap`` are server-supplied and never reach the
+    model: they are how a caller in-process pins an author-locked expression and
+    result ceiling onto this tool. The filter is AND-combined with ``filter`` so
+    a caller can only narrow within it, and the cap bounds the effective limit
+    whether the caller named one or fell through to the binding default.
     """
     try:
         rt = server.resolve_binding(index)
@@ -478,6 +651,7 @@ async def search_records(
             return_fields=return_fields,
             runtime=rt.binding.runtime,
             schema=rt.schema,
+            limit_cap=limit_cap,
         )
         built_query, score_field, score_type, search_type = await _build_query(
             rt=rt,
@@ -486,6 +660,7 @@ async def search_records(
             offset=offset,
             filter_value=filter,
             return_fields=effective_return_fields,
+            locked_filter=locked_filter,
         )
         raw_results = await server.run_guarded(
             "search-records",

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -637,10 +637,10 @@ async def search_records(
     response so multi-index clients can confirm routing.
 
     ``locked_filter`` and ``limit_cap`` are server-supplied and never reach the
-    model: they are how a caller in-process pins an author-locked expression and
-    result ceiling onto this tool. The filter is AND-combined with ``filter`` so
-    a caller can only narrow within it, and the cap bounds the effective limit
-    whether the caller named one or fell through to the binding default.
+    model: custom tool profiles pass an author-locked expression and result
+    ceiling here. The filter is AND-combined with ``filter`` so a caller can only
+    narrow within it, and the cap bounds the effective limit whether the caller
+    named one or fell through to the binding default.
     """
     try:
         rt = server.resolve_binding(index)

--- a/tests/integration/test_mcp/test_profiles.py
+++ b/tests/integration/test_mcp/test_profiles.py
@@ -1,0 +1,335 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from redisvl.index import AsyncSearchIndex
+from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
+from redisvl.mcp.server import RedisVLMCPServer
+from redisvl.mcp.settings import MCPSettings
+from redisvl.schema import IndexSchema
+
+
+@pytest.fixture
+async def profile_index(async_client, worker_id):
+    schema = IndexSchema.from_dict(
+        {
+            "index": {
+                "name": f"mcp-profile-{worker_id}",
+                "prefix": f"mcp-profile:{worker_id}",
+                "storage_type": "hash",
+            },
+            "fields": [
+                {"name": "content", "type": "text"},
+                {"name": "category", "type": "tag"},
+                {"name": "rating", "type": "numeric"},
+            ],
+        }
+    )
+    index = AsyncSearchIndex(schema=schema, redis_client=async_client)
+    await index.create(overwrite=True, drop=True)
+
+    await index.load(
+        [
+            {
+                "id": f"prof:{worker_id}:1",
+                "content": "science article about planets",
+                "category": "science",
+                "rating": 5,
+            },
+            {
+                "id": f"prof:{worker_id}:2",
+                "content": "medical science and health",
+                "category": "health",
+                "rating": 4,
+            },
+            {
+                "id": f"prof:{worker_id}:3",
+                "content": "science of sports performance",
+                "category": "sports",
+                "rating": 2,
+            },
+        ]
+    )
+
+    yield index
+
+    await index.delete(drop=True)
+
+
+@pytest.fixture
+def profile_config_path(tmp_path: Path, redis_url: str):
+    def factory(
+        redis_name: str,
+        custom_tools: list[dict],
+        *,
+        builtin_tools: dict | None = None,
+    ) -> str:
+        server: dict = {"redis_url": redis_url}
+        if builtin_tools is not None:
+            server["builtin_tools"] = builtin_tools
+
+        config = {
+            "server": server,
+            "indexes": {
+                "knowledge": {
+                    "redis_name": redis_name,
+                    "search": {"type": "fulltext"},
+                    "runtime": {
+                        "text_field_name": "content",
+                        "default_limit": 10,
+                        "max_limit": 20,
+                    },
+                }
+            },
+            "custom_tools": custom_tools,
+        }
+        config_path = tmp_path / f"{redis_name}-profiles.yaml"
+        config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+        return str(config_path)
+
+    return factory
+
+
+@pytest.fixture
+async def started_server(profile_index, profile_config_path):
+    servers: list[RedisVLMCPServer] = []
+
+    async def started(custom_tools: list[dict], **kwargs) -> RedisVLMCPServer:
+        server = RedisVLMCPServer(
+            MCPSettings(
+                config=profile_config_path(
+                    profile_index.schema.index.name, custom_tools, **kwargs
+                )
+            )
+        )
+        await server.startup()
+        servers.append(server)
+        return server
+
+    yield started
+
+    for server in servers:
+        await server.shutdown()
+
+
+async def _tool(server: RedisVLMCPServer, name: str):
+    """Return the registered callable for a tool name."""
+    tool = await server.get_tool(name)
+    assert tool is not None, f"tool '{name}' is not registered"
+    return tool.fn
+
+
+async def _tool_names(server: RedisVLMCPServer) -> set[str]:
+    """Return every registered tool name."""
+    return {tool.name for tool in await server.list_tools()}
+
+
+_SCIENCE_ONLY = {
+    "name": "science-search",
+    "description": "Search science records.",
+    "lock": {"filter": {"field": "category", "op": "eq", "value": "science"}},
+}
+
+
+@pytest.mark.asyncio
+async def test_profile_locked_filter_restricts_results_in_redis(started_server):
+    server = await started_server([_SCIENCE_ONLY])
+
+    tool = await _tool(server, "science-search")
+    response = await tool(query="science")
+
+    # All three documents match the text query, so only the locked filter can
+    # account for a single result coming back.
+    assert len(response["results"]) == 1
+    assert response["results"][0]["record"]["category"] == "science"
+
+
+@pytest.mark.asyncio
+async def test_profile_caller_filter_cannot_escape_the_locked_scope(started_server):
+    server = await started_server([_SCIENCE_ONLY])
+
+    tool = await _tool(server, "science-search")
+    response = await tool(
+        query="science",
+        filter={"field": "category", "op": "eq", "value": "sports"},
+    )
+
+    # The sports document exists and matches the text query, but asking for it
+    # intersects with the locked category rather than replacing it.
+    assert response["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_profile_caller_or_filter_stays_inside_the_locked_scope(started_server):
+    server = await started_server([_SCIENCE_ONLY])
+
+    tool = await _tool(server, "science-search")
+    response = await tool(
+        query="science",
+        filter={
+            "or": [
+                {"field": "category", "op": "eq", "value": "sports"},
+                {"field": "category", "op": "eq", "value": "health"},
+            ]
+        },
+    )
+
+    # An OR of two other categories cannot widen past the locked AND, so nothing
+    # comes back rather than the sports and health documents.
+    assert response["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_profile_locked_return_fields_restrict_the_projection(started_server):
+    server = await started_server(
+        [
+            {
+                "name": "redacted-search",
+                "description": "Search records with a redacted projection.",
+                "lock": {"return_fields": ["content"]},
+            }
+        ]
+    )
+
+    tool = await _tool(server, "redacted-search")
+    response = await tool(query="science")
+
+    assert response["results"]
+    for result in response["results"]:
+        # `category` and `rating` exist on every document but are not projected.
+        assert set(result["record"]) == {"content"}
+
+
+@pytest.mark.asyncio
+async def test_disabled_builtin_is_not_registered_alongside_a_profile(started_server):
+    server = await started_server(
+        [_SCIENCE_ONLY], builtin_tools={"search-records": "disabled"}
+    )
+
+    registered = await _tool_names(server)
+
+    # The curated tool replaces the generic one rather than sitting beside it.
+    assert "science-search" in registered
+    assert "search-records" not in registered
+    assert "list-indexes" in registered
+
+
+@pytest.mark.asyncio
+async def test_startup_fails_when_a_locked_filter_names_an_unknown_field(
+    started_server,
+):
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        await started_server(
+            [
+                {
+                    "name": "broken-search",
+                    "description": "Search records.",
+                    "lock": {"filter": {"field": "missing", "op": "eq", "value": "x"}},
+                }
+            ]
+        )
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+
+
+@pytest.mark.asyncio
+async def test_profile_advertises_only_its_exposed_arguments(started_server):
+    server = await started_server(
+        [
+            {
+                "name": "narrow-search",
+                "description": "Search science records.",
+                "lock": {
+                    "filter": {"field": "category", "op": "eq", "value": "science"},
+                    "return_fields": ["content"],
+                },
+                "params": {"offset": {"expose": False}},
+            }
+        ]
+    )
+
+    tool = await server.get_tool("narrow-search")
+    schema = tool.parameters
+
+    # This is the actual security boundary: a locked or hidden argument is not
+    # merely ignored, it is never published, and a compliant client cannot send
+    # one because extras are refused. Asserted against real FastMCP rather than
+    # a fake, since the schema is derived by the library from the signature.
+    assert set(schema["properties"]) == {"query", "limit", "filter"}
+    # A set, not a list: `required` ordering is a pydantic implementation detail,
+    # and only its membership is behavior. `fastmcp` is pinned `>=2.0.0` with no
+    # upper bound, so a minor bump must not break this on presentation alone.
+    assert set(schema["required"]) == {"query"}
+    assert schema["additionalProperties"] is False
+
+    # A raw string filter has no safe composition with a locked filter, so the
+    # object form is the only shape offered. Optional[dict] is encoded as an
+    # `anyOf` union by current pydantic, but a nullable type list is the other
+    # legal JSON Schema spelling of the same thing -- accept either, since only
+    # the advertised type set is the behavior under test.
+    filter_schema = schema["properties"]["filter"]
+    if "anyOf" in filter_schema:
+        filter_types = {entry.get("type") for entry in filter_schema["anyOf"]}
+    else:
+        declared = filter_schema["type"]
+        filter_types = set(declared) if isinstance(declared, list) else {declared}
+    assert filter_types == {"object", "null"}
+
+
+@pytest.mark.asyncio
+async def test_profile_text_filter_cannot_inject_past_the_locked_filter(started_server):
+    server = await started_server([_SCIENCE_ONLY])
+
+    tool = await _tool(server, "science-search")
+    response = await tool(
+        query="science",
+        filter={
+            "field": "content",
+            "op": "like",
+            "value": "zzznomatch) | (@category:{sports}",
+        },
+    )
+
+    # Unescaped, this payload closes the text clause and the trailing `|` splits
+    # the query into a union, returning documents the lock excludes. Escaped, it
+    # is a literal that simply matches nothing.
+    assert response["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_profile_caps_an_omitted_limit_against_real_results(started_server):
+    server = await started_server(
+        [
+            {
+                "name": "one-result-search",
+                "description": "Search records, one at a time.",
+                "params": {"limit": {"expose": True, "max": 1}},
+            }
+        ]
+    )
+
+    tool = await _tool(server, "one-result-search")
+    response = await tool(query="science")
+
+    # Three documents match the query and the binding default is 10, so only the
+    # cap can explain a single result.
+    assert len(response["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_profile_offset_past_the_locked_result_set_returns_nothing(
+    started_server,
+):
+    server = await started_server([_SCIENCE_ONLY])
+
+    tool = await _tool(server, "science-search")
+    unpaged = await tool(query="science")
+    paged = await tool(query="science", offset=1, limit=2)
+
+    # The lock leaves exactly one of the three matching documents, so paging past
+    # it has to come back empty. If offset were applied before the locked filter
+    # -- or if the filter were applied only to the first page -- this would return
+    # documents the lock excludes.
+    assert len(unpaged["results"]) == 1
+    assert paged["results"] == []

--- a/tests/unit/test_mcp/test_config.py
+++ b/tests/unit/test_mcp/test_config.py
@@ -31,6 +31,25 @@ def _valid_config() -> dict:
     }
 
 
+def _profile_dict(**overrides) -> dict:
+    """Build one *unvalidated* profile dict.
+
+    Named for its return type on purpose: this file's job is to feed raw
+    payloads to the validator, so it must not be confused with a helper that
+    returns an already-validated MCPCustomToolConfig.
+    """
+    profile = {"name": "resolved-search", "description": "Search resolved records."}
+    profile.update(overrides)
+    return profile
+
+
+def _raw_config_with_profiles(*profiles: dict) -> dict:
+    """Build an unvalidated config dict carrying the given raw profile dicts."""
+    config = _valid_config()
+    config["custom_tools"] = list(profiles)
+    return config
+
+
 def _inspected_schema() -> dict:
     return {
         "index": {
@@ -643,3 +662,308 @@ indexes:
 
     assert config.server.builtin_tool_enabled("upsert-records") is False
     assert config.server.builtin_tool_enabled("search-records") is True
+
+
+def test_mcp_config_defaults_to_no_custom_tools():
+    config = MCPConfig.model_validate(_valid_config())
+
+    assert config.custom_tools == []
+
+
+def test_mcp_config_custom_tool_defaults():
+    config = MCPConfig.model_validate(_raw_config_with_profiles(_profile_dict()))
+
+    profile = config.custom_tools[0]
+    assert profile.name == "resolved-search"
+    assert profile.kind == "profile"
+    assert profile.based_on == "search-records"
+    # An unpinned profile is legal with one binding and resolves to it.
+    assert profile.index is None
+    assert profile.suppress_schema_hints is False
+    assert profile.lock.return_fields is None
+    assert profile.lock.filter is None
+    assert profile.params == {}
+    assert config.resolved_profile_index(profile) == "knowledge"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # One violation per position the pattern constrains: the anchored first
+        # character, and the body character class.
+        "1foo",
+        "shop.foo",
+    ],
+)
+def test_mcp_config_rejects_invalid_custom_tool_names(name):
+    with pytest.raises(ValueError, match="is invalid"):
+        MCPConfig.model_validate(_raw_config_with_profiles(_profile_dict(name=name)))
+
+
+@pytest.mark.parametrize(
+    ("name", "valid"),
+    [
+        # The pattern is `^[a-z][a-z0-9_-]{0,63}$`, so 64 characters is the
+        # inclusive ceiling and 65 is the first rejection. Nothing else pins this
+        # bound, and an off-by-one in the quantifier is otherwise invisible.
+        ("a" + "b" * 63, True),
+        ("a" + "b" * 64, False),
+    ],
+)
+def test_mcp_config_bounds_custom_tool_name_length_at_64_characters(name, valid):
+    config = _raw_config_with_profiles(_profile_dict(name=name))
+
+    if valid:
+        assert MCPConfig.model_validate(config).custom_tools[0].name == name
+    else:
+        with pytest.raises(ValueError, match="is invalid"):
+            MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_custom_tool_names_that_collide_with_builtins():
+    # One built-in stands in for the rest: the check is a membership test against
+    # builtin_tool_names(), not per-name logic.
+    name = "search-records"
+    assert name in builtin_tool_names()
+
+    with pytest.raises(ValueError, match="collides with a built-in tool"):
+        MCPConfig.model_validate(_raw_config_with_profiles(_profile_dict(name=name)))
+
+
+def test_mcp_config_rejects_unknown_custom_tool_params():
+    config = _raw_config_with_profiles(
+        _profile_dict(params={"search_type": {"expose": False}})
+    )
+
+    with pytest.raises(ValueError, match="params contains unknown arguments"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_max_on_params_other_than_limit():
+    # `limit` is the sole param with a cap; every other name takes the same
+    # rejection branch, so one stands in for all of them.
+    config = _raw_config_with_profiles(_profile_dict(params={"offset": {"max": 5}}))
+
+    with pytest.raises(ValueError, match="does not support 'max'"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_non_positive_param_max():
+    # 0 is the boundary: it is the largest value the `> 0` check must still refuse.
+    config = _raw_config_with_profiles(_profile_dict(params={"limit": {"max": 0}}))
+
+    with pytest.raises(ValueError, match="max must be greater than 0"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_hiding_the_query_param():
+    config = _raw_config_with_profiles(
+        _profile_dict(params={"query": {"expose": False}})
+    )
+
+    with pytest.raises(ValueError, match="params.query cannot be hidden"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_locking_return_fields_while_exposing_them():
+    config = _raw_config_with_profiles(
+        _profile_dict(
+            lock={"return_fields": ["content"]},
+            params={"return_fields": {"expose": True}},
+        )
+    )
+
+    with pytest.raises(ValueError, match="cannot both lock return_fields"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_allows_locking_return_fields_when_they_are_explicitly_hidden():
+    config = _raw_config_with_profiles(
+        _profile_dict(
+            lock={"return_fields": ["content"]},
+            params={"return_fields": {"expose": False}},
+        )
+    )
+
+    profile = MCPConfig.model_validate(config).custom_tools[0]
+
+    assert profile.lock.return_fields == ["content"]
+    assert profile.param_exposed("return_fields") is False
+
+
+def test_mcp_config_allows_locking_a_filter_while_the_caller_filter_stays_exposed():
+    config = _raw_config_with_profiles(
+        _profile_dict(
+            lock={"filter": {"field": "content", "op": "like", "value": "jam*"}},
+            params={"filter": {"expose": True}},
+        )
+    )
+
+    profile = MCPConfig.model_validate(config).custom_tools[0]
+
+    # Unlike return_fields, locked-plus-exposed is the intended narrowing case.
+    assert profile.param_exposed("filter") is True
+
+
+def test_mcp_config_rejects_empty_locked_return_fields():
+    config = _raw_config_with_profiles(_profile_dict(lock={"return_fields": []}))
+
+    with pytest.raises(ValueError, match="must contain at least one field"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_blank_locked_return_field_names():
+    # Whitespace rather than "": the empty string is already falsy, so only this
+    # one requires the check to `.strip()` before testing emptiness.
+    config = _raw_config_with_profiles(_profile_dict(lock={"return_fields": ["   "]}))
+
+    with pytest.raises(ValueError, match="must contain non-empty strings"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_duplicate_custom_tool_names():
+    config = _raw_config_with_profiles(
+        _profile_dict(), _profile_dict(description="Another description.")
+    )
+
+    with pytest.raises(ValueError, match="contains duplicate tool name"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_requires_custom_tool_index_when_multiple_bindings_exist():
+    config = _raw_config_with_profiles(_profile_dict())
+    config["indexes"]["tickets"] = deepcopy(config["indexes"]["knowledge"])
+
+    with pytest.raises(
+        ValueError, match="must set 'index' when multiple indexes are configured"
+    ):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_rejects_custom_tool_index_naming_an_unknown_binding():
+    config = _raw_config_with_profiles(_profile_dict(index="missing"))
+
+    with pytest.raises(ValueError, match="references unknown index"):
+        MCPConfig.model_validate(config)
+
+
+def test_mcp_config_resolves_a_pinned_custom_tool_index():
+    config = _raw_config_with_profiles(_profile_dict(index="tickets"))
+    config["indexes"]["tickets"] = deepcopy(config["indexes"]["knowledge"])
+
+    loaded = MCPConfig.model_validate(config)
+
+    assert loaded.resolved_profile_index(loaded.custom_tools[0]) == "tickets"
+
+
+def test_mcp_config_param_exposed_hides_return_fields_implicitly_when_locked():
+    config = _raw_config_with_profiles(
+        _profile_dict(lock={"return_fields": ["content"]})
+    )
+
+    profile = MCPConfig.model_validate(config).custom_tools[0]
+
+    # Locking implies hiding without the author having to say so twice.
+    assert profile.param_exposed("return_fields") is False
+    assert profile.param_exposed("filter") is True
+
+
+@pytest.mark.parametrize(
+    ("label", "profile_patch"),
+    [
+        # One case per model that declares `extra="forbid"` -- the profile itself,
+        # its `lock`, and a per-param policy. There are exactly three, and within
+        # any one of them every misspelling takes the identical pydantic branch.
+        ("profile", {"basedon": "search-records"}),
+        ("lock", {"lock": {"return_field": ["content"]}}),
+        ("params policy", {"params": {"limit": {"exposed": True}}}),
+    ],
+)
+def test_custom_tools_rejects_misspelled_keys(label, profile_patch):
+    del label
+    config = _valid_config()
+    profile = {"name": "resolved-search", "description": "Search resolved records."}
+    profile.update(profile_patch)
+    config["custom_tools"] = [profile]
+
+    # A dropped key would leave a tool that reads as locked in config while
+    # enforcing nothing, so unrecognized keys must fail rather than be ignored.
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        MCPConfig.model_validate(config)
+
+
+def test_custom_tools_rejects_a_limit_cap_above_the_bindings_max_limit():
+    config = _valid_config()
+    config["indexes"]["knowledge"]["runtime"]["default_limit"] = 5
+    config["indexes"]["knowledge"]["runtime"]["max_limit"] = 5
+    config["custom_tools"] = [
+        {
+            "name": "capped-search",
+            "description": "Search records.",
+            "params": {"limit": {"expose": False, "max": 10}},
+        }
+    ]
+
+    # With `limit` hidden the cap becomes the request size, so a cap the binding
+    # can never satisfy would make every call fail. Catch it before startup.
+    with pytest.raises(ValueError, match="exceeds the bound index's"):
+        MCPConfig.model_validate(config)
+
+
+@pytest.mark.parametrize("name", ["redisvl-search", "redisvl_search"])
+def test_custom_tools_rejects_both_reserved_prefix_separators(name):
+    config = _valid_config()
+    config["custom_tools"] = [{"name": name, "description": "Search records."}]
+
+    # The name pattern permits either separator, so both spellings of the
+    # reserved prefix have to be refused.
+    with pytest.raises(ValueError, match="reserved prefix"):
+        MCPConfig.model_validate(config)
+
+
+def test_load_mcp_config_parses_custom_tools_from_yaml(tmp_path: Path):
+    """The whole point is YAML authoring, so cover the real load path once."""
+    config_path = tmp_path / "mcp.yaml"
+    config_path.write_text(
+        """
+server:
+  redis_url: redis://localhost:6379
+  builtin_tools:
+    search-records: disabled
+indexes:
+    knowledge:
+      redis_name: docs-index
+      search:
+        type: fulltext
+      runtime:
+        text_field_name: content
+custom_tools:
+  - name: resolved-search
+    description: Search resolved records.
+    lock:
+      return_fields: [content]
+      filter:
+        field: category
+        op: eq
+        value: resolved
+    params:
+      limit:
+        max: 5
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_mcp_config(str(config_path))
+
+    profile = config.custom_tools[0]
+    assert profile.name == "resolved-search"
+    assert profile.lock.return_fields == ["content"]
+    assert profile.lock.filter == {
+        "field": "category",
+        "op": "eq",
+        "value": "resolved",
+    }
+    assert profile.param_max("limit") == 5
+    # Disabling the built-in a profile supersedes is the motivating pairing, so
+    # confirm both halves survive one load.
+    assert config.server.builtin_tool_enabled("search-records") is False

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -3,6 +3,7 @@ from conftest import _schema
 
 from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
 from redisvl.mcp.filters import parse_filter
+from redisvl.mcp.tools.search import merge_locked_filter
 from redisvl.query.filter import FilterExpression, Text
 
 
@@ -201,3 +202,206 @@ def test_parse_filter_like_still_escapes_clause_delimiters():
     # within `content` rather than splitting the whole expression.
     assert skeleton.index("|") > skeleton.index("(")
     assert skeleton.index("|") < skeleton.rindex(")")
+
+
+# --------------------------------------------------------------------------
+# Caller shapes merged under a locked filter
+#
+# The merge is the security boundary for custom tool profiles: whatever the
+# caller sends must end up ANDed *under* the locked clause rather than beside or
+# instead of it. The caller shapes below are enumerated because they reach `&` as
+# different renderings -- a single clause, a parenthesized AND, a parenthesized
+# OR chain, a negation, a missing-field check -- and only the compound ones could
+# hoist themselves out of the AND.
+#
+# The locked side is a single shape rather than a second axis. Nothing in the
+# merge inspects it: the guard is `_reject_escapable_filter(caller)`, which takes
+# only the caller's rendering, so the locked shape cannot change whether a caller
+# shape is accepted. A compound AND is the one kept because it is the locked
+# shape most likely to be damaged by a careless merge -- it arrives already
+# parenthesized, so a merge that concatenated instead of nesting would show here.
+# --------------------------------------------------------------------------
+
+_LOCKED_SHAPE = {
+    "and": [
+        {"field": "category", "op": "eq", "value": "resolved"},
+        {"field": "rating", "op": "gte", "value": 3},
+    ]
+}
+
+_CALLER_SHAPES = {
+    "not": {"not": {"field": "category", "op": "eq", "value": "sports"}},
+    "and": {
+        "and": [
+            {"field": "rating", "op": "gte", "value": 4},
+            {"field": "content", "op": "like", "value": "jam*"},
+        ]
+    },
+    # Text and numeric `in` expand to an OR chain, so they reach `&` already
+    # parenthesized -- a different shape from the single-clause cases above.
+    "text_in": {"field": "content", "op": "in", "value": ["jam", "jelly"]},
+    "numeric_in": {"field": "rating", "op": "in", "value": [3, 5]},
+    "exists": {"field": "content", "op": "exists"},
+}
+
+
+@pytest.mark.parametrize("caller_shape", sorted(_CALLER_SHAPES))
+def test_merge_locked_filter_ands_every_caller_shape_under_the_locked_filter(
+    caller_shape,
+):
+    locked = parse_filter(_LOCKED_SHAPE, _schema())
+    caller = parse_filter(_CALLER_SHAPES[caller_shape], _schema())
+
+    merged = merge_locked_filter(locked, caller)
+
+    # Never a bare string: a string cannot be safely combined further, and a
+    # profile that received one back would have lost the composability the lock
+    # depends on.
+    assert isinstance(merged, FilterExpression)
+    # The merge is exactly the AND of the two sides as each renders on its own.
+    # That pins both halves of the guarantee at once: the locked clause is
+    # unchanged and still at the top level of the AND, and the caller's side is
+    # reproduced verbatim beside it -- fully parenthesized when compound, so
+    # neither its `|` nor its `-` can reach the top level and widen the scope.
+    assert str(merged) == f"({locked} {caller})"
+
+
+def test_merge_locked_filter_ands_a_multi_value_tag_in_caller_filter():
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "resolved"}, _schema()
+    )
+    caller = parse_filter(
+        {"field": "category", "op": "in", "value": ["sports", "health"]}, _schema()
+    )
+
+    # Tag `in` is the one caller shape that collapses to a SINGLE clause,
+    # `@category:{sports|health}`, instead of expanding to an OR chain the way
+    # text and numeric `in` do. The `|` is scoped by the tag braces and cannot
+    # widen past an enclosing AND, so this is a legitimate narrowing filter and
+    # should merge like any other clause.
+    merged = merge_locked_filter(locked, caller)
+
+    assert isinstance(merged, FilterExpression)
+    assert str(merged) == "(@category:{resolved} @category:{sports|health})"
+
+
+# --------------------------------------------------------------------------
+# The escape backstop -- what it refuses, not just what it lets through
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "rendered"),
+    [
+        ("stray close paren", "@content:(a) | (-@category:{secret})"),
+        ("unclosed group", "@content:(a( | (-@category:{secret})"),
+        ("stray close brace", "@category:{a} | @category:{secret}"),
+        # A literal backslash does NOT escape what follows it, so this `|` is a
+        # real union. Looking back one character would misread it as escaped.
+        ("literal backslash then pipe", "@category:{a}\\\\|@category:{secret}"),
+        # The `[...]` span is skipped so an exclusive bound's `(` is not counted
+        # as a group. Skipping the span wholesale would also skip a `|` inside it,
+        # letting a union hide behind brackets.
+        ("pipe hidden inside a range span", "@rating:[4 | @category:{secret}]"),
+    ],
+)
+def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
+    label, rendered
+):
+    del label
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "science"}, _schema()
+    )
+
+    # Simulates a field type that renders a value unescaped. Text values are
+    # escaped today, so this path is unreachable through the DSL -- which is
+    # exactly why it needs an explicit test: without one, deleting the guard
+    # leaves the whole suite green.
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        merge_locked_filter(locked, FilterExpression(rendered))
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+
+
+@pytest.mark.parametrize(
+    ("label", "caller_filter"),
+    [
+        ("exclusive lower bound", {"field": "rating", "op": "gt", "value": 4}),
+        ("exclusive upper bound", {"field": "rating", "op": "lt", "value": 4}),
+        ("trailing backslash", {"field": "category", "op": "eq", "value": "ns\\\\"}),
+        (
+            "windows path",
+            {"field": "content", "op": "like", "value": "C:\\\\Users\\\\"},
+        ),
+        (
+            "compound with exclusive bound",
+            {
+                "and": [
+                    {"field": "category", "op": "eq", "value": "science"},
+                    {"field": "rating", "op": "gt", "value": 4},
+                ]
+            },
+        ),
+    ],
+)
+def test_merge_locked_filter_accepts_legitimate_narrowing_shapes(label, caller_filter):
+    del label
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "science"}, _schema()
+    )
+    caller = parse_filter(caller_filter, _schema())
+
+    # An exclusive numeric bound renders `[(4 +inf]` and an escaped value can end
+    # in a backslash. Neither is an escape, and refusing them would block the most
+    # ordinary narrowing a caller can ask for.
+    merged = merge_locked_filter(locked, caller)
+
+    assert isinstance(merged, FilterExpression)
+    assert "@category:{science}" in str(merged)
+
+
+def test_merge_locked_filter_rejects_a_raw_string_caller_filter_against_a_lock():
+    locked = parse_filter(_LOCKED_SHAPE, _schema())
+
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        merge_locked_filter(locked, "@category:{open}")
+
+    # A string has no safe composition with an expression: concatenating could
+    # close the locked group and escape the scope entirely.
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+    assert exc_info.value.retryable is False
+
+
+def test_merge_locked_filter_returns_each_side_unchanged_when_the_other_is_absent():
+    caller = parse_filter({"field": "category", "op": "eq", "value": "open"}, _schema())
+    locked = parse_filter(_LOCKED_SHAPE, _schema())
+
+    # No lock means the built-in's own behavior, including the raw-string form
+    # that a locked filter has to refuse.
+    assert merge_locked_filter(None, caller) is caller
+    assert merge_locked_filter(None, "@category:{open}") == "@category:{open}"
+    # A lock with no caller filter applies on its own.
+    assert merge_locked_filter(locked, None) is locked
+
+
+@pytest.mark.parametrize(
+    ("label", "rendered"),
+    [
+        # The reason the span is skipped at all: `(` here is an exclusive-bound
+        # marker, not a group, so counting it would reject a legitimate range.
+        ("exclusive lower bound", "@rating:[(5 +inf]"),
+        ("exclusive upper bound", "@rating:[-inf (5]"),
+        ("plain inclusive range", "@rating:[4 +inf]"),
+    ],
+)
+def test_merge_locked_filter_still_accepts_legitimate_range_bounds(label, rendered):
+    """Narrowing the range skip to parens must not start rejecting real ranges."""
+    del label
+    locked = parse_filter(
+        {"field": "category", "op": "eq", "value": "science"}, _schema()
+    )
+
+    merged = merge_locked_filter(locked, FilterExpression(rendered))
+
+    assert isinstance(merged, FilterExpression)
+    assert "@category:{science}" in str(merged)

--- a/tests/unit/test_mcp/test_profiles_unit.py
+++ b/tests/unit/test_mcp/test_profiles_unit.py
@@ -1,0 +1,920 @@
+import inspect
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any, Optional, get_args
+
+import pytest
+from conftest import _schema
+
+from redisvl.mcp.config import _PROFILE_PARAM_NAMES, MCPConfig, MCPCustomToolConfig
+from redisvl.mcp.errors import MCPErrorCode, RedisVLMCPError
+from redisvl.mcp.filters import parse_filter
+from redisvl.mcp.runtime import BindingRuntime
+from redisvl.mcp.tools.profiles import (
+    _PROFILE_PARAM_SPECS,
+    build_profile_description,
+    register_profile_tool,
+    register_profile_tools,
+    resolve_locked_filter,
+    validate_profile_against_schema,
+)
+from redisvl.mcp.tools.search import merge_locked_filter
+
+LOCKED_CATEGORY_FILTER = {"field": "category", "op": "eq", "value": "resolved"}
+FILTER_HINT = "Object filter fields: content(text), category(tag), rating(numeric)."
+RETURN_FIELDS_HINT = "Allowed return_fields: content, category, rating."
+
+
+def _binding(search_type: str = "fulltext") -> dict[str, Any]:
+    # Full-text by default so the profile path needs no vectorizer; the built-in
+    # query class is monkeypatched at its import site to capture what the profile
+    # builds.
+    #
+    # The limits are deliberately larger than, and distinct from, every
+    # per-profile cap these tests declare. A default equal to a cap would let a
+    # broken cap look correct, and a max_limit close to the default would hide
+    # which of the two bounded a result count.
+    runtime: dict[str, Any] = {
+        "text_field_name": "content",
+        "default_limit": 10,
+        "max_limit": 20,
+    }
+    binding: dict[str, Any] = {
+        "redis_name": "docs-index",
+        "search": {"type": search_type},
+        "runtime": runtime,
+    }
+    if search_type != "fulltext":
+        # Vector and hybrid modes embed the query text, so those bindings need a
+        # vector field and a vectorizer.
+        runtime["vector_field_name"] = "embedding"
+        runtime["default_embed_text_field"] = "content"
+        binding["vectorizer"] = {"class": "FakeVectorizer", "model": "test-model"}
+    return binding
+
+
+def _config_with_profiles(
+    *profiles: dict[str, Any],
+    index_ids: tuple[str, ...] = ("knowledge",),
+    search_type: str = "fulltext",
+) -> MCPConfig:
+    return MCPConfig.model_validate(
+        {
+            "server": {"redis_url": "redis://localhost:6379"},
+            "indexes": {
+                index_id: deepcopy(_binding(search_type)) for index_id in index_ids
+            },
+            "custom_tools": [deepcopy(profile) for profile in profiles],
+        }
+    )
+
+
+def _profile(**overrides: Any) -> MCPCustomToolConfig:
+    """Build one validated profile through the real config model."""
+    profile: dict[str, Any] = {
+        "name": "resolved-search",
+        "description": "Search resolved records.",
+    }
+    profile.update(overrides)
+    return _config_with_profiles(profile).custom_tools[0]
+
+
+class FakeVectorizer:
+    async def embed(self, text: str):
+        return [0.1, 0.2, 0.3]
+
+
+class FakeIndex:
+    def __init__(self):
+        self.schema = _schema()
+        self.query_calls = []
+
+    async def query(self, query):
+        self.query_calls.append(query)
+        return []
+
+
+class FakeServer:
+    def __init__(
+        self,
+        *profiles: dict[str, Any],
+        index_ids: tuple[str, ...] = ("knowledge",),
+        search_type: str = "fulltext",
+    ):
+        self.config = _config_with_profiles(
+            *profiles, index_ids=index_ids, search_type=search_type
+        )
+        self.mcp_settings = SimpleNamespace(tool_search_description=None)
+        self.indexes = {index_id: FakeIndex() for index_id in index_ids}
+        self.vectorizer = None if search_type == "fulltext" else FakeVectorizer()
+        self.native_hybrid_supported = False
+        self.registered_tools: list[dict[str, Any]] = []
+        self.resolved_index_ids: list[str | None] = []
+        # A read scope is always declared so the wrapper's scope gate has
+        # something to check. `_auth_enabled` stays off by default, mirroring the
+        # unauthenticated stdio transport; a test turns it on to arm the gate.
+        self.auth_config = SimpleNamespace(read_scope="kb.search.read")
+        self._auth_enabled = False
+
+    def resolve_binding(self, index_id=None):
+        self.resolved_index_ids.append(index_id)
+        resolved = next(iter(self.indexes)) if index_id is None else index_id
+        if resolved not in self.indexes:
+            raise RedisVLMCPError(
+                f"Unknown index '{resolved}'; available: {', '.join(self.indexes)}",
+                code=MCPErrorCode.INVALID_REQUEST,
+                retryable=False,
+            )
+        index = self.indexes[resolved]
+        return BindingRuntime(
+            binding_id=resolved,
+            binding=self.config.indexes[resolved],
+            index=index,
+            schema=index.schema,
+            vectorizer=self.vectorizer,
+            supports_native_hybrid_search=self.native_hybrid_supported,
+            effective_read_only=False,
+        )
+
+    async def run_guarded(self, operation_name, awaitable, *, timeout_seconds=None):
+        return await awaitable
+
+    async def supports_native_hybrid_search(self):
+        return self.native_hybrid_supported
+
+    def tool(self, name=None, description=None, **kwargs):
+        def decorator(fn):
+            self.registered_tools.append(
+                {"name": name, "description": description, "fn": fn}
+            )
+            return fn
+
+        return decorator
+
+
+def _capture_text_queries(monkeypatch) -> list[dict[str, Any]]:
+    """Record the kwargs of every TextQuery the search tool builds."""
+    built: list[dict[str, Any]] = []
+
+    class FakeTextQuery:
+        def __init__(self, **kwargs):
+            built.append(kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.TextQuery", FakeTextQuery)
+    return built
+
+
+def _capture_any_query(monkeypatch) -> list[tuple[str, dict[str, Any]]]:
+    """Record (mode, kwargs) for every query class `_build_query` can construct.
+
+    All four are patched at once so the recorded mode proves which construction
+    branch ran, rather than the test having to trust the binding config.
+    """
+    built: list[tuple[str, dict[str, Any]]] = []
+
+    def _fake_query_class(mode: str):
+        class FakeQuery:
+            def __init__(self, **kwargs):
+                built.append((mode, kwargs))
+                # Only the native hybrid branch touches this, but giving every
+                # fake the attribute keeps the classes interchangeable.
+                self.postprocessing_config = SimpleNamespace(apply=lambda **_: None)
+
+        return FakeQuery
+
+    for mode, attribute in (
+        ("vector", "VectorQuery"),
+        ("fulltext", "TextQuery"),
+        ("hybrid-native", "HybridQuery"),
+        ("hybrid-fallback", "AggregateHybridQuery"),
+    ):
+        monkeypatch.setattr(
+            f"redisvl.mcp.tools.search.{attribute}", _fake_query_class(mode)
+        )
+    return built
+
+
+def _registered_fns(server: FakeServer) -> dict[str, Any]:
+    """Map every registered tool name to its callable."""
+    return {tool["name"]: tool["fn"] for tool in server.registered_tools}
+
+
+def _register(server: FakeServer, profile: MCPCustomToolConfig, binding_id="knowledge"):
+    register_profile_tool(server, profile, binding_id, _schema())
+    return server.registered_tools[0]["fn"]
+
+
+# --------------------------------------------------------------------------
+# Registration and the generated signature
+# --------------------------------------------------------------------------
+
+
+def test_profile_param_specs_cover_exactly_the_params_config_accepts():
+    # Two independent sources of truth for the same argument list: config
+    # validation rejects `params` keys outside _PROFILE_PARAM_NAMES, while the
+    # wrapper's signature is generated from _PROFILE_PARAM_SPECS. Divergence is
+    # silent in both directions -- an argument accepted in config but never
+    # rendered into the signature is quietly ignored, and one rendered but not
+    # allowed cannot be configured at all -- so assert they agree.
+    assert {name for name, _, _ in _PROFILE_PARAM_SPECS} == _PROFILE_PARAM_NAMES
+
+
+def test_register_profile_tool_registers_under_the_configured_name():
+    profile_config = {"name": "resolved-search", "description": "Search resolved."}
+    server = FakeServer(profile_config)
+
+    register_profile_tool(server, server.config.custom_tools[0], "knowledge", _schema())
+
+    assert server.registered_tools[0]["name"] == "resolved-search"
+    # FastMCP reads the callable's __name__ in places; hyphens are not valid in a
+    # Python identifier, so the wrapper sanitizes it while the tool name keeps them.
+    assert server.registered_tools[0]["fn"].__name__ == "resolved_search"
+    assert server.registered_tools[0]["fn"].__doc__ == "Search resolved."
+
+
+def test_register_profile_tool_exposes_every_search_param_by_default():
+    server = FakeServer()
+    fn = _register(server, _profile())
+
+    signature = inspect.signature(fn)
+
+    # Order matches the built-in's: required query first, then narrowing args.
+    assert list(signature.parameters) == [
+        "query",
+        "limit",
+        "offset",
+        "filter",
+        "return_fields",
+    ]
+    # Keyword-only so the generated schema is unambiguous for the model.
+    assert all(
+        param.kind is inspect.Parameter.KEYWORD_ONLY
+        for param in signature.parameters.values()
+    )
+    # A profile pins its index at registration, so the model never routes.
+    assert "index" not in signature.parameters
+
+
+def test_register_profile_tool_annotates_filter_as_an_object_never_a_string():
+    server = FakeServer()
+    fn = _register(server, _profile())
+
+    annotation = fn.__annotations__["filter"]
+
+    # A raw string filter bypasses the DSL's field validation and cannot be
+    # safely combined with a locked filter, so `str` is never advertised as an
+    # accepted filter type -- the schema refuses it before any runtime guard.
+    assert annotation == Optional[dict[str, Any]]
+    assert str not in get_args(annotation)
+    # The signature FastMCP derives the schema from must agree.
+    assert inspect.signature(fn).parameters["filter"].annotation == annotation
+
+
+def test_register_profile_tool_hides_params_the_author_does_not_expose():
+    server = FakeServer()
+    fn = _register(
+        server,
+        _profile(
+            params={
+                "offset": {"expose": False},
+                "filter": {"expose": False},
+                "return_fields": {"expose": False},
+            }
+        ),
+    )
+
+    signature = inspect.signature(fn)
+
+    assert list(signature.parameters) == ["query", "limit"]
+    # A hidden argument is absent from the annotations too, which is what
+    # FastMCP derives the advertised schema from.
+    assert set(fn.__annotations__) == {"query", "limit", "return"}
+
+
+def test_register_profile_tool_omits_locked_return_fields_from_the_signature():
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"return_fields": ["content"]}))
+
+    signature = inspect.signature(fn)
+
+    # Locking a projection implies the model cannot choose one, so the argument
+    # is not offered rather than merely overridden.
+    assert "return_fields" not in signature.parameters
+    assert "return_fields" not in fn.__annotations__
+
+
+def test_register_profile_tool_keeps_filter_exposed_when_a_filter_is_locked():
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    # Unlike return_fields, a locked filter is the narrowing case: the caller may
+    # still add a filter, which AND-combines with the locked one.
+    assert "filter" in inspect.signature(fn).parameters
+
+
+# --------------------------------------------------------------------------
+# Locked filter merging -- the security-critical behavior
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_applies_locked_filter_when_caller_supplies_none(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    await fn(query="jam")
+
+    assert str(built[0]["filter_expression"]) == "@category:{resolved}"
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_and_combines_locked_filter_with_caller_filter(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    await fn(query="jam", filter={"field": "rating", "op": "gte", "value": 4})
+
+    assert (
+        str(built[0]["filter_expression"]) == "(@category:{resolved} @rating:[4 +inf])"
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_keeps_caller_or_nested_inside_the_locked_filter(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    await fn(
+        query="jam",
+        filter={
+            "or": [
+                {"field": "rating", "op": "gte", "value": 4},
+                {"field": "content", "op": "like", "value": "jam*"},
+            ]
+        },
+    )
+
+    # The key scoping guarantee: both sides are fully parenthesized, so a
+    # caller's `or` cannot be hoisted to the top level and widen past the lock.
+    assert str(built[0]["filter_expression"]) == (
+        "(@category:{resolved} (@rating:[4 +inf] | @content:(jam*)))"
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_fails_closed_when_caller_contradicts_the_locked_field(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    await fn(query="jam", filter={"field": "category", "op": "eq", "value": "open"})
+
+    # Both tag clauses are ANDed, which is unsatisfiable rather than a silent
+    # override -- the caller cannot swap the locked category for their own.
+    assert (
+        str(built[0]["filter_expression"]) == "(@category:{resolved} @category:{open})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_passes_caller_filter_through_when_nothing_is_locked(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile())
+
+    await fn(query="jam", filter={"field": "rating", "op": "gte", "value": 4})
+
+    assert str(built[0]["filter_expression"]) == "@rating:[4 +inf]"
+
+
+def test_merge_locked_filter_rejects_a_raw_string_caller_filter_against_a_lock():
+    locked = parse_filter(LOCKED_CATEGORY_FILTER, _schema())
+
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        merge_locked_filter(locked, "@category:{open}")
+
+    # A string has no safe composition with an expression: concatenating could
+    # close the locked group and escape the scope entirely.
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+    assert exc_info.value.retryable is False
+
+
+# --------------------------------------------------------------------------
+# Locked return_fields
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_sends_locked_return_fields_to_the_query(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"return_fields": ["content", "category"]}))
+
+    await fn(query="jam")
+
+    assert built[0]["return_fields"] == ["content", "category"]
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_ignores_caller_return_fields_when_locked(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(lock={"return_fields": ["content"]}))
+
+    # The argument is absent from the advertised schema, but a client that sends
+    # it anyway must still not widen the projection.
+    await fn(query="jam", return_fields=["category", "rating"])
+
+    assert built[0]["return_fields"] == ["content"]
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_forwards_caller_return_fields_when_not_locked(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile())
+
+    await fn(query="jam", return_fields=["category"])
+
+    assert built[0]["return_fields"] == ["category"]
+
+
+# --------------------------------------------------------------------------
+# Limit policy
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_rejects_a_limit_above_the_declared_cap(monkeypatch):
+    _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"limit": {"max": 3}}))
+
+    with pytest.raises(
+        RedisVLMCPError, match="limit must be less than or equal to 3"
+    ) as exc_info:
+        await fn(query="jam", limit=4)
+
+    assert exc_info.value.code == MCPErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_allows_a_limit_at_the_declared_cap(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"limit": {"max": 3}}))
+
+    await fn(query="jam", limit=3)
+
+    assert built[0]["num_results"] == 3
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_uses_the_cap_as_a_fixed_limit_when_limit_is_hidden(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"limit": {"expose": False, "max": 3}}))
+
+    assert "limit" not in inspect.signature(fn).parameters
+
+    await fn(query="jam")
+
+    # With the argument hidden the declared cap becomes the fixed result count.
+    assert built[0]["num_results"] == 3
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_falls_back_to_binding_default_when_limit_is_hidden_uncapped(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"limit": {"expose": False}}))
+
+    await fn(query="jam")
+
+    # No cap declared, so the binding's runtime.default_limit applies.
+    assert built[0]["num_results"] == 10
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_adds_offset_to_the_requested_result_window(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile())
+
+    response = await fn(query="jam", limit=2, offset=1)
+
+    assert built[0]["num_results"] == 3
+    assert response["offset"] == 1
+    assert response["limit"] == 2
+
+
+# --------------------------------------------------------------------------
+# Description building
+# --------------------------------------------------------------------------
+
+
+def test_build_profile_description_appends_both_hints_when_both_args_are_exposed():
+    description = build_profile_description(_profile(), _schema())
+
+    assert description == f"Search resolved records. {FILTER_HINT} {RETURN_FIELDS_HINT}"
+
+
+def test_build_profile_description_returns_verbatim_when_hints_are_suppressed():
+    profile = _profile(
+        suppress_schema_hints=True, description="  Search resolved records.  "
+    )
+
+    description = build_profile_description(profile, _schema())
+
+    # Suppression is total, but the authored text is still normalized.
+    assert description == "Search resolved records."
+
+
+def test_build_profile_description_omits_the_return_fields_hint_when_locked():
+    profile = _profile(lock={"return_fields": ["content"]})
+
+    description = build_profile_description(profile, _schema())
+
+    # Enumerating returnable fields is misleading once the projection is frozen.
+    assert description == f"Search resolved records. {FILTER_HINT}"
+    assert RETURN_FIELDS_HINT not in description
+
+
+def test_build_profile_description_omits_the_filter_hint_when_filter_is_hidden():
+    profile = _profile(params={"filter": {"expose": False}})
+
+    description = build_profile_description(profile, _schema())
+
+    assert description == f"Search resolved records. {RETURN_FIELDS_HINT}"
+    assert "Object filter fields" not in description
+
+
+def test_register_profile_tool_advertises_the_built_description():
+    server = FakeServer()
+    profile = _profile(lock={"return_fields": ["content"]})
+
+    register_profile_tool(server, profile, "knowledge", _schema())
+
+    assert server.registered_tools[0]["description"] == (
+        f"Search resolved records. {FILTER_HINT}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Startup validation against the bound schema
+# --------------------------------------------------------------------------
+
+
+def test_validate_profile_against_schema_accepts_fields_the_index_has():
+    validate_profile_against_schema(
+        _profile(
+            lock={
+                "return_fields": ["content", "rating"],
+                "filter": LOCKED_CATEGORY_FILTER,
+            }
+        ),
+        _schema(),
+    )
+
+
+def test_validate_profile_against_schema_rejects_unknown_locked_return_field():
+    profile = _profile(lock={"return_fields": ["missing"]})
+
+    with pytest.raises(ValueError, match="references unknown field"):
+        validate_profile_against_schema(profile, _schema())
+
+
+def test_validate_profile_against_schema_rejects_locked_vector_return_field():
+    profile = _profile(lock={"return_fields": ["embedding"]})
+
+    with pytest.raises(ValueError, match="cannot return vector field"):
+        validate_profile_against_schema(profile, _schema())
+
+
+def test_validate_profile_against_schema_rejects_locked_filter_on_unknown_field():
+    profile = _profile(
+        lock={"filter": {"field": "missing", "op": "eq", "value": "resolved"}}
+    )
+
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        validate_profile_against_schema(profile, _schema())
+
+    # Caught at startup rather than silently matching nothing per request.
+    assert exc_info.value.code == MCPErrorCode.INVALID_FILTER
+
+
+def test_resolve_locked_filter_returns_none_when_no_filter_is_locked():
+    assert resolve_locked_filter(_profile(), _schema()) is None
+
+
+def test_resolve_locked_filter_parses_the_locked_dsl_object():
+    resolved = resolve_locked_filter(
+        _profile(lock={"filter": LOCKED_CATEGORY_FILTER}), _schema()
+    )
+
+    assert str(resolved) == "@category:{resolved}"
+
+
+# --------------------------------------------------------------------------
+# register_profile_tools
+# --------------------------------------------------------------------------
+
+
+def test_register_profile_tools_returns_nothing_when_no_profiles_are_configured():
+    server = FakeServer()
+
+    assert register_profile_tools(server) == []
+    assert server.registered_tools == []
+
+
+def test_register_profile_tools_returns_nothing_when_the_server_has_no_config():
+    assert register_profile_tools(SimpleNamespace()) == []
+
+
+def test_register_profile_tools_registers_every_configured_profile():
+    server = FakeServer(
+        {"name": "resolved-search", "description": "Search resolved."},
+        {"name": "open-search", "description": "Search open."},
+    )
+
+    registered = register_profile_tools(server)
+
+    assert registered == ["resolved-search", "open-search"]
+    assert [tool["name"] for tool in server.registered_tools] == [
+        "resolved-search",
+        "open-search",
+    ]
+
+
+def test_register_profile_tools_pins_each_profile_to_its_configured_binding():
+    server = FakeServer(
+        {
+            "name": "tickets-search",
+            "description": "Search tickets.",
+            "index": "tickets",
+        },
+        index_ids=("knowledge", "tickets"),
+    )
+
+    register_profile_tools(server)
+
+    # The binding is resolved once at registration and frozen into the wrapper.
+    assert server.resolved_index_ids == ["tickets"]
+
+
+# --------------------------------------------------------------------------
+# Closure isolation between profiles registered on the same server
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_profile_tools_gives_each_profile_its_own_locked_filter(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer(
+        {
+            "name": "a-search",
+            "description": "Search science.",
+            "lock": {"filter": {"field": "category", "op": "eq", "value": "science"}},
+        },
+        {
+            "name": "b-search",
+            "description": "Search health.",
+            "lock": {"filter": {"field": "category", "op": "eq", "value": "health"}},
+        },
+    )
+
+    register_profile_tools(server)
+    fns = _registered_fns(server)
+    await fns["a-search"](query="jam")
+    await fns["b-search"](query="jam")
+
+    # Each wrapper must close over the lock parsed for *its* profile. If the
+    # registration loop ever hoisted the parsed expression into a variable shared
+    # across iterations, every tool would carry whichever profile was registered
+    # last -- and the only visible symptom would be cross-tenant leakage.
+    assert str(built[0]["filter_expression"]) == "@category:{science}"
+    assert str(built[1]["filter_expression"]) == "@category:{health}"
+    # Stated the other way round, so a merge that accumulated both locks would
+    # also fail rather than pass the equality above by containing extra clauses.
+    assert "health" not in str(built[0]["filter_expression"])
+    assert "science" not in str(built[1]["filter_expression"])
+
+
+@pytest.mark.asyncio
+async def test_register_profile_tools_isolates_locked_filters_across_bindings(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer(
+        {
+            "name": "a-search",
+            "description": "Search knowledge.",
+            "index": "knowledge",
+            "lock": {"filter": {"field": "category", "op": "eq", "value": "science"}},
+        },
+        {
+            "name": "b-search",
+            "description": "Search tickets.",
+            "index": "tickets",
+            "lock": {"filter": {"field": "category", "op": "eq", "value": "health"}},
+        },
+        index_ids=("knowledge", "tickets"),
+    )
+
+    register_profile_tools(server)
+    fns = _registered_fns(server)
+    a_response = await fns["a-search"](query="jam")
+    b_response = await fns["b-search"](query="jam")
+
+    # The pinned binding and the locked filter are captured by the same closure,
+    # so they have to stay paired: a tool routed to one index while carrying the
+    # other index's lock is the exact multi-tenant failure this guards.
+    assert a_response["index"] == "knowledge"
+    assert b_response["index"] == "tickets"
+    assert str(built[0]["filter_expression"]) == "@category:{science}"
+    assert str(built[1]["filter_expression"]) == "@category:{health}"
+    assert len(server.indexes["knowledge"].query_calls) == 1
+    assert len(server.indexes["tickets"].query_calls) == 1
+
+
+# --------------------------------------------------------------------------
+# Hidden arguments are ignored, not merely unadvertised
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_profile_tool_ignores_a_hidden_filter_argument(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(
+        server,
+        _profile(
+            lock={"filter": {"field": "category", "op": "eq", "value": "resolved"}},
+            params={"filter": {"expose": False}},
+        ),
+    )
+
+    # A compliant client cannot send `filter` at all, since it is absent from the
+    # advertised schema. Ignoring it here as well means the lock does not depend
+    # on the client or the schema layer holding up.
+    await fn(query="jam", filter={"field": "category", "op": "eq", "value": "open"})
+
+    assert str(built[0]["filter_expression"]) == "@category:{resolved}"
+
+
+@pytest.mark.asyncio
+async def test_registered_profile_tool_ignores_a_hidden_offset_argument(monkeypatch):
+    _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"offset": {"expose": False}}))
+
+    response = await fn(query="jam", offset=25)
+
+    assert response["offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_registered_profile_tool_ignores_a_hidden_return_fields_argument(
+    monkeypatch,
+):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"return_fields": {"expose": False}}))
+
+    await fn(query="jam", return_fields=["category"])
+
+    # With no lock to substitute, a hidden projection falls back to the
+    # binding's default rather than honoring the caller.
+    assert built[0]["return_fields"] == ["content", "category", "rating"]
+
+
+@pytest.mark.asyncio
+async def test_registered_profile_tool_caps_an_omitted_limit(monkeypatch):
+    built = _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(server, _profile(params={"limit": {"expose": True, "max": 1}}))
+
+    response = await fn(query="jam")
+
+    # The cap has to bound the binding default too. Capping only an explicitly
+    # supplied limit would let the common case -- the model omitting it -- sail
+    # straight past the declared ceiling.
+    assert response["limit"] == 1
+    assert built[0]["num_results"] == 1
+
+
+@pytest.mark.asyncio
+async def test_registered_profile_tool_rejects_a_caller_filter_that_could_escape(
+    monkeypatch,
+):
+    _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    fn = _register(
+        server,
+        _profile(
+            lock={"filter": {"field": "category", "op": "eq", "value": "resolved"}},
+            params={"filter": {"expose": True}},
+        ),
+    )
+
+    # Text values are escaped at the DSL boundary, so this payload is a literal
+    # rather than syntax. Assert the end state a caller can observe: the query
+    # still runs and nothing widened the locked scope.
+    response = await fn(
+        query="jam",
+        filter={
+            "field": "content",
+            "op": "like",
+            "value": "zzz) | (-@category:{resolved}",
+        },
+    )
+
+    assert response["results"] == []
+
+
+# --------------------------------------------------------------------------
+# The wrapper's auth scope gate
+# --------------------------------------------------------------------------
+
+
+def _patch_access_token(monkeypatch, scopes: list[str]) -> None:
+    """Make the current request look authenticated with the given scopes."""
+    pytest.importorskip(
+        "fastmcp", reason="fastmcp not installed (install redisvl[mcp])"
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_access_token",
+        lambda: SimpleNamespace(scopes=scopes, claims={}),
+        raising=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_forbids_a_token_missing_the_configured_read_scope(
+    monkeypatch,
+):
+    _capture_text_queries(monkeypatch)
+    server = FakeServer()
+    server._auth_enabled = True
+    _patch_access_token(monkeypatch, ["kb.search.write"])
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    with pytest.raises(RedisVLMCPError) as exc_info:
+        await fn(query="jam")
+
+    assert exc_info.value.code == MCPErrorCode.FORBIDDEN
+    assert exc_info.value.retryable is False
+    # A profile inherits the built-in's scoping rather than restating it, so the
+    # gate has to fire before any binding work. Reaching resolve_binding would
+    # mean an unauthorized call had already selected and touched an index.
+    assert server.resolved_index_ids == []
+
+
+# --------------------------------------------------------------------------
+# Locked filters reach every search mode's query class
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("search_type", "supports_native_hybrid", "expected_mode"),
+    [
+        ("vector", False, "vector"),
+        ("fulltext", False, "fulltext"),
+        ("hybrid", True, "hybrid-native"),
+        ("hybrid", False, "hybrid-fallback"),
+    ],
+)
+async def test_profile_tool_threads_the_locked_filter_into_every_search_mode(
+    monkeypatch, search_type, supports_native_hybrid, expected_mode
+):
+    built = _capture_any_query(monkeypatch)
+    server = FakeServer(search_type=search_type)
+    server.native_hybrid_supported = supports_native_hybrid
+    fn = _register(server, _profile(lock={"filter": LOCKED_CATEGORY_FILTER}))
+
+    await fn(query="jam", filter={"field": "rating", "op": "gte", "value": 4})
+
+    mode, kwargs = built[0]
+    # `_build_query` constructs a different class per search mode, each with its
+    # own kwargs assembly. A locked filter that only threaded into the full-text
+    # branch would leave vector and hybrid profiles silently unscoped.
+    assert mode == expected_mode
+    assert str(kwargs["filter_expression"]) == "(@category:{resolved} @rating:[4 +inf])"

--- a/tests/unit/test_mcp/test_search_tool_unit.py
+++ b/tests/unit/test_mcp/test_search_tool_unit.py
@@ -16,6 +16,7 @@ from redisvl.mcp.tools.search import (
     search_records,
 )
 from redisvl.query import VectorQuery
+from redisvl.query.filter import Tag
 from redisvl.schema import IndexSchema
 
 
@@ -948,3 +949,105 @@ def test_empty_default_projection_still_yields_a_return_clause():
     assert "RETURN" in rendered
     # And what it returns is the score, not the embedding.
     assert "embedding" not in rendered.split("RETURN", 1)[1]
+
+
+# --------------------------------------------------------------------------
+# Server-supplied narrowing: `limit_cap` and `locked_filter`
+#
+# Both are passed in-process rather than by the model. They are exercised here
+# at the `search_records` boundary so the contract holds regardless of which
+# caller supplies them.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_records_rejects_an_explicit_limit_above_the_cap():
+    server = FakeServer()
+
+    with pytest.raises(RedisVLMCPError, match="less than or equal to 2") as exc:
+        await search_records(server, query="science", limit=3, limit_cap=2)
+
+    assert exc.value.code == MCPErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_search_records_caps_an_omitted_limit_instead_of_rejecting(monkeypatch):
+    """The binding default must not sail past the cap just because it is implicit."""
+    # default_limit is 2 and the cap is 1, so a cap applied only to explicit
+    # limits would let this request through at 2.
+    server = FakeServer()
+    built_queries = []
+
+    class FakeVectorQuery(FakeQuery):
+        def __init__(self, **kwargs):
+            built_queries.append(kwargs)
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.VectorQuery", FakeVectorQuery)
+
+    await search_records(server, query="science", limit_cap=1)
+
+    # No exception: the caller never named a number, so there is nothing to
+    # reject -- but the window is still bounded by the cap.
+    assert built_queries[0]["num_results"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_records_leaves_the_limit_alone_when_no_cap_is_supplied(
+    monkeypatch,
+):
+    server = FakeServer()
+    built_queries = []
+
+    class FakeVectorQuery(FakeQuery):
+        def __init__(self, **kwargs):
+            built_queries.append(kwargs)
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.VectorQuery", FakeVectorQuery)
+
+    await search_records(server, query="science", limit=3)
+
+    assert built_queries[0]["num_results"] == 3
+
+
+@pytest.mark.asyncio
+async def test_search_records_ands_a_locked_filter_under_the_caller_filter(monkeypatch):
+    server = FakeServer()
+    built_queries = []
+
+    class FakeVectorQuery(FakeQuery):
+        def __init__(self, **kwargs):
+            built_queries.append(kwargs)
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr("redisvl.mcp.tools.search.VectorQuery", FakeVectorQuery)
+
+    await search_records(
+        server,
+        query="science",
+        filter={"field": "rating", "op": "gte", "value": 4},
+        locked_filter=Tag("category") == "resolved",
+    )
+
+    rendered = str(built_queries[0]["filter_expression"])
+    # Both clauses survive, and the caller's is nested rather than replacing the
+    # lock.
+    assert "@category:{resolved}" in rendered
+    assert "@rating:[4 +inf]" in rendered
+
+
+@pytest.mark.asyncio
+async def test_search_records_refuses_a_raw_string_filter_under_a_locked_filter():
+    server = FakeServer()
+
+    with pytest.raises(RedisVLMCPError) as exc:
+        await search_records(
+            server,
+            query="science",
+            filter="@category:{open}",
+            locked_filter=Tag("category") == "resolved",
+        )
+
+    # Strings bypass the DSL's field validation and cannot be safely composed.
+    assert exc.value.code == MCPErrorCode.INVALID_FILTER

--- a/tests/unit/test_mcp/test_server.py
+++ b/tests/unit/test_mcp/test_server.py
@@ -68,6 +68,7 @@ def _startup_config(indexes=None):
             builtin_tool_enabled=lambda _name: True,
         ),
         indexes=indexes or {"knowledge": _binding_namespace()},
+        custom_tools=[],
     )
 
 

--- a/tests/unit/test_mcp/test_server_unit.py
+++ b/tests/unit/test_mcp/test_server_unit.py
@@ -162,6 +162,21 @@ def _register_tools_with(monkeypatch, bindings: dict, *, config=None) -> list[st
         lambda server, index_ids=None: registered.append("upsert-records"),
     )
 
+    def fake_register_profile_tools(server):
+        registered.append("register-profile-tools")
+        server_config = getattr(server, "config", None)
+        names = (
+            []
+            if server_config is None
+            else [profile.name for profile in server_config.custom_tools]
+        )
+        registered.extend(names)
+        return names
+
+    monkeypatch.setattr(
+        "redisvl.mcp.server.register_profile_tools", fake_register_profile_tools
+    )
+
     server = RedisVLMCPServer.__new__(RedisVLMCPServer)
     server._bindings = bindings
     server._tools_registered = False
@@ -174,7 +189,7 @@ def _register_tools_with(monkeypatch, bindings: dict, *, config=None) -> list[st
     return registered
 
 
-def _config_with(*, builtin_tools=None) -> MCPConfig:
+def _config_with(*, builtin_tools=None, custom_tools=None) -> MCPConfig:
     """Build a real validated config so the gating logic sees the real methods."""
     server_config: dict = {"redis_url": "redis://localhost:6379"}
     if builtin_tools is not None:
@@ -189,6 +204,7 @@ def _config_with(*, builtin_tools=None) -> MCPConfig:
                     "runtime": {"text_field_name": "content"},
                 }
             },
+            "custom_tools": custom_tools or [],
         }
     )
 
@@ -227,7 +243,12 @@ def test_register_tools_registers_every_builtin_when_no_config_is_attached(monke
         monkeypatch, {"knowledge": _binding_runtime("knowledge")}
     )
 
-    assert registered == ["list-indexes", "search-records", "upsert-records"]
+    assert registered == [
+        "list-indexes",
+        "search-records",
+        "upsert-records",
+        "register-profile-tools",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -261,7 +282,10 @@ def test_register_tools_warns_when_the_whole_tool_surface_is_empty(monkeypatch, 
 
     # The surface really is empty, so the warning is not passing for some other
     # reason.
-    assert registered == []
+    # Only the profile-registration call itself ran, and it produced no names,
+    # so the surface really is empty and the warning is not passing for another
+    # reason.
+    assert registered == ["register-profile-tools"]
     # A client sees a server that connects and then offers nothing, which is
     # indistinguishable from a broken deployment unless the operator is told.
     assert [
@@ -457,7 +481,146 @@ def test_register_tools_warns_when_discovery_is_disabled_on_a_write_only_surface
         )
 
     # Only upsert is published, so a check keyed on search-records would miss it.
-    assert registered == ["upsert-records"]
+    assert registered == ["upsert-records", "register-profile-tools"]
     messages = [r.message for r in caplog.records if "cannot discover" in r.message]
     assert messages
     assert "upsert-records" in messages[0]
+
+
+def test_register_tools_registers_configured_profiles(monkeypatch):
+    registered = _register_tools_with(
+        monkeypatch,
+        {"knowledge": _binding_runtime("knowledge")},
+        config=_config_with(
+            custom_tools=[
+                {"name": "resolved-search", "description": "Search resolved."},
+                {"name": "open-search", "description": "Search open."},
+            ]
+        ),
+    )
+
+    assert registered[-2:] == ["resolved-search", "open-search"]
+
+
+def test_register_tools_is_idempotent(monkeypatch):
+    """A second call must not re-register the same names on the FastMCP object."""
+    registered: list[str] = []
+    monkeypatch.setattr(
+        "redisvl.mcp.server.register_list_indexes_tool",
+        lambda server: registered.append("list-indexes"),
+    )
+    monkeypatch.setattr(
+        "redisvl.mcp.server.register_search_tool",
+        lambda server, schema, index_ids=None: registered.append("search-records"),
+    )
+    monkeypatch.setattr(
+        "redisvl.mcp.server.register_upsert_tool",
+        lambda server, index_ids=None: registered.append("upsert-records"),
+    )
+    monkeypatch.setattr(
+        "redisvl.mcp.server.register_profile_tools",
+        lambda server: registered.append("register-profile-tools") or [],
+    )
+
+    server = RedisVLMCPServer.__new__(RedisVLMCPServer)
+    server._bindings = {"knowledge": _binding_runtime("knowledge")}
+    server._tools_registered = False
+    server.tool = object()
+    server.config = None
+    server.mcp_settings = SimpleNamespace(read_only=False)
+
+    server._register_tools()
+    server._register_tools()
+
+    assert registered.count("register-profile-tools") == 1
+
+
+def test_validate_custom_tools_checks_each_profile_against_its_bound_schema(
+    monkeypatch,
+):
+    validated: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "redisvl.mcp.server.validate_profile_against_schema",
+        lambda profile, schema: validated.append((profile.name, schema.marker)),
+    )
+
+    config = MCPConfig.model_validate(
+        {
+            "server": {"redis_url": "redis://localhost:6379"},
+            "indexes": {
+                "knowledge": {
+                    "redis_name": "docs-index",
+                    "search": {"type": "fulltext"},
+                    "runtime": {"text_field_name": "content"},
+                },
+                "tickets": {
+                    "redis_name": "tickets-index",
+                    "search": {"type": "fulltext"},
+                    "runtime": {"text_field_name": "content"},
+                },
+            },
+            "custom_tools": [
+                {
+                    "name": "resolved-search",
+                    "description": "Search resolved.",
+                    "index": "tickets",
+                }
+            ],
+        }
+    )
+
+    server = RedisVLMCPServer.__new__(RedisVLMCPServer)
+    server.config = config
+    server._bindings = {
+        "knowledge": _binding_runtime("knowledge"),
+        "tickets": _binding_runtime("tickets"),
+    }
+    server._bindings["knowledge"].schema.marker = "knowledge-schema"
+    server._bindings["tickets"].schema.marker = "tickets-schema"
+
+    server._validate_custom_tools()
+
+    # Each profile is validated against the schema of the binding it is pinned to.
+    assert validated == [("resolved-search", "tickets-schema")]
+
+
+def test_register_tools_warns_when_profile_config_changed_after_registration(
+    monkeypatch, caplog
+):
+    """Profiles bake their lock in at registration, so a reload cannot retighten it."""
+    registered = _register_tools_with(
+        monkeypatch,
+        {"knowledge": _binding_runtime("knowledge")},
+        config=_config_with(
+            custom_tools=[{"name": "open-search", "description": "Search open."}]
+        ),
+    )
+    assert "open-search" in registered
+
+    # Simulate a restart that reloaded a *tightened* config: same server object,
+    # tools already registered, different profile set.
+    server = RedisVLMCPServer.__new__(RedisVLMCPServer)
+    server._bindings = {"knowledge": _binding_runtime("knowledge")}
+    server.tool = object()
+    server._tools_registered = True
+    server._registered_tool_fingerprint = ""
+    server.config = _config_with(
+        custom_tools=[
+            {
+                "name": "open-search",
+                "description": "Search open.",
+                "lock": {"filter": {"field": "category", "op": "eq", "value": "safe"}},
+            }
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="redisvl.mcp.server"):
+        server._register_tools()
+
+    # The dangerous direction: an operator tightens a lock, restarts, and believes
+    # it took effect while the old profile is still the one enforcing.
+    assert [
+        record.message
+        for record in caplog.records
+        if "changed since tools were registered" in record.message
+    ]


### PR DESCRIPTION
## Motivation

The built-in MCP tools expose the index generically, which leaves the model doing query engineering on every call: pick the index, understand the schema, build a filter in the JSON DSL, choose return fields. That work was already done by whoever designed the index, and re-deriving it per call has three costs. Tool selection is less accurate, because a generic `search-records` is harder for a model to choose correctly than a domain-named tool. Invariants are unenforceable, because "always filter on resolved tickets" is a prompt rather than a boundary, and a model that forgets it produces wrong results rather than an error. And there is nowhere to put application rules such as a redacted field list or a result cap, so they live in a system prompt or nowhere.

A profile closes that gap without any Python. It is the built-in `search-records` with some arguments pre-filled and frozen by the author and the rest still offered to the model, published under a name and description the author chooses.

## Changes

### Declarative profiles in the server config

A `custom_tools` list in the same YAML the server already loads registers additional tools at startup. Each entry names the built-in it specialises, pins the index it targets, and supplies the name and description the model sees.

```yaml
custom_tools:
  - name: search-resolved-tickets
    based_on: search-records
    index: tickets
    description: >
      Search resolved customer support tickets by relevance.
      Use this to find how a similar problem was fixed before.
    lock:
      return_fields: [subject, resolution, created_at]
      filter: { field: status, op: eq, value: resolved }
    params:
      limit: { expose: true, max: 10 }
      filter: { expose: true }
```

`lock` holds what the author decides; `params` holds the exposure policy for what the model may still pass. An argument absent from `params` stays exposed, so a profile that only locks a filter keeps the rest of the built-in's contract. `index` is pinned by the top-level key rather than offered as an argument, and may be omitted only when exactly one index is configured.

### Locked filters combine rather than override

A locked filter is AND-combined with any filter the model supplies, so the model narrows within the locked scope and cannot widen past it. Given a profile locking `status == resolved` and a model-supplied `category` filter, the executed query is `status == resolved AND category == X`, and there is no request shape that removes the status clause.

Two properties make that hold. A compound model-supplied expression renders parenthesised, so an `or` or `not` nests inside the locked AND instead of reaching the top level. And every filter value stays inside its own clause, which is what stops a crafted value closing its clause and appending query syntax; a value that still renders as something able to break out of the enclosing AND is refused rather than combined.

For the same reason a profile accepts only the object form of a filter from the model. A raw filter string is rejected both by the advertised input schema and by the tool itself, because a string bypasses the DSL's field validation and has no safe composition with an expression.

### Locked arguments are unreachable, not merely undocumented

Each profile's wrapper is built with a signature carrying only its exposed arguments, and the MCP input schema is derived from that signature with `additionalProperties` false. A locked or hidden argument therefore has no name the model can pass. The wrapper re-checks exposure per call rather than relying on the schema alone.

`params.limit.max` bounds the result count. It applies whether the model names a limit or omits one, so an omitted limit is capped rather than falling through to the binding default, and an explicit request above the cap is rejected. Hiding `limit` turns the cap into a fixed result count. The cap may not exceed the bound index's own `runtime.max_limit`, which is checked at startup.

### Misconfiguration fails at startup

Validation runs at config load where the information is available there, and at startup once each index has been inspected. Covered: a name colliding with a built-in or using a reserved prefix, a duplicate tool name, a missing or unknown `index`, a `params` key that is not a real argument, a cap on any argument other than `limit` or above the binding's ceiling, hiding `query`, locking `return_fields` while also exposing them, and a locked filter or projection naming a field the bound index does not have. Unrecognised keys are rejected, so a typo in `lock` fails loudly instead of producing a tool that reads as locked and enforces nothing.

### Secondary changes

- Concept documentation for profiles, the merge rule and the validation set, in `docs/concepts/mcp.md`.
- A worked configuration example in `docs/user_guide/how_to_guides/mcp.md`.
- `search_records` gains two keyword-only parameters, `locked_filter` and `limit_cap`, which are supplied in-process and never reach the advertised schema.

## Notes

The three commits on this branch were each opened, reviewed and merged as their own pull requests against it (#675, #676 and #677). This branch is their aggregation, and the code reaches `main` here for the first time. Reviewing the commits individually gives the same three-way split: the filter-merge primitive, the config models, then registration and execution.

A profile resolves to a built-in call and nothing further, so it inherits the concurrency cap, request timeout, read-only policy, auth scoping and error mapping already applied to `search-records`. That is the reason the feature carries no new execution surface: the path a custom tool travels is the path the built-ins already travel.

Tools register once per process. A profile bakes its locked filter, projection and signature in at registration, so a restart that reloads a changed configuration keeps enforcing the previous profiles. The server fingerprints the configuration its tools were built from and warns when the two no longer match; changing the tool surface requires a new process.

Three validation gaps are known and deliberately left: an empty `lock.filter` object is accepted at config load and fails later at startup with a less specific message, duplicate entries in `lock.return_fields` are accepted, and the `offset + limit` bound names an argument that a profile hiding `offset` gives the caller no way to supply. All three produce a worse error than necessary rather than incorrect behaviour.

## Next Steps

No provisioning is required, and no existing configuration changes behaviour: profiles are inert until a `custom_tools` block is added.

1. Verify the MCP suites against a real Redis:

```bash
uv run pytest tests/unit/test_mcp tests/integration/test_mcp -q
```

2. Add a `custom_tools` entry to a server configuration and confirm the tool is advertised with only its exposed arguments:

```bash
rvl mcp --config mcp.yaml --transport stdio
```

## Release Notes

The RedisVL MCP server can now publish **custom tool profiles**: additional tools defined entirely in the server's YAML configuration, with no Python required. A profile specialises the built-in `search-records` under a name and description you choose, pinning the index it targets and freezing whichever arguments you want fixed.

An author can lock the filter, the returned field set and a maximum result count, and choose per argument whether the model may pass it. A locked filter is AND-combined with any filter the model supplies, so the model can narrow the search but cannot widen or remove the locked clause; locked and hidden arguments are absent from the tool's advertised input schema, so there is no argument name for the model to pass. Profiles execute through the same path as the built-in tool and inherit its concurrency limit, request timeout, read-only enforcement, auth scoping and error contract.

Configuration errors fail at server startup with an actionable message rather than at the first tool call, and unrecognised keys in a profile are rejected rather than ignored.

This is additive. Existing configurations are unaffected, and a server with no `custom_tools` block behaves exactly as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP retrieval contracts and adds security-sensitive locked-filter composition, but profiles reuse the existing `search-records` path with startup validation and broad test coverage; default configs are unchanged.
> 
> **Overview**
> Adds **YAML-defined custom tool profiles** so operators can publish domain-named search tools without Python. Each `custom_tools` entry specializes `search-records` with a chosen name/description, a pinned `index`, **`lock`** (frozen filter and/or `return_fields`), and **`params`** (per-argument `expose` and optional `limit.max`).
> 
> At startup the server validates profile config (names, indexes, caps vs `max_limit`, schema-backed locked fields) and registers wrappers whose MCP schemas only list exposed arguments; locked/hidden args are omitted from the signature and ignored at runtime. Profiles delegate to `search_records` with in-process **`locked_filter`** and **`limit_cap`**.
> 
> **Filter behavior for profiles:** caller filters are always **`locked AND caller`** via new `merge_locked_filter` (plus a rendering backstop); profiles advertise **object-only** filters and reject raw strings. Omitted limits are capped silently; explicit limits above the cap fail validation.
> 
> Documentation covers profiles in concepts and the how-to guide. Tool-surface fingerprinting and warnings now include `custom_tools`; empty-tool warnings mention profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38adaa3c23961a272fda4b81cc4244a0391342d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->