### PR TITLE
fix: contain Text equality and numeric filter values in their own clause

### DIFF
--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -189,7 +189,7 @@ Two things about filters are easy to conflate:
 
 For that reason a profile accepts only the **object** form of a filter from the model. A raw filter string is rejected both by the advertised schema and by the tool itself, because strings bypass the DSL's field validation and have no safe composition with a locked expression.
 
-Structure is only half of it: the nesting guarantee holds only while every filter *value* stays inside its own clause. Text values are escaped at the filter boundary for that reason — unescaped, a value containing a quote or a parenthesis could close its clause and inject query syntax after it, including a `|` that escapes the surrounding AND. Tag values are escaped and numeric values are type-checked. A caller filter that still renders as something able to break out is refused rather than combined.
+Structure is only half of it: the nesting guarantee holds only while every filter *value* stays inside its own clause. Text `eq`/`ne` values are handled by the `Text` filter itself, which renders them as a quoted phrase with any `"` or `\` replaced by a space, so a parenthesis or a `|` the value carries is literal text rather than syntax. Text `like` values are patterns, so the library leaves them raw and this boundary escapes them instead — the delimiters that would close the clause are escaped, the pattern metacharacters are not. Tag values have their delimiters escaped and numeric values are type-checked. A caller filter that still renders as something able to break out is refused rather than combined.
 
 Profiles resolve to a built-in call and nothing more, so they inherit the concurrency cap, request timeout, read-only policy, auth scoping, and error mapping already applied to `search-records`.
 

--- a/docs/user_guide/02_complex_filtering.ipynb
+++ b/docs/user_guide/02_complex_filtering.ipynb
@@ -691,7 +691,12 @@
    "source": [
     "### Text Filters\n",
     "\n",
-    "Text filters are filters that are applied to text fields. These filters are applied to the entire text field. For example, if you have a text field that contains the text \"The quick brown fox jumps over the lazy dog\", a text filter of \"quick\" will match this text field."
+    "Text filters are filters that are applied to text fields. These filters are applied to the entire text field. For example, if you have a text field that contains the text \"The quick brown fox jumps over the lazy dog\", a text filter of \"quick\" will match this text field.\n",
+    "\n",
+    "A value passed to `==` or `!=` is matched as a literal phrase, so a `\"` or a\n",
+    "`\\` inside it is insignificant rather than interpreted. The `%` operator is the\n",
+    "opposite: its value is a raw pattern, so pass it only patterns your own code\n",
+    "composes."
    ]
   },
   {

--- a/redisvl/mcp/filters.py
+++ b/redisvl/mcp/filters.py
@@ -6,14 +6,11 @@ from redisvl.query.filter import FilterExpression, Num, Tag, Text
 from redisvl.schema import IndexSchema
 from redisvl.utils.token_escaper import TokenEscaper
 
-# Text values reach the query string unescaped: `Text`'s operator templates are
-# `@field:("value")` for eq/ne and `@field:(value)` for like, so a caller value
-# containing a quote or a paren can close its own clause and inject arbitrary
-# RediSearch syntax after it -- including a `|` that escapes an enclosing AND.
-# Tag and numeric values are already escaped or type-checked upstream; text is
-# not, so this boundary escapes it before building the expression.
-_TEXT_ESCAPER = TokenEscaper()
-
+# `Text` neutralizes its own eq/ne values (see `_PHRASE_UNSAFE` in
+# `redisvl.query.filter`), so this boundary must not treat them again -- doubled
+# handling mangles ordinary values. `like` below is the exception, because the
+# library leaves `%` raw by design.
+#
 # `like` is the pattern operator, so the metacharacters that give a pattern its
 # meaning have to stay live: `*` and `?` for wildcards, `%` for fuzzy matching,
 # and a space for the implicit AND between terms. Escaping those does not fail
@@ -156,11 +153,6 @@ def _parse_tag_expression(field_name: str, op: str, operand: Any) -> FilterExpre
     )
 
 
-def _escape_text(value: str) -> str:
-    """Escape a caller-supplied text value so it cannot leave its own clause."""
-    return _TEXT_ESCAPER.escape(value)
-
-
 def _escape_like_pattern(value: str) -> str:
     """Escape a `like` pattern, leaving its pattern metacharacters intact."""
     return _LIKE_ESCAPER.escape(value)
@@ -169,17 +161,20 @@ def _escape_like_pattern(value: str) -> str:
 def _parse_text_expression(field_name: str, op: str, operand: Any) -> FilterExpression:
     field = Text(field_name)
     if op == "eq":
-        return field == _escape_text(_require_string(operand, field_name, op))
+        return field == _require_string(operand, field_name, op)
     if op == "ne":
-        return field != _escape_text(_require_string(operand, field_name, op))
+        return field != _require_string(operand, field_name, op)
     if op == "like":
-        # An exact-match value is a literal, but a `like` value is a pattern, so
-        # the two need different escaping -- see `_LIKE_ESCAPED_CHARS`.
+        # An exact-match value is a literal that `Text` neutralizes itself, but a
+        # `like` value is a pattern the library leaves raw -- see
+        # `_LIKE_ESCAPED_CHARS`.
         return field % _escape_like_pattern(_require_string(operand, field_name, op))
     if op == "in":
+        # A fresh builder per item: each `==` mutates the instance, so reusing one
+        # only works while `FilterExpression` captures the rendering eagerly.
         return _combine_or(
             [
-                field == _escape_text(item)
+                Text(field_name) == item
                 for item in _require_string_list(operand, field_name, op)
             ]
         )

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -370,37 +370,42 @@ def _build_fallback_hybrid_kwargs(
     }
 
 
-def _find_range_end(rendered: str, position: int) -> int | None:
-    """Return the index of the `]` closing a numeric range, or None if unclosed."""
-    while position < len(rendered):
+def _find_unescaped(
+    rendered: str, position: int, character: str, end: int | None = None
+) -> int | None:
+    """Return the index of the next unescaped `character` before `end`, or None.
+
+    `end` bounds the scan. Without it a caller inside a span pays for the whole
+    remaining string, which makes the enclosing walk quadratic in the number of
+    spans.
+    """
+    limit = len(rendered) if end is None else min(end, len(rendered))
+    while position < limit:
         if rendered[position] == "\\":
             position += 2
             continue
-        if rendered[position] == "]":
+        if rendered[position] == character:
             return position
         position += 1
     return None
 
 
-def _span_holds_unescaped_pipe(rendered: str, start: int, end: int) -> bool:
-    """Report whether `rendered[start:end]` holds a `|` that is not escaped."""
-    position = start
-    while position < end:
-        if rendered[position] == "\\":
-            position += 2
-            continue
-        if rendered[position] == "|":
-            return True
-        position += 1
-    return False
-
-
 def _reject_escapable_filter(caller: FilterExpression) -> None:
     """Refuse a caller filter whose rendering could break out of a locked AND.
 
-    A well-formed expression built from escaped values cannot escape, so anything
-    this rejects means a value reached the query string unescaped. It is a
-    backstop, not the primary defense -- see ``merge_locked_filter``.
+    Outside a quoted phrase every value reaches the rendering escaped or
+    type-checked -- by the DSL, or at this server's filter boundary for ``like``
+    patterns, which the library leaves raw. So a rejection means one of those
+    failed. It is a backstop, not the primary defense -- see
+    ``merge_locked_filter`` -- and it runs only when a lock exists, so an
+    unlocked tool relies on those two layers alone.
+
+    The quoted-phrase skip below assumes a rendering's unescaped quotes arrive in
+    delimiting pairs, which holds for every value the DSL can render: ``==`` and
+    ``!=`` quote the value and take any quote it carried out first, and ``Tag``
+    and ``like`` values arrive with theirs escaped. If that ever stops holding,
+    the skip finds no closing quote and refuses the filter, so the failure is
+    loud rather than silent.
     """
     # Braces scope as much as parens do: a tag clause holds its alternatives in
     # braces, so `@category:{sports|health}` is one scoped clause rather than a
@@ -425,6 +430,21 @@ def _reject_escapable_filter(caller: FilterExpression) -> None:
             position += 2
             continue
 
+        if character == '"':
+            # A quoted phrase is a literal, so nothing inside it is structure and
+            # a `|` inside it is a separator rather than a union. Unlike the range
+            # span below, the whole phrase can therefore be skipped. Ending the
+            # skip at the first *unescaped* quote is what keeps this failing
+            # closed: a value that did reach the rendering raw ends the phrase
+            # there, and the injected remainder is counted as before.
+            end = _find_unescaped(rendered, position + 1, '"')
+            if end is None:
+                # Unterminated phrase: the remainder is unparsable.
+                escaped = True
+                break
+            position = end + 1
+            continue
+
         if character == "[":
             # A numeric range is bounds, not structure: an exclusive bound
             # renders as `[(5 +inf]`, where `(` is a marker rather than a group.
@@ -434,11 +454,11 @@ def _reject_escapable_filter(caller: FilterExpression) -> None:
             # range holds numbers, so a `|` in here means a value reached the
             # query string raw, which is exactly the case this backstop exists
             # to catch; skipping past it would let a union hide behind brackets.
-            end = _find_range_end(rendered, position + 1)
+            end = _find_unescaped(rendered, position + 1, "]")
             if end is None:
                 escaped = True
                 break
-            if _span_holds_unescaped_pipe(rendered, position + 1, end):
+            if _find_unescaped(rendered, position + 1, "|", end) is not None:
                 escaped = True
                 break
             position = end + 1
@@ -485,7 +505,9 @@ def merge_locked_filter(
     The locked expression always applies, so a caller can only narrow within it
     and never widen past it. That rests on two things: the caller's expression
     rendering nested inside the AND, and every value staying inside its own
-    clause (which ``_parse_text_expression`` escaping provides).
+    clause. ``Text`` removes the quote that delimits a phrase, ``Tag`` escapes
+    the braces that delimit a tag clause, numeric values are type-checked, and
+    ``like`` patterns are escaped at the filter boundary.
     """
     if locked is None:
         return caller

--- a/redisvl/mcp/tools/search.py
+++ b/redisvl/mcp/tools/search.py
@@ -400,12 +400,12 @@ def _reject_escapable_filter(caller: FilterExpression) -> None:
     ``merge_locked_filter`` -- and it runs only when a lock exists, so an
     unlocked tool relies on those two layers alone.
 
-    The quoted-phrase skip below assumes a rendering's unescaped quotes arrive in
+    The quoted-phrase skip below assumes a rendering's quotes arrive in
     delimiting pairs, which holds for every value the DSL can render: ``==`` and
     ``!=`` quote the value and take any quote it carried out first, and ``Tag``
-    and ``like`` values arrive with theirs escaped. If that ever stops holding,
-    the skip finds no closing quote and refuses the filter, so the failure is
-    loud rather than silent.
+    and ``like`` values arrive with theirs escaped, outside any phrase. If that
+    ever stops holding, the skip finds no closing quote and refuses the filter,
+    so the failure is loud rather than silent.
     """
     # Braces scope as much as parens do: a tag clause holds its alternatives in
     # braces, so `@category:{sports|health}` is one scoped clause rather than a
@@ -433,12 +433,17 @@ def _reject_escapable_filter(caller: FilterExpression) -> None:
         if character == '"':
             # A quoted phrase is a literal, so nothing inside it is structure and
             # a `|` inside it is a separator rather than a union. Unlike the range
-            # span below, the whole phrase can therefore be skipped. Ending the
-            # skip at the first *unescaped* quote is what keeps this failing
-            # closed: a value that did reach the rendering raw ends the phrase
-            # there, and the injected remainder is counted as before.
-            end = _find_unescaped(rendered, position + 1, '"')
-            if end is None:
+            # span below, the whole phrase can therefore be skipped.
+            #
+            # The scan deliberately does not treat `\` as escaping the closing
+            # quote, because RediSearch does not either: `@f:("x\")` closes the
+            # phrase and yields the term `x\`. Honouring the escape would read
+            # that as unterminated and refuse an ordinary value ending in a
+            # backslash, a Windows path among them. Nothing is given up, since a
+            # value cannot contribute a quote of its own -- `Text` replaces it,
+            # and `Tag` and `like` escape theirs outside any phrase.
+            end = rendered.find('"', position + 1)
+            if end == -1:
                 # Unterminated phrase: the remainder is unparsable.
                 escaped = True
                 break
@@ -454,14 +459,14 @@ def _reject_escapable_filter(caller: FilterExpression) -> None:
             # range holds numbers, so a `|` in here means a value reached the
             # query string raw, which is exactly the case this backstop exists
             # to catch; skipping past it would let a union hide behind brackets.
-            end = _find_unescaped(rendered, position + 1, "]")
-            if end is None:
+            span_end = _find_unescaped(rendered, position + 1, "]")
+            if span_end is None:
                 escaped = True
                 break
-            if _find_unescaped(rendered, position + 1, "|", end) is not None:
+            if _find_unescaped(rendered, position + 1, "|", span_end) is not None:
                 escaped = True
                 break
-            position = end + 1
+            position = span_end + 1
             continue
 
         if character in openers:

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -1,4 +1,6 @@
 import datetime
+import math
+import numbers
 import re
 from enum import Enum
 from functools import wraps
@@ -353,10 +355,9 @@ class Num(FilterField):
         FilterOperator.LT: "@%s:[-inf (%s]",
         FilterOperator.GE: "@%s:[%s +inf]",
         FilterOperator.LE: "@%s:[-inf %s]",
-        FilterOperator.BETWEEN: "@%s:[%s %s]",
     }
 
-    SUPPORTED_VAL_TYPES = (int, float, tuple, type(None))
+    SUPPORTED_VAL_TYPES = (int, float, type(None))
 
     def __eq__(self, other: int | float) -> "FilterExpression":
         """Create a Numeric equality filter expression.
@@ -462,8 +463,41 @@ class Num(FilterField):
                 f"Invalid inclusive value must be: {[i.value for i in Inclusive]}"
             )
 
+    @classmethod
+    def _coerce_numeric(cls, value: Any, name: str = "value") -> int | float:
+        """Return a numeric filter value as a plain int or float.
+
+        Coercion rather than the type check is the guard: every numeric value is
+        formatted into the query string, so a subclass overriding __str__ would
+        satisfy isinstance and inject syntax. int() and float() return builtins
+        regardless, which strips the override.
+        """
+        if isinstance(value, numbers.Integral):
+            return int(value)
+        if isinstance(value, numbers.Real):
+            coerced = float(value)
+            if math.isnan(coerced):
+                # Renders `@field:[nan ...]`, which RediSearch rejects outright.
+                raise ValueError(f"{cls.__name__} {name} cannot be NaN")
+            return coerced
+        raise TypeError(
+            f"{cls.__name__} {name} must be an int, a float, or another "
+            f"numbers.Real; got {type(value).__name__}"
+        )
+
+    def _set_value(
+        self,
+        val: Any,
+        val_type: type | tuple[type, ...],
+        operator: FilterOperator,
+    ):
+        """Type-check as usual, then coerce, so no operator formats a subclass."""
+        super()._set_value(val, val_type, operator)
+        if self._value is not None:
+            self._value = self._coerce_numeric(self._value)
+
     def _format_inclusive_between(
-        self, inclusive: Inclusive, start: int, end: int
+        self, inclusive: Inclusive, start: int | float, end: int | float
     ) -> str:
         if inclusive.value == Inclusive.BOTH.value:
             return f"@{self._field}:[{start} {end}]"
@@ -480,24 +514,44 @@ class Num(FilterField):
         raise ValueError(f"Inclusive value not found")
 
     def between(
-        self, start: int, end: int, inclusive: str = "both"
+        self, start: int | float, end: int | float, inclusive: str = "both"
     ) -> "FilterExpression":
-        """Operator for searching values between two numeric values."""
-        inclusive = self._validate_inclusive_string(inclusive)
-        expression = self._format_inclusive_between(inclusive, start, end)
+        """Operator for searching values between two numeric values.
 
-        return FilterExpression(expression)
+        Args:
+            start (Union[int, float]): The lower bound of the range.
+            end (Union[int, float]): The upper bound of the range.
+            inclusive (str, optional): Which bounds to include: "both",
+                "neither", "left" or "right". Defaults to "both".
+
+        Raises:
+            TypeError: If either bound is not an ``int``, a ``float``, or
+                another ``numbers.Real``. numpy scalars qualify; ``Decimal``
+                and ``str`` do not.
+            ValueError: If either bound is NaN, or if ``inclusive`` is not one
+                of the four accepted values.
+
+        .. code-block:: python
+
+            from redisvl.query.filter import Num
+
+            f = Num("age").between(18, 65)
+            f = Num("age").between(18, 65, inclusive="neither")
+
+        """
+        # between() is the one operator that never reaches _set_value.
+        checked_start = self._coerce_numeric(start, "start")
+        checked_end = self._coerce_numeric(end, "end")
+        inclusive_value = self._validate_inclusive_string(inclusive)
+
+        return FilterExpression(
+            self._format_inclusive_between(inclusive_value, checked_start, checked_end)
+        )
 
     def __str__(self) -> str:
         """Return the Redis Query string for the Numeric filter"""
         if self._value is None:
             return "*"
-        if self._operator == FilterOperator.BETWEEN:
-            return self.OPERATOR_MAP[self._operator] % (
-                self._field,
-                self._value[0],
-                self._value[1],
-            )
         if self._operator == FilterOperator.EQ or self._operator == FilterOperator.NE:
             return self.OPERATOR_MAP[self._operator] % (
                 self._field,
@@ -508,8 +562,29 @@ class Num(FilterField):
             return self.OPERATOR_MAP[self._operator] % (self._field, self._value)
 
 
+# A double quote is the only character that can terminate a quoted phrase, so it
+# is the only one that needs replacing. (A trailing backslash does not terminate
+# one either -- `@f:("x\")` parses as the term `x\`.)
+#
+# Replaced rather than escaped, because escaping is symmetric: a backslash joins
+# the separator into the term, so `@f:("say \"hi\" now")` asks for a term with a
+# quote in it, and RedisVL writes documents unescaped. On `==` that matches
+# nothing, and on `!=` the unmatchable phrase makes the negation match
+# everything. A space is what the tokenizer left at that position anyway.
+_PHRASE_UNSAFE = re.compile(r'"')
+
+
 class Text(FilterField):
-    """A Text is a FilterField representing a text field in a Redis index."""
+    """A Text is a FilterField representing a text field in a Redis index.
+
+    Note:
+        ``==`` and ``!=`` match the value as a quoted phrase. Any ``"`` in the
+        value becomes a space first, so the value cannot close that phrase; a
+        quote already separates tokens at index time, so this matches the same
+        documents that escaping it never could. A value of nothing but quotes
+        therefore selects everything, like an empty value. ``%`` is the pattern
+        operator and interpolates its value untouched.
+    """
 
     OPERATORS: dict[FilterOperator, str] = {
         FilterOperator.EQ: "==",
@@ -522,6 +597,12 @@ class Text(FilterField):
         FilterOperator.LIKE: "@%s:(%s)",
     }
     SUPPORTED_VAL_TYPES = (str, type(None))
+
+    # `%` is the pattern operator: its value is raw by design, which is what
+    # makes `*`, `%%` and `|` work. Listing the exception rather than the rule
+    # means a new operator -- or a subclass adding one -- is contained unless it
+    # opts out here.
+    _RAW_VALUE_OPERATORS = frozenset({FilterOperator.LIKE})
 
     @check_operator_misuse
     def __eq__(self, other: str) -> "FilterExpression":
@@ -578,6 +659,13 @@ class Text(FilterField):
             f = Text("job") % "engineer|doctor" # contains either term in field
             f = Text("job") % "engineer doctor" # contains both terms in field
 
+        Note:
+            The value is interpolated raw, which is what makes ``*``, ``%%`` and
+            ``|`` work. A value carrying a ``)`` therefore closes this clause and
+            has its remainder parsed as query syntax, past any surrounding
+            filter. Pass only patterns your own code composes; for a value you
+            did not construct, use ``==``, which matches it as a literal phrase.
+
         """
         self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.LIKE)
         return FilterExpression(str(self))
@@ -587,9 +675,17 @@ class Text(FilterField):
         if not self._value:
             return "*"
 
+        value = self._value
+        if self._operator not in self._RAW_VALUE_OPERATORS:
+            value = _PHRASE_UNSAFE.sub(" ", value)
+            if not value.strip():
+                # Nothing but quotes. An empty phrase matches no document, so
+                # `!=` would match every one -- report "no filter" instead.
+                return "*"
+
         return self.OPERATOR_MAP[self._operator] % (
             self._field,
-            self._value,
+            value,
         )
 
 

--- a/redisvl/query/filter.py
+++ b/redisvl/query/filter.py
@@ -582,8 +582,9 @@ class Text(FilterField):
         value becomes a space first, so the value cannot close that phrase; a
         quote already separates tokens at index time, so this matches the same
         documents that escaping it never could. A value of nothing but quotes
-        therefore selects everything, like an empty value. ``%`` is the pattern
-        operator and interpolates its value untouched.
+        therefore becomes an empty phrase, which ``==`` matches no document
+        against. ``%`` is the pattern operator and interpolates its value
+        untouched.
     """
 
     OPERATORS: dict[FilterOperator, str] = {
@@ -677,11 +678,10 @@ class Text(FilterField):
 
         value = self._value
         if self._operator not in self._RAW_VALUE_OPERATORS:
+            # Substituting a space never empties the value, so the phrase always
+            # holds at least one character and never trips the `INDEXEMPTY`
+            # error that a literal `@field:("")` raises.
             value = _PHRASE_UNSAFE.sub(" ", value)
-            if not value.strip():
-                # Nothing but quotes. An empty phrase matches no document, so
-                # `!=` would match every one -- report "no filter" instead.
-                return "*"
 
         return self.OPERATOR_MAP[self._operator] % (
             self._field,

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -451,6 +451,13 @@ def test_filters(index, query, sample_datetimes):
     t = Text("job") % "%%engine%%"
     search(query, index, t, 2)
 
+    # A quote-bearing value on `!=`, against a live index. This is the one claim
+    # no rendering assertion can make: escaping the quote instead of replacing it
+    # would ask for a term RediSearch never stored, so the negated phrase would
+    # match nothing and the exclusion would return all 7 rather than 6.
+    t = Text("description") != 'high stress,"'
+    search(query, index, t, 6)
+
     # Test empty filters
     t = Text("job") % ""
     search(query, index, t, 7)

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -3,9 +3,19 @@ import operator
 import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 
+import numpy as np
 import pytest
 
-from redisvl.query.filter import Geo, GeoRadius, Num, Tag, Text, Timestamp
+from redisvl.query.filter import (
+    FilterExpression,
+    FilterOperator,
+    Geo,
+    GeoRadius,
+    Num,
+    Tag,
+    Text,
+    Timestamp,
+)
 
 
 # Test cases for various scenarios of tag usage, combinations, and their string representations.
@@ -154,112 +164,18 @@ def test_tag_wildcard_combined_with_exact_match():
     assert "@status:{active\\*}" in str(complex_filter)  # asterisk escaped
 
 
-def test_nullable():
-    tag = Tag("tag_field") == None
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") != None
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") == []
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") != []
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") == ""
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") != ""
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") == [None]
-    assert str(tag) == "*"
-
-    tag = Tag("tag_field") == [None, "tag"]
-    assert str(tag) == "@tag_field:{tag}"
-
-
-def test_numeric_filter():
-    nf = Num("numeric_field") == 5
-    assert str(nf) == "@numeric_field:[5 5]"
-
-    nf = Num("numeric_field") != 5
-    assert str(nf) == "(-@numeric_field:[5 5])"
-
-    nf = Num("numeric_field") > 5
-    assert str(nf) == "@numeric_field:[(5 +inf]"
-
-    nf = Num("numeric_field") >= 5
-    assert str(nf) == "@numeric_field:[5 +inf]"
-
-    nf = Num("numeric_field") < 5
-    assert str(nf) == "@numeric_field:[-inf (5]"
-
-    nf = Num("numeric_field") <= 5
-    assert str(nf) == "@numeric_field:[-inf 5]"
-
-    nf = Num("numeric_field") > 5.5
-    assert str(nf) == "@numeric_field:[-inf 5.5]"
-
-    nf = Num("numeric_field") <= None
-    assert str(nf) == "*"
-
-    nf = Num("numeric_field") == None
-    assert str(nf) == "*"
-
-    nf = Num("numeric_field") != None
-    assert str(nf) == "*"
-
-    nf = Num("numeric_field").between(2, 5)
-    assert str(nf) == "@numeric_field:[2 5]"
-
-    nf = Num("numeric_field").between(2, 5, inclusive="neither")
-    assert str(nf) == "@numeric_field:[2 5]"
-
-    nf = Num("numeric_field").between(2, 5, inclusive="left")
-    assert str(nf) == "@numeric_field:[2 (5]"
-
-    nf = Num("numeric_field").between(2, 5, inclusive="right")
-    assert str(nf) == "@numeric_field:[(2 5]"
-
-
-def test_text_filter():
-    txt_f = Text("text_field") == "text"
-    assert str(txt_f) == '@text_field:("text")'
-
-    txt_f = Text("text_field") != "text"
-    assert str(txt_f) == '(-@text_field:"text")'
-
-    txt_f = Text("text_field") % "text"
-    assert str(txt_f) == "@text_field:(text)"
-
-    txt_f = Text("text_field") % "tex*"
-    assert str(txt_f) == "@text_field:(tex*)"
-
-    txt_f = Text("text_field") % "%text%"
-    assert str(txt_f) == "@text_field:(%text%)"
-
-    txt_f = Text("text_field") % ""
-    assert str(txt_f) == "*"
-
-
-def test_geo_filter():
-    geo_f = Geo("geo_field") == GeoRadius(1.0, 2.0, 3, "km")
-    assert str(geo_f) == "@geo_field:[1.0 2.0 3 km]"
-
-    geo_f = Geo("geo_field") != GeoRadius(1.0, 2.0, 3, "km")
-    assert str(geo_f) != "(-@geo_field:[1.0 2.0 3 m])"
-
-
 @pytest.mark.parametrize(
-    "value, expected",
+    "operation, value, expected",
     [
-        (None, "*"),
-        ([], "*"),
-        ("", "*"),
-        ([None], "*"),
-        ([None, "tag"], "@tag_field:{tag}"),
+        ("__eq__", None, "*"),
+        ("__eq__", [], "*"),
+        ("__eq__", "", "*"),
+        ("__eq__", [None], "*"),
+        ("__eq__", [None, "tag"], "@tag_field:{tag}"),
+        # Tag.__str__ short-circuits to "*" before consulting OPERATOR_MAP, so
+        # one falsy row covers every falsy value on the negated operator too.
+        ("__ne__", None, "*"),
+        ("__ne__", [None, "tag"], "(-@tag_field:{tag})"),
     ],
     ids=[
         "none",
@@ -267,11 +183,13 @@ def test_geo_filter():
         "empty_string",
         "list_with_none",
         "list_with_none_and_tag",
+        "ne_none",
+        "ne_list_with_none_and_tag",
     ],
 )
-def test_nullable(value, expected):
+def test_nullable(operation, value, expected):
     tag = Tag("tag_field")
-    assert str(tag == value) == expected
+    assert str(getattr(tag, operation)(value)) == expected
 
 
 @pytest.mark.parametrize(
@@ -295,6 +213,82 @@ def test_numeric_filter(operation, value, expected):
 
 
 @pytest.mark.parametrize(
+    "inclusive, expected",
+    [
+        ("both", "@numeric_field:[2 5]"),
+        ("neither", "@numeric_field:[(2 (5]"),
+        ("left", "@numeric_field:[2 (5]"),
+        ("right", "@numeric_field:[(2 5]"),
+    ],
+)
+def test_numeric_between(inclusive, expected):
+    assert str(Num("numeric_field").between(2, 5, inclusive=inclusive)) == expected
+
+
+class _StrOverridingInt(int):
+    """A numeric type that satisfies isinstance and injects when formatted."""
+
+    def __str__(self) -> str:
+        return "5] | @secret:{leaked} @numeric_field:[-inf +inf"
+
+
+class _StrOverridingFloat(float):
+    """The same, on the float branch of the coercion."""
+
+    def __str__(self) -> str:
+        return "5.5] | @secret:{leaked} @numeric_field:[-inf +inf"
+
+
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        (np.int64(5), "@numeric_field:[2 5]"),
+        (_StrOverridingInt(5), "@numeric_field:[2 5]"),
+        (_StrOverridingFloat(5.5), "@numeric_field:[2 5.5]"),
+    ],
+    ids=["numpy_scalar_is_real_but_not_int", "subclass_int_str", "subclass_float_str"],
+)
+def test_numeric_between_coerces_a_real_endpoint(endpoint, expected):
+    """The first row proves `numbers.Real` is wide enough, the rest why it is not enough.
+
+    numpy integers are not `int` subclasses, so a concrete `(int, float)` check
+    would reject them. And the type check alone lets a subclass through, since
+    the endpoint is formatted into the query string -- coercion is the guard, on
+    both the Integral and the Real branch.
+    """
+    assert str(Num("numeric_field").between(2, endpoint)) == expected
+
+
+def test_numeric_comparison_coerces_a_formattable_value():
+    """Coercion covers every operator, not only between()."""
+    assert (
+        str(Num("numeric_field") <= _StrOverridingInt(5)) == "@numeric_field:[-inf 5]"
+    )
+
+
+@pytest.mark.parametrize(
+    "call, expected_error",
+    [
+        (
+            lambda: Num("numeric_field").between(
+                4, "5] | @secret:{leaked} @r:[-inf +inf"
+            ),
+            TypeError,
+        ),
+        # `@field:[nan ...]` is a query RediSearch refuses.
+        (lambda: Num("numeric_field") == float("nan"), ValueError),
+        # `tuple` outlived the BETWEEN branch that unpacked it, and nothing ever
+        # validated the elements.
+        (lambda: Num("numeric_field") == ("5] | @secret:{leaked}", 1), TypeError),
+    ],
+    ids=["between_string_endpoint", "nan", "tuple"],
+)
+def test_numeric_refuses_an_unrenderable_value(call, expected_error):
+    with pytest.raises(expected_error):
+        call()
+
+
+@pytest.mark.parametrize(
     "operation, value, expected",
     [
         ("__eq__", "text", '@text_field:("text")'),
@@ -308,6 +302,39 @@ def test_numeric_filter(operation, value, expected):
         ("__mod__", "%text%", "@text_field:(%text%)"),
         ("__mod__", "", "*"),
         ("__mod__", None, "*"),
+        # The quote is the only character that can terminate a quoted value, so
+        # it goes and everything it carried stays inside the phrase.
+        (
+            "__eq__",
+            'hello") | (@secret:{leaked} @v:"nothing',
+            '@text_field:("hello ) | (@secret:{leaked} @v: nothing")',
+        ),
+        (
+            "__ne__",
+            'hello") | (@secret:{leaked} @v:"nothing',
+            '(-@text_field:"hello ) | (@secret:{leaked} @v: nothing")',
+        ),
+        # A value of nothing but quotes leaves an empty phrase, which matches no
+        # document -- so `!=` would match every one. Report "no filter" instead.
+        ("__eq__", '"', "*"),
+        ("__ne__", '""', "*"),
+        # Everything else survives untouched, the backslash included: escaping is
+        # symmetric, so a document written with one indexes the joined term and
+        # only an equally escaped query finds it. Replacing any of these would ask
+        # for a term no document stored -- a silent zero-hit failure. These rows
+        # fail if a single extra character joins the pattern.
+        ("__eq__", "trailing\\", '@text_field:("trailing\\")'),
+        (
+            "__eq__",
+            "e-mail, 50% off (C++) @ user@x.com O'Brien 3.5",
+            '@text_field:("e-mail, 50% off (C++) @ user@x.com O\'Brien 3.5")',
+        ),
+        # `%` is the raw pattern operator by design, so its value is untouched.
+        (
+            "__mod__",
+            'hello") | (@secret:{leaked}',
+            '@text_field:(hello") | (@secret:{leaked})',
+        ),
     ],
     ids=[
         "eq",
@@ -321,11 +348,41 @@ def test_numeric_filter(operation, value, expected):
         "like_full",
         "like_empty",
         "like_none",
+        "eq_quote_neutralized",
+        "ne_quote_neutralized",
+        "eq_quotes_only",
+        "ne_quotes_only",
+        "eq_backslash_untouched",
+        "eq_punctuation_preserved",
+        "like_raw_by_design",
     ],
 )
 def test_text_filter(operation, value, expected):
     txt_f = getattr(Text("text_field"), operation)(value)
     assert str(txt_f) == expected
+
+
+def test_text_subclass_inherits_containment_for_a_new_quoted_operator():
+    """Listing only the raw operator means a new one is contained by default.
+
+    A subclass adding a quoted template is the case a set of *quoted* operators
+    would miss, because it would be computed from the base class's own map.
+    """
+
+    class Phrase(Text):
+        OPERATOR_MAP = {
+            **Text.OPERATOR_MAP,
+            FilterOperator.IN: '@%s:("%s")=>{$slop: 2}',
+        }
+        OPERATORS = {**Text.OPERATORS, FilterOperator.IN: "within"}
+
+        def within(self, other):
+            self._set_value(other, self.SUPPORTED_VAL_TYPES, FilterOperator.IN)
+            return FilterExpression(str(self))
+
+    rendered = str(Phrase("t").within('a") | (@secret:{leaked}'))
+
+    assert rendered == '@t:("a ) | (@secret:{leaked}")=>{$slop: 2}'
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -314,10 +314,14 @@ def test_numeric_refuses_an_unrenderable_value(call, expected_error):
             'hello") | (@secret:{leaked} @v:"nothing',
             '(-@text_field:"hello ) | (@secret:{leaked} @v: nothing")',
         ),
-        # A value of nothing but quotes leaves an empty phrase, which matches no
-        # document -- so `!=` would match every one. Report "no filter" instead.
-        ("__eq__", '"', "*"),
-        ("__ne__", '""', "*"),
+        # A value that neutralizes down to whitespace still renders as a phrase
+        # rather than collapsing to `*`. An empty phrase matches no document, so
+        # `==` fails closed; collapsing would invert that to matching every one,
+        # and `format_expression` drops a `*` operand, so it would also delete
+        # this clause from a surrounding AND.
+        ("__eq__", '"', '@text_field:(" ")'),
+        ("__ne__", '""', '(-@text_field:"  ")'),
+        ("__eq__", "   ", '@text_field:("   ")'),
         # Everything else survives untouched, the backslash included: escaping is
         # symmetric, so a document written with one indexes the joined term and
         # only an equally escaped query finds it. Replacing any of these would ask
@@ -352,6 +356,7 @@ def test_numeric_refuses_an_unrenderable_value(call, expected_error):
         "ne_quote_neutralized",
         "eq_quotes_only",
         "ne_quotes_only",
+        "eq_whitespace_only",
         "eq_backslash_untouched",
         "eq_punctuation_preserved",
         "like_raw_by_design",

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -338,6 +338,13 @@ def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
             "unbalanced bracket in a value",
             {"field": "content", "op": "eq", "value": "a[b"},
         ),
+        # Reported by review: a value ending in a backslash sits immediately
+        # before the template's closing quote, and an escape-honouring phrase
+        # scan reads the pair as one and refuses the filter.
+        (
+            "value ending in a backslash",
+            {"field": "content", "op": "eq", "value": "C:\\Users\\"},
+        ),
         (
             "compound with exclusive bound",
             {
@@ -401,11 +408,12 @@ def test_merge_locked_filter_returns_each_side_unchanged_when_the_other_is_absen
         # end. Unbounded it reads this as a union hidden in the range and
         # refuses, and it costs the whole remaining string on every `[`.
         ("pipe after a range span", "(@rating:[4 5] | @category:{sports})"),
-        # The phrase skip must honour `\\"`. No DSL path emits this today -- eq/ne
-        # replace a quote, and `like`/`Tag` escape one outside any phrase -- so it
-        # comes in as a rendering. An escape-blind scan ends the phrase at the
-        # escaped quote and refuses every quote-bearing value on a locked tool.
-        ("escaped quote inside a phrase", '@content:("say \\"hi\\" now")'),
+        # RediSearch closes a phrase at `\"` rather than reading it as an escape,
+        # so the phrase scan must not honour the escape either. Honouring it
+        # reads these as unterminated and refuses an ordinary value ending in a
+        # backslash. Both templates, since each renders its own quote.
+        ("trailing backslash on eq", '@content:("trailing\\")'),
+        ("trailing backslash on ne", '(-@content:"C:\\Users\\")'),
     ],
 )
 def test_merge_locked_filter_accepts_a_legitimate_rendering(label, rendered):

--- a/tests/unit/test_mcp/test_filters.py
+++ b/tests/unit/test_mcp/test_filters.py
@@ -123,33 +123,6 @@ def test_parse_filter_rejects_malformed_payload():
 
 
 @pytest.mark.parametrize(
-    ("op", "operand"),
-    [
-        ("eq", 'alpha") | (-@category:{secret}'),
-        ("ne", 'alpha") | (-@category:{secret}'),
-        ("like", "alpha) | (-@category:{secret}"),
-        ("in", ['alpha") | (-@category:{secret}']),
-    ],
-)
-def test_parse_filter_escapes_text_values_so_they_cannot_leave_their_clause(
-    op, operand
-):
-    parsed = parse_filter({"field": "content", "op": op, "value": operand}, _schema())
-
-    # Text operator templates interpolate the value into `@field:("...")` or
-    # `@field:(...)`, so an unescaped quote or paren would close the clause and
-    # let the rest of the value inject query syntax -- including a `|` that
-    # escapes an enclosing AND. Stripping escape pairs leaves the structural
-    # skeleton: the payload must contribute no syntax to it.
-    skeleton = _strip_escapes(_render_filter(parsed))
-    # The clause boundary survives: quotes and parens from the payload are
-    # escaped, so its `|` stays scoped inside this field's own query instead of
-    # splitting the whole expression into a union.
-    assert skeleton.count("(") == skeleton.count(")")
-    assert skeleton.count('"') % 2 == 0
-
-
-@pytest.mark.parametrize(
     ("value", "rendered"),
     [
         # Each metacharacter that gives a `like` pattern its meaning. Escaping any
@@ -167,6 +140,20 @@ def test_parse_filter_preserves_like_pattern_metacharacters(value, rendered):
     parsed = parse_filter({"field": "content", "op": "like", "value": value}, _schema())
 
     assert _render_filter(parsed) == rendered
+
+
+def test_parse_filter_does_not_double_handle_text_eq_values():
+    """`Text` neutralizes eq/ne itself, so this boundary must not treat them again.
+
+    The boundary escaper this replaced escaped the space as well, so an ordinary
+    multi-word value rendered as a literal that matched nothing.
+    """
+    parsed = parse_filter(
+        {"field": "content", "op": "eq", "value": "senior engineer (50% off)"},
+        _schema(),
+    )
+
+    assert _render_filter(parsed) == '@content:("senior engineer (50% off)")'
 
 
 def test_parse_filter_like_matches_library_semantics_for_patterns():
@@ -303,6 +290,16 @@ def test_merge_locked_filter_ands_a_multi_value_tag_in_caller_filter():
         # as a group. Skipping the span wholesale would also skip a `|` inside it,
         # letting a union hide behind brackets.
         ("pipe hidden inside a range span", "@rating:[4 | @category:{secret}]"),
+        # A quoted phrase is skipped wholesale, so the skip has to resynchronize
+        # on the payload's own quote and still catch what follows. Both of these
+        # are what a raw quote reaching the rendering would actually look like.
+        (
+            "balanced raw quote then pipe",
+            '@content:("hello") | (-@category:{secret} @content:"x")',
+        ),
+        # Balanced parens, so only the phrase branch can refuse this: skipping to
+        # end-of-string instead would swallow the injected union.
+        ("unterminated phrase", '@content:"unterminated | @category:{secret}'),
     ],
 )
 def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
@@ -313,10 +310,10 @@ def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
         {"field": "category", "op": "eq", "value": "science"}, _schema()
     )
 
-    # Simulates a field type that renders a value unescaped. Text values are
-    # escaped today, so this path is unreachable through the DSL -- which is
-    # exactly why it needs an explicit test: without one, deleting the guard
-    # leaves the whole suite green.
+    # Simulates a field type that renders a value unescaped. No DSL path produces
+    # these shapes today -- values are neutralized, escaped or type-checked --
+    # which is exactly why this needs an explicit test: without one, deleting the
+    # guard leaves the whole suite green.
     with pytest.raises(RedisVLMCPError) as exc_info:
         merge_locked_filter(locked, FilterExpression(rendered))
 
@@ -332,6 +329,14 @@ def test_merge_locked_filter_refuses_a_caller_rendering_that_could_escape(
         (
             "windows path",
             {"field": "content", "op": "like", "value": "C:\\\\Users\\\\"},
+        ),
+        # Text eq/ne leave brackets and parens raw, so the backstop has to know a
+        # quoted phrase is literal rather than counting its delimiters. Brackets
+        # are the case the range-span skip would otherwise mishandle, and parens
+        # only survive today when they happen to balance.
+        (
+            "unbalanced bracket in a value",
+            {"field": "content", "op": "eq", "value": "a[b"},
         ),
         (
             "compound with exclusive bound",
@@ -392,10 +397,19 @@ def test_merge_locked_filter_returns_each_side_unchanged_when_the_other_is_absen
         ("exclusive lower bound", "@rating:[(5 +inf]"),
         ("exclusive upper bound", "@rating:[-inf (5]"),
         ("plain inclusive range", "@rating:[4 +inf]"),
+        # The pipe lies beyond the `]`, so the range scan must stop at the span
+        # end. Unbounded it reads this as a union hidden in the range and
+        # refuses, and it costs the whole remaining string on every `[`.
+        ("pipe after a range span", "(@rating:[4 5] | @category:{sports})"),
+        # The phrase skip must honour `\\"`. No DSL path emits this today -- eq/ne
+        # replace a quote, and `like`/`Tag` escape one outside any phrase -- so it
+        # comes in as a rendering. An escape-blind scan ends the phrase at the
+        # escaped quote and refuses every quote-bearing value on a locked tool.
+        ("escaped quote inside a phrase", '@content:("say \\"hi\\" now")'),
     ],
 )
-def test_merge_locked_filter_still_accepts_legitimate_range_bounds(label, rendered):
-    """Narrowing the range skip to parens must not start rejecting real ranges."""
+def test_merge_locked_filter_accepts_a_legitimate_rendering(label, rendered):
+    """Narrowing the skips must not start rejecting renderings the DSL can emit."""
     del label
     locked = parse_filter(
         {"field": "category", "op": "eq", "value": "science"}, _schema()
@@ -403,5 +417,4 @@ def test_merge_locked_filter_still_accepts_legitimate_range_bounds(label, render
 
     merged = merge_locked_filter(locked, FilterExpression(rendered))
 
-    assert isinstance(merged, FilterExpression)
-    assert "@category:{science}" in str(merged)
+    assert str(merged) == f"(@category:{{science}} {rendered})"


### PR DESCRIPTION
## Motivation

A filter value could terminate the clause it was rendered into and append arbitrary RediSearch syntax. `Text.__str__` interpolated the caller's value straight into its operator templates, so a value carrying a `"` closed the quoted phrase early; under DIALECT 2 an injected `|` binds looser than the implicit space-AND, so it lifts to the root of the parse tree and any surrounding filter stops constraining the query. Measured on Redis 8.4.5 against an index holding two tenants, `str((Tag("tenant") == "acme") & (Text("v") == crafted))` returned the other tenant's document and `FT.EXPLAINCLI` reported a top-level `UNION`. `Num` had the same class of defect by a different route: `_set_value` type-checked without coercing, so a numeric subclass overriding `__str__` satisfied the check and injected when formatted, and `between` never reached that check at all.

The library is the exposed surface. The MCP server escaped text at its own boundary and was never affected, but any caller building a filter from untrusted input was.

## Changes

### Text equality replaces the quote rather than escaping it

Escaping does not work here, and the reason decides the whole design. RediSearch tokenization is symmetric: punctuation separates tokens on both sides of the wire, and a backslash joins the separator into the term. Since RedisVL writes documents unescaped, `@f:("say \"hi\" now")` asks for a term containing a quote that no document ever stored. On `==` that matches nothing. On `!=` the unmatchable phrase makes the negation match everything, so an exclusion filter silently stops excluding, which is strictly worse than the injection it would have prevented.

Equality and inequality therefore replace `"` with a space, which is what the tokenizer left at that position anyway. A value of nothing but quotes renders `*`, for the same reason. Only the quote is replaced: a trailing backslash does not terminate a phrase either, since `@f:("x\")` parses as the term `x\`, and replacing it would break matching against documents that were written escaped.

```python
crafted = 'hello") | (@secret:{leaked} @v:"nothing'
str((Tag("tenant") == "acme") & (Text("v") == crafted))
# before: (@tenant:{acme} @v:("hello") | (@secret:{leaked} @v:"nothing"))   root UNION, leaks
# after:  (@tenant:{acme} @v:("hello ) | (@secret:{leaked} @v: nothing"))   root INTERSECT, 0 hits
```

`%` continues to interpolate its value raw, which is what makes `*`, `%%` and `|` work, and its docstring now says so and points a caller holding untrusted input at `==`. `Text` lists that one raw operator rather than deriving the quoted ones from the templates, so a new operator is contained unless it opts out. That covers one added by a subclass, which a set of quoted operators computed in the base class body would miss.

### Numeric values are coerced, not merely type-checked

All seven `Num` operators now pass their value through `_coerce_numeric` after the type check. Coercion is the guard rather than the check: every numeric value is formatted into the query string, so `int()` and `float()` returning builtins is what strips a subclass's `__str__` override. `numbers.Real` keeps numpy scalars working, which a concrete `(int, float)` check would have rejected. NaN is refused, since `@field:[nan ...]` is a query RediSearch rejects outright.

```python
class Hostile(float):
    def __str__(self): return "5] | (@secret:{leaked}) @r:[-inf +inf"

str(Num("r") <= Hostile(5))
# before: @r:[-inf 5] | (@secret:{leaked}) @r:[-inf +inf]
# after:  @r:[-inf 5]
```

The unreachable `BETWEEN` entry in `OPERATOR_MAP`, its branch in `Num.__str__`, and the `tuple` in `SUPPORTED_VAL_TYPES` that only that branch consumed are deleted. Nothing assigned `FilterOperator.BETWEEN` to an instance, which is why `between` looked like it was bypassing machinery that worked.

### The MCP locked-filter backstop learns about quoted phrases

`_reject_escapable_filter` counted bracket depth without knowing quotes exist. That was safe only while the filter boundary escaped every parenthesis and brace in a text value; without it the guard refused ordinary values such as `smiley :)` and `a[b`. It now skips a quoted phrase wholesale, because inside quotes a parenthesis is literal text and a `|` is a separator rather than a union. Ending the skip at the first *unescaped* quote is what keeps it failing closed: a value that did reach the rendering raw ends the phrase there, and the injected remainder is counted as before.

Two near-identical scanners collapse into `_find_unescaped`, which takes a bound. Without one the range branch pays for the whole remaining string on every `[`, which made the walk quadratic in the number of spans. Measured at 14 seconds of blocking CPU on a 1 MB rendering, that is enough to stall the server's event loop for every concurrent request.

### The MCP text boundary stops escaping eq, ne and in

Required rather than cleanup: with `Text` also handling the value it would be treated twice and mangled. This also fixes a live defect, because the boundary escaper escaped the space and so rendered any multi-word value as a literal that matched nothing.

```python
# {"field": "job", "op": "eq", "value": "senior engineer"}
# before: @job:("senior\ engineer")   matches nothing
# after:  @job:("senior engineer")
```

`like` keeps its boundary escaping, since the library leaves `%` raw.

- `docs/concepts/mcp.md` no longer attributes text escaping to the filter boundary, and no longer names a parenthesis as able to close a clause.
- The filtering user guide states that `==` and `!=` match a literal phrase while `%` takes a raw pattern.

### Tests

Four test functions in `tests/unit/test_filter.py` were defined twice, so the earlier definition of each never collected. `Num.between` with its `inclusive=` variants and `Tag != <falsy>` had coverage only there and are ported forward; two of the dead assertions were simply wrong, which is independent evidence they had never run.

Because the existing suite passed identically with the fix applied and reverted, each guard is mutation-checked by reverting it alone. Fourteen mutations are each caught by a named test. The integration suite gains one row asserting that a quote-bearing value on `!=` excludes its document, which is the one claim no rendering assertion can make: escaping the quote instead returns the whole corpus.

## Notes

Two behaviour changes reach existing callers. A `Text` `==` or `!=` value containing a `"` now renders differently, and a value of only quotes selects everything instead of producing a malformed query. `Num.between` now raises `TypeError` on a `str` or `Decimal` endpoint, both of which rendered successfully before, since neither is a `numbers.Real`; the `Raises` docstring names them explicitly. No working caller regresses on any other input.

The one change that widens a result set is the MCP boundary fix, and it stays inside the lock: a structured text `eq`, `ne` or `in` filter whose value contains a space went from matching nothing to matching correctly. Operators running a profile with a locked multi-word text filter should expect that scope to start applying.

`Timestamp.between` overrides `Num.between` and calls the formatter directly, so it does not inherit the endpoint coercion. It is not injectable, because `_convert_to_timestamp` raises on a non-ISO string, but `between(None, None)` renders `@ts:[None None]` and NaN renders `@ts:[nan ...]`, both server-side syntax errors. Deliberately out of scope and filed separately.

Tag value handling is deliberately untouched here; #717 addressed that separately and has merged, so this branch now sits on top of it. `Geo` has the same missing-validation shape as `Num` did, since `GeoSpec.__init__` validates only `unit` and leaves the coordinates to reach `Geo.__str__` unchecked. Tracked in #723 rather than folded in.

Three changes to the filter layer are in flight together: this one, #717 for tag values, and #720 for filter clauses in vector query strings. All three are independent, all target `main`, and none needs to merge before another on functional grounds. #717 merges cleanly against both of the others. This branch and #720 both touch `redisvl/query/filter.py` and `tests/unit/test_filter.py`, in different regions. `git merge-tree` reports a single conflict, in the `tests/unit/test_filter.py` import block, which both changes rewrote; whichever merges second resolves it in one hunk. The two fixes are complementary and neither substitutes for the other: #720 stops a legitimately built union binding across an intersection at assembly time, and verified against a live server, its parenthesisation does not contain the injection this change fixes: as a KNN pre-filter the crafted value still explains as a root `UNION`.

## Next Steps

1. Merge in the order #717, this PR, #720, so the smallest change lands first and the one conflict is resolved once. Any order works; only the conflict below is order-sensitive.
2. Resolve the `tests/unit/test_filter.py` import conflict against #720, whichever of the two lands second.
3. File the deferred defects as issues: `Timestamp.between` endpoint validation, and `TokenEscaper.escaped_chars_no_wildcard_re` compiling from the class constant and so ignoring an injected pattern.
4. Confirm on a live index that structured MCP text filters with multi-word values now return results, for any deployed profile that locks one.

## Release Notes

Query filter values are now contained in the clause they render into. A value containing a double quote could previously close its own clause and have the remainder parsed as RediSearch syntax, so a filter built from untrusted input could be widened past the scope it was meant to enforce. Upgrade if any filter value in your application originates from user input.

One backwards-incompatible change comes with it. `Num(field).between(start, end)` now raises `TypeError` unless both bounds are real numbers. A `str` or `Decimal` bound rendered successfully before and now fails, so a caller passing a numeric string from a request body, or a `Decimal` from a database column, has to coerce it first. `int`, `float` and numpy scalars are unaffected.

One fix moves result counts rather than breaking anything. `Text(field) != value` with a quote-bearing value previously matched every document, so the filter excluded nothing at all; it now excludes correctly.

For the MCP server, structured text filters carrying a multi-word value were escaped in a way that matched nothing. `eq`, `ne` and `in` now work as intended, and `like` is unchanged.

`Text(field) % pattern` is deliberately unchanged and still interpolates its value raw, so do not pass untrusted input to it.