### PR TITLE
fix: escape the union operator in tag filter values

### DIFF
--- a/redisvl/mcp/filters.py
+++ b/redisvl/mcp/filters.py
@@ -23,8 +23,8 @@ _TEXT_ESCAPER = TokenEscaper()
 # Dropping them costs nothing in containment, because containment comes from the
 # delimiters rather than from these. With `(` and `)` escaped, the value cannot
 # close its own `@field:(...)`, so anything it carries -- including a `|`, which
-# no escaper in RedisVL touches -- stays scoped to this one field instead of
-# reaching the surrounding expression.
+# the like path deliberately leaves live so a pattern can express a union --
+# stays scoped to this one field instead of reaching the surrounding expression.
 _LIKE_ESCAPED_CHARS = re.compile(r"[,.<>{}\[\]\\\"\':;!@#$^&()\-+=~\/]")
 _LIKE_ESCAPER = TokenEscaper(escape_chars_re=_LIKE_ESCAPED_CHARS)
 

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -130,6 +130,15 @@ class Tag(FilterField):
     }
     SUPPORTED_VAL_TYPES = (list, set, tuple, str, type(None))
 
+    # A tag clause holds its alternatives in braces, so an unescaped `|` inside
+    # one value reads as a union rather than as part of the value. Values are
+    # escaped individually before being joined, so the list form that renders a
+    # union deliberately still works. Only the non-wildcard path uses this: the
+    # `%` operator keeps `|` live as a union between patterns.
+    escaper: TokenEscaper = TokenEscaper(
+        escape_chars_re=re.compile(TokenEscaper.TAG_ESCAPED_CHARS)
+    )
+
     def _set_tag_value(
         self, other: list[str] | set[str] | str, operator: FilterOperator
     ):

--- a/redisvl/utils/token_escaper.py
+++ b/redisvl/utils/token_escaper.py
@@ -10,9 +10,12 @@ class TokenEscaper:
 
     # Characters that Redis Search requires us to escape during queries.
     # Source: https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/escaping/
-    DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?]"
+    DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~|\/ \?]"
 
-    # Same as above but excludes * and ? to allow wildcard patterns
+    # Same as above but excludes * and ? to allow wildcard patterns, and `|`
+    # because the `%` (LIKE) operator documents it as a union between wildcard
+    # patterns -- see `Tag.__mod__`. On the default path `|` is escaped, since
+    # a value carrying one would otherwise widen its clause into a union.
     ESCAPED_CHARS_NO_WILDCARD = r"[,.<>{}\[\]\\\"\':;!@#$%^&()\-+=~\/ ]"
 
     def __init__(self, escape_chars_re: Pattern | None = None):

--- a/redisvl/utils/token_escaper.py
+++ b/redisvl/utils/token_escaper.py
@@ -10,13 +10,21 @@ class TokenEscaper:
 
     # Characters that Redis Search requires us to escape during queries.
     # Source: https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/escaping/
-    DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~|\/ \?]"
+    DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?]"
 
-    # Same as above but excludes * and ? to allow wildcard patterns, and `|`
-    # because the `%` (LIKE) operator documents it as a union between wildcard
-    # patterns -- see `Tag.__mod__`. On the default path `|` is escaped, since
-    # a value carrying one would otherwise widen its clause into a union.
+    # Same as above but excludes * and ? to allow wildcard patterns
     ESCAPED_CHARS_NO_WILDCARD = r"[,.<>{}\[\]\\\"\':;!@#$%^&()\-+=~\/ ]"
+
+    # The default set plus `|`, for tag equality values only. A tag clause holds
+    # its alternatives directly in braces -- `@f:{a|b}` -- so an unescaped `|`
+    # inside a single value silently turns an equality match into a union.
+    #
+    # Deliberately not added to the default set: a text query string joins its
+    # own terms with `|`, so escaping it there turns a documented union into a
+    # literal that matches nothing. The wildcard path is likewise unaffected,
+    # because the `%` operator documents `|` as a union between patterns -- see
+    # `Tag.__mod__`.
+    TAG_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~|\/ \?]"
 
     def __init__(self, escape_chars_re: Pattern | None = None):
         if escape_chars_re:

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -107,6 +107,19 @@ def test_tag_wildcard_preserves_asterisk():
     assert str(tf_like) == "@tag_field:{tech*}"
 
 
+def test_tag_equality_escapes_pipe_but_list_still_unions():
+    """A `|` inside one tag value is literal; a list of values is still a union."""
+    # Unescaped, this value would widen its clause into a union across tenants.
+    assert str(Tag("tenant_id") == "acme|victim") == "@tenant_id:{acme\\|victim}"
+    assert str(Tag("tenant_id") != "acme|victim") == "(-@tenant_id:{acme\\|victim})"
+
+    # Values are escaped before being joined, so the list form is unaffected.
+    assert str(Tag("tenant_id") == ["acme", "victim"]) == "@tenant_id:{acme|victim}"
+
+    # The % operator documents `|` as a union between wildcard patterns.
+    assert str(Tag("category") % "elec*|*soft") == "@category:{elec*|*soft}"
+
+
 def test_tag_wildcard_combined_with_exact_match():
     """Test combining wildcard and exact match Tag filters in the same query."""
     # Create filters with different operators

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -120,6 +120,14 @@ def test_tag_equality_escapes_pipe_but_list_still_unions():
     assert str(Tag("category") % "elec*|*soft") == "@category:{elec*|*soft}"
 
 
+def test_text_query_pipe_is_still_a_union():
+    """Escaping `|` is scoped to tags; a text query joins its own terms with it."""
+    from redisvl.query import TextQuery
+
+    query = TextQuery(text="engineer|doctor", text_field_name="job")
+    assert "@job:(engineer|doctor)" in str(query)
+
+
 def test_tag_wildcard_combined_with_exact_match():
     """Test combining wildcard and exact match Tag filters in the same query."""
     # Create filters with different operators

--- a/tests/unit/test_token_escaper.py
+++ b/tests/unit/test_token_escaper.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from redisvl.utils.token_escaper import TokenEscaper
@@ -123,6 +125,11 @@ def test_escape_long_string(escaper):
     assert escaped == expected
 
 
+@pytest.fixture
+def tag_escaper():
+    return TokenEscaper(escape_chars_re=re.compile(TokenEscaper.TAG_ESCAPED_CHARS))
+
+
 @pytest.mark.parametrize(
     ("test_input,expected"),
     [
@@ -132,13 +139,21 @@ def test_escape_long_string(escaper):
     ],
     ids=["pair", "chain", "leading"],
 )
-def test_escape_pipe_on_the_default_path(escaper, test_input, expected):
-    # A `|` is RediSearch's union operator and binds looser than the implicit
-    # intersection, so one reaching the query string raw widens its clause.
-    assert escaper.escape(test_input) == expected
+def test_tag_escaper_escapes_pipe(tag_escaper, test_input, expected):
+    # A `|` is RediSearch's union operator, and a tag clause holds its
+    # alternatives directly in braces, so one reaching the query string raw
+    # turns an equality match into a union.
+    assert tag_escaper.escape(test_input) == expected
 
 
-def test_pipe_stays_live_when_wildcards_are_preserved(escaper):
+def test_default_escaper_leaves_pipe_live(escaper):
+    # A text query string joins its own terms with `|`, so escaping it on the
+    # default path would turn a documented union into a literal matching
+    # nothing -- see TextQuery(text="engineer|doctor").
+    assert escaper.escape("engineer|doctor") == "engineer|doctor"
+
+
+def test_pipe_stays_live_when_wildcards_are_preserved(tag_escaper):
     # The `%` operator documents `|` as a union between wildcard patterns, so
-    # the no-wildcard class must not escape it.
-    assert escaper.escape("elec*|*soft", preserve_wildcards=True) == "elec*|*soft"
+    # the no-wildcard class must not escape it even for a tag.
+    assert tag_escaper.escape("elec*|*soft", preserve_wildcards=True) == "elec*|*soft"

--- a/tests/unit/test_token_escaper.py
+++ b/tests/unit/test_token_escaper.py
@@ -121,3 +121,24 @@ def test_escape_long_string(escaper):
     # Use pytest's benchmark fixture to check performance
     escaped = escaper.escape(long_str)
     assert escaped == expected
+
+
+@pytest.mark.parametrize(
+    ("test_input,expected"),
+    [
+        ("acme|victim", r"acme\|victim"),
+        ("a|b|c", r"a\|b\|c"),
+        ("|leading", r"\|leading"),
+    ],
+    ids=["pair", "chain", "leading"],
+)
+def test_escape_pipe_on_the_default_path(escaper, test_input, expected):
+    # A `|` is RediSearch's union operator and binds looser than the implicit
+    # intersection, so one reaching the query string raw widens its clause.
+    assert escaper.escape(test_input) == expected
+
+
+def test_pipe_stays_live_when_wildcards_are_preserved(escaper):
+    # The `%` operator documents `|` as a union between wildcard patterns, so
+    # the no-wildcard class must not escape it.
+    assert escaper.escape("elec*|*soft", preserve_wildcards=True) == "elec*|*soft"


### PR DESCRIPTION
## Motivation

A `|` inside a tag filter value reaches the query string unescaped, where RediSearch reads it as its union operator. A tag clause holds its alternatives directly in braces, `@field:{a|b}`, so an unescaped `|` inside a single value turns an equality match into a union.

Measured on 0.27.0:

```
Tag("tenant_id") == "acme|victim"  ->  '@tenant_id:{acme|victim}'
```

That is a match on either value, not on the one asked for. It matters most where a tag value comes from outside the caller's control and is combined with other clauses: under DIALECT 2 `|` binds looser than the implicit intersection, so a union appearing at the top level of a combined expression stops the surrounding clauses constraining the result at all.

## Changes

### A tag-specific escaped set, not a change to the default

`TokenEscaper` gains `TAG_ESCAPED_CHARS`, the default set plus `|`, and `Tag` overrides `escaper` to use it:

```python
    escaper: TokenEscaper = TokenEscaper(
        escape_chars_re=re.compile(TokenEscaper.TAG_ESCAPED_CHARS)
    )
```

Tag values are escaped element by element before being joined, so the list form that renders a union deliberately is unaffected:

```
Tag("tenant_id") == "acme|victim"      ->  '@tenant_id:{acme\|victim}'
Tag("tenant_id") == ["acme", "victim"] ->  '@tenant_id:{acme|victim}'
```

### Why this is scoped to tags rather than applied to `DEFAULT_ESCAPED_CHARS`

A text query string joins its own terms with `|`, and passing one directly is supported and tested behaviour:

```python
TextQuery(text="engineer|doctor|teacher|lawyer", text_field_name="job")
  ->  '@job:(engineer|doctor|teacher|lawyer) ...'
```

`_tokenize_and_escape_query` splits on whitespace and escapes each token, so an embedded `|` survives as a union across the four terms. Escaping it on the default path turns that into a literal matching nothing, which is exactly what `tests/integration/test_multi_prefix.py::TestMultiPrefixTextQuery::test_text_query_returns_both_prefixes` asserts against. The union is the feature there; in a tag value it is the hazard.

`ESCAPED_CHARS_NO_WILDCARD` is likewise untouched. It backs `preserve_wildcards=True`, which is what the `%` operator uses, and `Tag.__mod__`'s own docstring documents `Tag("category") % "elec*|*soft"` as multiple wildcard patterns. So a tag escapes `|` under `==` and `!=`, and keeps it live under `%`.

### Secondary changes

- Six tests: the escaped pair, a chain and a leading `|` on the tag escaper; the default escaper leaving a text-query union live; the preserved-wildcard union; and the list form.
- A regression test asserting `TextQuery(text="engineer|doctor")` still renders a union, so the scoping cannot be widened later without a failure.
- A stale comment in `redisvl/mcp/filters.py` corrected, to say that the `like` path deliberately leaves `|` live rather than that no escaper in RedisVL touches it.

## Notes

The comments on both character classes now carry the reasoning for the asymmetry, because the split is not self-evident from the code and the failure mode in each direction is silent: escaping `|` too widely returns nothing, and escaping it too narrowly returns too much.

`Text` filters are not covered here and remain unescaped. `Text.__str__` interpolates its value straight into `@field:("%s")` without calling the escaper at all, so a tag-scoped escaper does not reach them, and neither would a change to the default set. That is a separate defect with a different fix, since escaping a text value has to keep spaces live for phrase matching. The MCP server already guards its own text boundary in `redisvl/mcp/filters.py`.

## Release Notes

An embedded `|` in a tag filter value no longer acts as RediSearch's union operator, and is escaped instead. `Tag("field") == "a|b"` matches the single literal value `a|b`, where it previously matched documents tagged either `a` or `b`.

**Callers relying on that implicit union will get fewer results, or none.** Passing a list remains the supported way to express a tag union and is unchanged: `Tag("field") == ["a", "b"]` still matches either value. Code depending on the old behaviour should pass a list.

Two related paths are deliberately unchanged. The `%` pattern operator continues to treat `|` as a union between wildcard patterns, so `Tag("category") % "elec*|*soft"` behaves as before. Text queries also continue to treat `|` as a union, so `TextQuery(text="engineer|doctor")` still matches either term.

The previous behaviour meant a tag value drawn from outside the caller's control could widen its own clause. Under DIALECT 2 `|` binds looser than the implicit intersection, so such a union appearing at the top level of a combined filter stopped the surrounding clauses constraining the result.

## Next Steps

1. Run the full unit suite plus the multi-prefix integration tests, which cover both sides of the scoping:

```bash
uv run pytest tests/unit tests/integration/test_multi_prefix.py -q
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query semantics for tag filters whose values contain `|` (fewer/wrong results for code that depended on the old implicit union); scoped fix but affects filter construction used in search paths.
> 
> **Overview**
> **Tag equality (`==` / `!=`) now escapes embedded `|`** so RediSearch treats it as part of the literal tag value instead of widening `@field:{…}` into a union. `TokenEscaper` adds **`TAG_ESCAPED_CHARS`** (default set plus `|`), and **`Tag`** uses that escaper only on the non-wildcard path.
> 
> **Intentionally unchanged:** passing a **list** still renders `@field:{a|b}` as a union; **`Tag % pattern`** still leaves `|` live for documented pattern unions (e.g. `elec*|*soft`); the **default** escaper and **text queries** still keep `|` as a union operator. MCP `filters.py` gets a comment fix about the like path leaving `|` live.
> 
> New unit tests lock in tag pipe escaping, list unions, `%` patterns, default/text-query behavior, and tag-escaper pipe cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8fc4e769058fa028790175431db43b1acd2c5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->