### PR TITLE
fix: parenthesise filter clauses in vector query strings

### DIFF
--- a/docs/user_guide/02_complex_filtering.ipynb
+++ b/docs/user_guide/02_complex_filtering.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "'@credit_score:{high}=>[KNN 10 @user_embedding $vector AS vector_distance] RETURN 7 user credit_score age job office_location last_updated vector_distance SORTBY vector_distance ASC DIALECT 2 LIMIT 0 10'"
+       "'(@credit_score:{high})=>[KNN 10 @user_embedding $vector AS vector_distance] RETURN 7 user credit_score age job office_location last_updated vector_distance SORTBY vector_distance ASC DIALECT 2 LIMIT 0 10'"
       ]
      },
      "execution_count": 7,
@@ -253,7 +253,7 @@
     {
      "data": {
       "text/plain": [
-       "'@credit_score:{high}=>[KNN 10 @user_embedding $vector AS vector_distance]'"
+       "'(@credit_score:{high})=>[KNN 10 @user_embedding $vector AS vector_distance]'"
       ]
      },
      "execution_count": 8,
@@ -1661,7 +1661,7 @@
     {
      "data": {
       "text/plain": [
-       "'@job:(\"engineer\")=>[KNN 5 @user_embedding $vector AS vector_distance] RETURN 6 user credit_score age job office_location vector_distance SORTBY age DESC DIALECT 3 LIMIT 0 5'"
+       "'(@job:(\"engineer\"))=>[KNN 5 @user_embedding $vector AS vector_distance] RETURN 6 user credit_score age job office_location vector_distance SORTBY age DESC DIALECT 3 LIMIT 0 5'"
       ]
      },
      "execution_count": 42,

--- a/redisvl/query/aggregate.py
+++ b/redisvl/query/aggregate.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from redis.commands.search.aggregation import AggregateRequest, Desc
 from typing_extensions import Self
 
-from redisvl.query.filter import FilterExpression
+from redisvl.query.filter import FilterExpression, intersect_with_filter
 from redisvl.redis.utils import array_to_buffer
 from redisvl.schema.fields import VectorDataType
 from redisvl.utils.full_text_query_helper import FullTextQueryHelper
@@ -380,16 +380,10 @@ class MultiVectorQuery(AggregationQuery):
                 f"@{field}:[VECTOR_RANGE {max_dist} $vector_{i}]=>{{$YIELD_DISTANCE_AS: distance_{i}}}"
             )
 
+        # Whitespace is intersection in Redis Search; there is no AND keyword.
         range_query = " ".join(range_queries)
 
-        filter_expression = self._filter_expression
-        if isinstance(self._filter_expression, FilterExpression):
-            filter_expression = str(self._filter_expression)
-
-        if filter_expression:
-            return f"({range_query}) ({filter_expression})"
-        else:
-            return f"{range_query}"
+        return intersect_with_filter(range_query, self._filter_expression)
 
     def __str__(self) -> str:
         """Return the string representation of the query."""

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -676,6 +676,60 @@ class FilterExpression:
         return self._filter
 
 
+def render_filter(filter_expression: str | FilterExpression | None) -> str | None:
+    """Render a filter expression, or None when it selects every document.
+
+    A ``None``, empty, or wildcard (``*``) filter contributes no clause to a
+    query: ``*`` is only valid as an entire query, never as one operand of an
+    intersection.
+
+    A string filter is returned verbatim and is never escaped, so an untrusted
+    value must be built through ``Tag``/``Text``/``Num`` rather than
+    interpolated into a filter string by the caller.
+
+    Internal helper; not part of the public API.
+    """
+    if filter_expression is None:
+        return None
+
+    # Coerce before comparing: `FilterField.__eq__` is overloaded to build a
+    # filter, so comparing an un-narrowed value against "*" would return a
+    # truthy FilterExpression and silently drop the filter.
+    if not isinstance(filter_expression, str):
+        filter_expression = str(filter_expression)
+
+    filter_expression = filter_expression.strip()
+    if not filter_expression or filter_expression == "*":
+        return None
+
+    return filter_expression
+
+
+def intersect_with_filter(
+    query: str, filter_expression: str | FilterExpression | None
+) -> str:
+    """Intersect a query clause with a filter expression.
+
+    Redis Search has no ``AND`` keyword -- intersection is expressed by
+    whitespace between clauses, and a literal ``AND`` would be parsed as an
+    ordinary search term. The filter is parenthesized so that a ``|`` union
+    inside it cannot bind across the intersection.
+
+    ``query`` is inserted unparenthesized, so it must not itself contain a
+    top-level ``|``; callers that build a union clause parenthesize it
+    themselves. The result is likewise ungrouped -- parenthesize it before
+    embedding it as an operand, as a KNN pre-filter does. A wildcard or absent
+    filter adds no clause and leaves ``query`` unchanged.
+
+    Internal helper; not part of the public API.
+    """
+    rendered = render_filter(filter_expression)
+    if rendered is None:
+        return query
+
+    return f"{query} ({rendered})"
+
+
 class Timestamp(Num):
     """
     A timestamp filter for querying date/time fields in Redis.

--- a/redisvl/query/hybrid.py
+++ b/redisvl/query/hybrid.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from redis.commands.search.query import Filter
 
-from redisvl.query.filter import FilterExpression
+from redisvl.query.filter import FilterExpression, render_filter
 from redisvl.redis.utils import array_to_buffer
 from redisvl.utils.full_text_query_helper import FullTextQueryHelper
 
@@ -276,13 +276,8 @@ def build_base_query(
     elif vector_search_method is not None:
         raise ValueError(f"Unknown vector search method: {vector_search_method}")
 
-    if isinstance(filter_expression, FilterExpression):
-        filter_expression = str(filter_expression)
-
-    if filter_expression and filter_expression != "*":
-        vsim_filter = Filter("FILTER", str(filter_expression))
-    else:
-        vsim_filter = None
+    rendered_filter = render_filter(filter_expression)
+    vsim_filter = Filter("FILTER", rendered_filter) if rendered_filter else None
 
     # Serialize the vector similarity query
     vsim_query = HybridVsimQuery(

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from redis.commands.search.query import Query as RedisQuery
 
-from redisvl.query.filter import FilterExpression
+from redisvl.query.filter import FilterExpression, intersect_with_filter, render_filter
 from redisvl.redis.utils import array_to_buffer
 from redisvl.utils.log import get_logger
 from redisvl.utils.stopwords import get_stopwords
@@ -580,9 +580,12 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
 
     def _build_query_string(self) -> str:
         """Build the full query string for vector search with optional filtering."""
-        filter_expression = self._filter_expression
-        if isinstance(filter_expression, FilterExpression):
-            filter_expression = str(filter_expression)
+        # Redis rejects a bare multi-clause pre-filter -- both
+        # "@a:{x} @b:{y}=>[KNN ...]" and "@a:{x} | @b:{y}=>[KNN ...]" are syntax
+        # errors -- so a real filter is parenthesized. Match-everything is the
+        # bare "*", which is why it does not go through the same path.
+        rendered_filter = render_filter(self._filter_expression)
+        prefilter = "*" if rendered_filter is None else f"({rendered_filter})"
 
         # Base KNN query
         knn_query = (
@@ -618,7 +621,7 @@ class VectorQuery(BaseVectorQuery, BaseQuery):
         # Add distance field alias
         knn_query += f" AS {self.DISTANCE_ID}"
 
-        return f"{filter_expression}=>[{knn_query}]"
+        return f"{prefilter}=>[{knn_query}]"
 
     def set_hybrid_policy(self, hybrid_policy: str):
         """Set the hybrid policy for the query.
@@ -1162,14 +1165,9 @@ class VectorRangeQuery(BaseVectorQuery, BaseQuery):
         # Add query attributes section
         attr_section = f"=>{{{'; '.join(attr_parts)}}}"
 
-        # Add filter expression if present
-        filter_expression = self._filter_expression
-        if isinstance(filter_expression, FilterExpression):
-            filter_expression = str(filter_expression)
-
-        if filter_expression == "*":
-            return f"{base_query}{attr_section}"
-        return f"({base_query}{attr_section} {filter_expression})"
+        return intersect_with_filter(
+            f"{base_query}{attr_section}", self._filter_expression
+        )
 
     @property
     def distance_threshold(self) -> float:
@@ -1544,10 +1542,6 @@ class TextQuery(BaseQuery):
 
     def _build_query_string(self) -> str:
         """Build the full query string for text search with optional filtering."""
-        filter_expression = self._filter_expression
-        if isinstance(filter_expression, FilterExpression):
-            filter_expression = str(filter_expression)
-
         escaped_query = self._tokenize_and_escape_query(self._text)
 
         # Build query parts for each field with its weight
@@ -1568,6 +1562,4 @@ class TextQuery(BaseQuery):
         else:
             text = "(" + " | ".join(field_queries) + ")"
 
-        if filter_expression and filter_expression != "*":
-            text += f" ({filter_expression})"
-        return text
+        return intersect_with_filter(text, self._filter_expression)

--- a/redisvl/utils/full_text_query_helper.py
+++ b/redisvl/utils/full_text_query_helper.py
@@ -1,4 +1,4 @@
-from redisvl.query.filter import FilterExpression
+from redisvl.query.filter import FilterExpression, intersect_with_filter
 from redisvl.utils.stopwords import get_stopwords
 from redisvl.utils.token_escaper import TokenEscaper
 
@@ -56,15 +56,11 @@ class FullTextQueryHelper:
         filter_expression: str | FilterExpression | None = None,
     ) -> str:
         """Build the full-text query string for text search with optional filtering."""
-        if isinstance(filter_expression, FilterExpression):
-            filter_expression = str(filter_expression)
+        # The text clause is optional (~) so that it contributes to scoring
+        # without excluding documents; the filter stays required.
+        text_clause = f"~@{text_field_name}:({self._tokenize_and_escape_query(text)})"
 
-        query = f"(~@{text_field_name}:({self._tokenize_and_escape_query(text)})"
-
-        if filter_expression and filter_expression != "*":
-            query += f" ({filter_expression})"
-
-        return query + ")"
+        return f"({intersect_with_filter(text_clause, filter_expression)})"
 
     def _get_stopwords(self, stopwords: str | set[str] | None = "english") -> set[str]:
         """Get the stopwords to use in the query.

--- a/tests/integration/test_aggregation.py
+++ b/tests/integration/test_aggregation.py
@@ -527,6 +527,21 @@ def test_multivector_query_with_filter(index):
     results = index.query(multi_query)
     assert len(results) == 0
 
+    # A wildcard filter must contribute no clause. This class had no such
+    # guard, so it emitted "(...) (*)" and Redis rejected the query with a
+    # syntax error: "(*)" is valid as a KNN pre-filter but never as an operand
+    # of an intersection. Regression coverage for issue #708.
+    unfiltered = MultiVectorQuery(vectors=vectors, return_fields=["description"])
+    wildcard = MultiVectorQuery(
+        vectors=vectors,
+        filter_expression="*",
+        return_fields=["description"],
+    )
+
+    unfiltered_results = index.query(unfiltered)
+    assert len(unfiltered_results) > 0
+    assert index.query(wildcard) == unfiltered_results
+
 
 def test_multivector_query_with_geo_filter(index):
     skip_if_redis_version_below(index.client, "7.2.0")

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -1409,3 +1409,69 @@ def test_missing_fields_workflow_filtering(missing_fields_index):
     else:
         # If not indexed, that's also acceptable behavior for this test
         pass
+
+
+# A raw-string union filter is what exercises the parenthesization of a filter
+# clause: FilterExpression unions self-parenthesize via `format_expression`, so
+# only a raw string can bind across the surrounding intersection. Regression
+# coverage for issue #708.
+UNION_FILTER = "@credit_score:{high} | @credit_score:{medium}"
+
+
+def test_vector_query_with_raw_string_union_filter(index):
+    """A multi-clause KNN pre-filter must be parenthesized to be valid at all.
+
+    Redis rejects a bare multi-clause pre-filter, so before the fix this query
+    raised a syntax error rather than returning wrong results. The credit score
+    assertion additionally proves the filter is applied rather than dropped.
+    """
+    query = VectorQuery(
+        vector=[0.1, 0.1, 0.5],
+        vector_field_name="user_embedding",
+        filter_expression=UNION_FILTER,
+        return_fields=["user", "credit_score"],
+        num_results=10,
+    )
+
+    results = index.query(query)
+
+    assert {result["credit_score"] for result in results} == {"high", "medium"}
+    assert {result["user"] for result in results} == {
+        "john",
+        "nancy",
+        "tyler",
+        "tim",
+        "joe",
+    }
+
+
+def test_vector_range_query_with_raw_string_union_filter(index):
+    """A union filter must stay grouped inside the vector range intersection.
+
+    Only john and mary sit at distance 0 from the query vector, and john is the
+    only one of the two with a credit score the filter admits. Without its own
+    parentheses the query parses as (range AND high) OR medium, which also
+    returns joe -- a document whose embedding is the negation of the query
+    vector and so nowhere near the range.
+
+    `return_score=False` is load-bearing, not incidental. Redis yields no
+    distance for a document matched only through the stray union branch, and
+    with the distance requested `process_results` drops any such document as a
+    suspected Redis 8.8 expiry race. That silently masks the extra result, so
+    with the default `return_score=True` this test passes even on the unfixed
+    code -- verified against v0.27.0, which returns ["john"] with the score
+    requested and ["john", "joe"] without it.
+    """
+    query = VectorRangeQuery(
+        vector=[0.1, 0.1, 0.5],
+        vector_field_name="user_embedding",
+        distance_threshold=0.01,
+        filter_expression=UNION_FILTER,
+        return_fields=["user", "credit_score"],
+        num_results=10,
+        return_score=False,
+    )
+
+    results = index.query(query)
+
+    assert [result["user"] for result in results] == ["john"]

--- a/tests/unit/test_aggregation_types.py
+++ b/tests/unit/test_aggregation_types.py
@@ -380,27 +380,54 @@ def test_multi_vector_query_string():
     weight_2 = 0.7
     max_distance_1 = 0.7
     max_distance_2 = 1.8
-    multi_vector_query = MultiVectorQuery(
-        vectors=[
-            Vector(
-                vector=sample_vector_2,
-                field_name=field_1,
-                weight=weight_1,
-                max_distance=max_distance_1,
-            ),
-            Vector(
-                vector=sample_vector_3,
-                field_name=field_2,
-                weight=weight_2,
-                max_distance=max_distance_2,
-            ),
-        ]
-    )
+    vectors = [
+        Vector(
+            vector=sample_vector_2,
+            field_name=field_1,
+            weight=weight_1,
+            max_distance=max_distance_1,
+        ),
+        Vector(
+            vector=sample_vector_3,
+            field_name=field_2,
+            weight=weight_2,
+            max_distance=max_distance_2,
+        ),
+    ]
+    multi_vector_query = MultiVectorQuery(vectors=vectors)
 
     assert (
         str(multi_vector_query)
         == f"@{field_1}:[VECTOR_RANGE {max_distance_1} $vector_0]=>{{$YIELD_DISTANCE_AS: distance_0}} @{field_2}:[VECTOR_RANGE {max_distance_2} $vector_1]=>{{$YIELD_DISTANCE_AS: distance_1}} SCORER TFIDF DIALECT 2 APPLY (2 - @distance_0)/2 AS score_0 APPLY (2 - @distance_1)/2 AS score_1 APPLY @score_0 * {weight_1} + @score_1 * {weight_2} AS combined_score SORTBY 2 @combined_score DESC MAX 10"
     )
+
+    # The filter is intersected with whitespace and parenthesized, so a union
+    # inside it cannot bind across the vector range clauses. Regression
+    # coverage for issue #708.
+    range_clauses = (
+        f"@{field_1}:[VECTOR_RANGE {max_distance_1} $vector_0]"
+        f"=>{{$YIELD_DISTANCE_AS: distance_0}} "
+        f"@{field_2}:[VECTOR_RANGE {max_distance_2} $vector_1]"
+        f"=>{{$YIELD_DISTANCE_AS: distance_1}}"
+    )
+
+    def query_string_for(filter_expression):
+        return MultiVectorQuery(
+            vectors=vectors, filter_expression=filter_expression
+        )._build_query_string()
+
+    assert query_string_for(Tag("category") == "tech") == (
+        f"{range_clauses} (@category:{{tech}})"
+    )
+    assert (
+        query_string_for("@a:{x} | @b:{y}") == f"{range_clauses} (@a:{{x}} | @b:{{y}})"
+    )
+
+    # A wildcard filter contributes no clause. This class had no such guard, so
+    # it emitted "(...) (*)", which Redis rejects with a syntax error -- "(*)"
+    # is valid as a KNN pre-filter but never as an intersection operand.
+    assert query_string_for("*") == range_clauses
+    assert query_string_for(None) == range_clauses
 
 
 def test_vector_object_validation():

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -5,7 +5,16 @@ from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
 
-from redisvl.query.filter import Geo, GeoRadius, Num, Tag, Text, Timestamp
+from redisvl.query.filter import (
+    Geo,
+    GeoRadius,
+    Num,
+    Tag,
+    Text,
+    Timestamp,
+    intersect_with_filter,
+    render_filter,
+)
 
 
 # Test cases for various scenarios of tag usage, combinations, and their string representations.
@@ -781,3 +790,63 @@ def test_is_missing_filter_combinations():
     assert "ismissing(@brand)" in complex_str
     assert "@price:[(100 +inf]" in complex_str
     assert "@category:{electronics}" in complex_str
+
+
+# Regression coverage for issue #708. These two helpers are the single place
+# that decides how a filter is joined to a query, so their edge cases are
+# asserted directly rather than only through the six query classes that use them.
+@pytest.mark.parametrize(
+    "filter_expression,expected",
+    [
+        (None, None),
+        ("", None),
+        ("*", None),
+        # Whitespace is stripped before the wildcard test: emitting "( * )" or
+        # "(  )" as an intersection operand is a Redis syntax error.
+        ("  ", None),
+        (" * ", None),
+        ("\t*\n", None),
+        ("@a:{x}", "@a:{x}"),
+        (" @a:{x} ", "@a:{x}"),
+        ("@a:{x} | @b:{y}", "@a:{x} | @b:{y}"),
+    ],
+)
+def test_render_filter(filter_expression, expected):
+    assert render_filter(filter_expression) == expected
+
+
+def test_render_filter_with_filter_expression_inputs():
+    """A FilterExpression is rendered via `str()`, and the input is left alone.
+
+    The coercion is not incidental: `FilterField.__eq__` is overloaded to build
+    a filter and mutates the receiver in place, so comparing an un-narrowed
+    field against "*" would both return a truthy FilterExpression -- silently
+    dropping the filter -- and corrupt the caller's object.
+    """
+    assert render_filter(Tag("category") == "tech") == "@category:{tech}"
+
+    # An empty filter renders as "*", which means "no filtering".
+    assert render_filter(Tag("category") == []) is None
+
+    field = Tag("category")
+    before = str(field)
+    assert render_filter(field) is None
+    assert str(field) == before
+
+
+@pytest.mark.parametrize(
+    "filter_expression,expected",
+    [
+        # A filter that selects everything contributes no clause at all.
+        (None, "@text:(fox)"),
+        ("", "@text:(fox)"),
+        ("*", "@text:(fox)"),
+        (" * ", "@text:(fox)"),
+        # Redis has no AND keyword, and the filter is parenthesized so that a
+        # union inside it cannot bind across the intersection.
+        ("@a:{x}", "@text:(fox) (@a:{x})"),
+        ("@a:{x} | @b:{y}", "@text:(fox) (@a:{x} | @b:{y})"),
+    ],
+)
+def test_intersect_with_filter(filter_expression, expected):
+    assert intersect_with_filter("@text:(fox)", filter_expression) == expected

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -351,6 +351,63 @@ def test_text_query_with_string_filter():
     assert "AND" not in query_string_wildcard
 
 
+def test_vector_query_prefilter_shapes():
+    """A KNN pre-filter is parenthesized unless it is the bare wildcard.
+
+    Redis rejects a bare multi-clause pre-filter outright, so a union filter
+    could not run at all, and an empty filter produced "=>[KNN ...]", which is
+    also a syntax error. Match-everything stays the bare "*", which is the
+    documented form and the one shape where "(*)" would be needless churn.
+    Regression coverage for issue #708.
+    """
+    knn = "[KNN 10 @embedding $vector AS vector_distance]"
+
+    def prefilter_for(filter_expression):
+        return VectorQuery(
+            vector=[0.1, 0.2, 0.3],
+            vector_field_name="embedding",
+            filter_expression=filter_expression,
+        )._build_query_string()
+
+    # A real filter is parenthesized, single clause included.
+    assert prefilter_for("@category:{tech}") == f"(@category:{{tech}})=>{knn}"
+    assert prefilter_for(Tag("category") == "tech") == f"(@category:{{tech}})=>{knn}"
+
+    # A top-level union must not bind across the "=>" pre-filter boundary.
+    assert prefilter_for("@a:{x} | @b:{y}") == f"(@a:{{x}} | @b:{{y}})=>{knn}"
+
+    assert prefilter_for(None) == f"*=>{knn}"
+    assert prefilter_for("*") == f"*=>{knn}"
+    assert prefilter_for("") == f"*=>{knn}"
+
+
+def test_vector_range_query_filter_is_parenthesised():
+    """The filter clause carries its own parentheses rather than the whole query.
+
+    Without them a raw-string union binds across the intersection, so the query
+    matches documents outside the vector range. The outer parentheses the old
+    form wrapped around everything were redundant: the string is always a
+    complete FT.SEARCH argument, never an embedded operand. See issue #708.
+    """
+    base = (
+        "@embedding:[VECTOR_RANGE $distance_threshold $vector]"
+        "=>{$YIELD_DISTANCE_AS: vector_distance}"
+    )
+
+    def query_string_for(filter_expression):
+        return VectorRangeQuery(
+            vector=[0.1, 0.2, 0.3],
+            vector_field_name="embedding",
+            distance_threshold=0.2,
+            filter_expression=filter_expression,
+        )._build_query_string()
+
+    assert query_string_for("@category:{tech}") == f"{base} (@category:{{tech}})"
+    assert query_string_for("@a:{x} | @b:{y}") == f"{base} (@a:{{x}} | @b:{{y}})"
+    assert query_string_for(None) == base
+    assert query_string_for("*") == base
+
+
 @pytest.mark.skip("Test is flaking")
 def test_text_query_word_weights():
     # verify word weights get added into the raw Redis query syntax


### PR DESCRIPTION
## Motivation

Redis Search has no `AND` keyword. Intersection is expressed by whitespace between clauses, and `|` binds more loosely than whitespace under DIALECT 2, so a filter expression used as one operand of an intersection has to be parenthesised. The match-everything wildcard is the exception in both directions: `*` is valid only as an entire query and never as an operand of an intersection, yet it is the documented spelling for "no filter" in a KNN pre-filter.

Issue #708 reported that filtered full-text queries joined the filter with a literal `" AND "`, which Redis parsed as an ordinary fieldless search term. #709 corrected the three sites that issue named. Three further sites still generate query strings that Redis either rejects outright or silently mis-parses, and the normalisation logic all of them share is copy-pasted into eight blocks across four files, which is how the defect came to differ between sites in the first place.

| Site | Previous output | Consequence |
|---|---|---|
| `VectorQuery` pre-filter | `@a:{x} \| @b:{y}=>[KNN ...]` | Syntax error. A bare pre-filter of more than one clause fails on whitespace as well as on `\|`, so the query cannot run. `filter_expression=""` produced `=>[KNN ...]`, also a syntax error. |
| `VectorRangeQuery` | `(@v:[VECTOR_RANGE ...]=>{...} @a:{x} \| @b:{y})` | Silently wrong results. The union binds across the intersection, so documents outside the vector range are returned. |
| `MultiVectorQuery` | `(...) (*)` | Syntax error on every index. The class had no wildcard guard, so an explicit `filter_expression="*"` emitted the wildcard as an intersection operand. |

## Changes

### Parenthesise the filter clause at the three remaining sites

Each site now wraps the filter in its own parentheses so that a union inside it cannot bind across the intersection, and drops the clause entirely when the filter selects every document.

```python
# VectorQuery._build_query_string
- return f"{filter_expression}=>[{knn_query}]"
+ return f"{prefilter}=>[{knn_query}]"    # "(@a:{x} | @b:{y})=>[KNN ...]", or bare "*"

# VectorRangeQuery._build_query_string
- return f"({base_query}{attr_section} {filter_expression})"
+ return intersect_with_filter(f"{base_query}{attr_section}", self._filter_expression)

# MultiVectorQuery._build_query_string
- if filter_expression:
-     return f"({range_query}) ({filter_expression})"
+ return intersect_with_filter(range_query, self._filter_expression)
```

`VectorQuery` is the one site that does not use `intersect_with_filter`, because a KNN pre-filter is not an intersection: the bare `*` has to survive there rather than be dropped. The parenthesised pre-filter is the form the Redis documentation gives as canonical, and parenthesising a single-clause pre-filter is inert — `FT.EXPLAIN` returns an identical plan for `@credit_score:{high}=>[KNN ...]` and `(@credit_score:{high})=>[KNN ...]`.

`VectorRangeQuery` also loses the parentheses it used to wrap around the whole query. Those were redundant: the string is always a complete `FT.SEARCH` argument, never an embedded operand. The parentheses the filter needed were the inner ones.

### Collapse the filter normalisation into two helpers

`render_filter` and `intersect_with_filter` in `redisvl/query/filter.py` are now the single place that decides how a filter joins a query. Six call sites route through them, across `query.py`, `aggregate.py`, `hybrid.py` and `full_text_query_helper.py`. `FilterQuery` and `CountQuery` keep their own blocks deliberately: there the filter is the entire query, so `*` must survive rather than be dropped.

Two details in `render_filter` are load-bearing rather than defensive. It coerces with `str()` before comparing against `"*"`, because `FilterField.__eq__` is overloaded to build a filter and mutates the receiver in place — comparing an un-narrowed field against `"*"` returns a truthy `FilterExpression` and corrupts the caller's object. And it strips whitespace before that comparison, because `( * )` is a syntax error as an operand of an intersection even though it parses as a query on its own.

`filter.py` is the right home: it imports only `redisvl.utils.token_escaper`, so there is no cycle, and every call site already imports `FilterExpression` from it. Neither helper is exported from `redisvl/query/__init__.py`; both are implementation detail.

Three stored query strings in `docs/user_guide/02_complex_filtering.ipynb` are also corrected to match the new `VectorQuery` output. `docs/user_guide/12_sql_to_redis_queries.ipynb` needs no change: it goes through the external SQL translator, which already emitted a parenthesised pre-filter.

## Notes

Filtered `MultiVectorQuery` output changes shape from `(range) (filter)` to `range (filter)`. `FT.EXPLAIN` confirms the two plan identically, because `INTERSECT` is flat and associative under DIALECT 2, so the reshaping is a no-op. Anyone asserting on the exact string rather than on results will see a difference.

Callers passing a raw-string filter containing a top-level `|` to `VectorRangeQuery` will get different, correct results: the union now binds inside the filter rather than across the whole query, so such queries return fewer and correctly-filtered documents. Filters built through `Tag`, `Text`, `Num` and the other field helpers are unaffected, since `format_expression` already parenthesises composite nodes.

Three edge-case inputs also change output, each from an invalid or actively wrong string to a valid one. A whitespace-only filter previously emitted `(  )` and a whitespace-padded wildcard emitted `( * )`. A bare un-narrowed `FilterField` such as `Tag("category")` previously emitted a negated filter, because the old code evaluated `filter_expression != "*"` and `__ne__` is overloaded in the same way as `__eq__`; it now contributes no clause. None of the three is a supported input, and the classes that accept them do no type validation, which is worth addressing separately.

One caller-supplied string still defeats the wildcard guard. Passing the literal `"(*)"` as `filter_expression` produces `((*))`, a syntax error. The guard is not widened to cover it: the input is a programming error, the behaviour predates this change, and it fails loudly rather than silently.

`process_results` in `redisvl/index/index.py` masks the `VectorRangeQuery` defect when the distance is requested. Redis yields no distance for a document matched only through a stray union branch, and any vector-query result missing `vector_distance` is dropped as a suspected Redis 8.8 expiry race, with a warning that misattributes the cause. The extra documents are therefore invisible with the default `return_score=True` and visible with `return_score=False`. The integration test covering this uses `return_score=False` for that reason. The masking itself is a separate concern and is left alone here.

DIALECT 1 inverts the scope of the `~` optional operator, wrapping the whole intersection — filter included — in `OPTIONAL` rather than just the text clause. This is unreachable from the affected code paths, because a KNN clause is itself a syntax error under DIALECT 1, so any caller passing `dialect=1` to a vector query already fails loudly. Recorded because the behaviour is not documented.

## Release Notes

Filter expressions are now parenthesised wherever they are combined with another clause, which fixes three classes of broken query. A `VectorQuery` whose `filter_expression` contains more than one clause previously failed with a syntax error and now runs. A `MultiVectorQuery` given an explicit wildcard filter previously failed with a syntax error and now runs. A `VectorRangeQuery` given a raw-string filter containing a top-level `|` previously returned documents outside the vector range, because the union bound across the intersection rather than inside the filter; such queries now return fewer, correctly-filtered results.

The change is backwards-compatible for filters built through `Tag`, `Text`, `Num`, `Geo` and `Timestamp`, which were already parenthesised. Two generated query strings change shape without changing meaning: a filtered `MultiVectorQuery` no longer parenthesises its vector-range clauses as a group, and a filtered `VectorRangeQuery` no longer wraps the whole query in parentheses. Code asserting on exact query strings rather than on results may need updating.