### PR TITLE
fix(tests): isolate the LangCache integration suite from its shared cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,13 @@ uv run pytest --cov=redisvl --cov-report=html
 
 **Note:** Tests requiring external APIs need appropriate API keys set as environment variables.
 
+Where such an API is a *shared, stateful* service -- one managed instance reached by
+every xdist worker and every concurrent CI run -- tests must namespace everything
+they write and must never issue a whole-service flush, which would delete data
+belonging to other workers and other pull requests' CI runs. See the module
+docstring in `tests/integration/test_langcache_semantic_cache_integration.py` for a
+worked example.
+
 ## Documentation
 
 Documentation is served from the `docs/` directory and built using Sphinx.

--- a/tests/integration/test_langcache_semantic_cache_integration.py
+++ b/tests/integration/test_langcache_semantic_cache_integration.py
@@ -4,6 +4,33 @@ These tests exercise the real LangCache API using two configured caches:
 - One with attributes configured
 - One without attributes configured
 
+Both caches are shared, and by more writers than is obvious: pytest-xdist
+spreads this suite across workers within a run (``make test-all`` uses
+``-n auto``), and every CI run reaching the same ``cache_id`` from repo secrets
+-- pull requests via ``.github/workflows/test.yml``, forks via
+``test-fork-pr.yml``, pushes to main, and the nightly cron -- runs it again
+concurrently. So the rules here are:
+
+- No test may flush a whole cache. ``delete()``/``clear()``/``adelete()``/
+  ``aclear()`` wipe every entry, including ones another worker or another PR's
+  job stored moments earlier. This is a constraint, not a preference: there is
+  no safe way to test a global flush against a cache we do not exclusively own,
+  so the flush wrappers are covered against a mocked SDK in
+  tests/unit/test_langcache_semantic_cache.py, and the flush HTTP path itself
+  is deliberately left untested.
+- Every test that writes tags its prompts, responses, and attribute values with
+  a unique ``scope`` token, so no test can observe or delete another's entries.
+- Assert that your own scoped entry is (or is no longer) among the hits -- never
+  on ``hits[0]`` and never on ``hits`` being empty. LangCache returns one result
+  by default and prompts here differ only by the scope token, so a concurrent
+  run's semantically identical prompt is a legitimate candidate for that slot.
+  Where a test's subject is not retrieval itself, filter on a scoped attribute
+  so the service can only return your own entries.
+- Write every entry with a TTL, so the shared caches self-clean without anyone
+  flushing them. Note that a TTL set on the constructor is silently ignored by
+  ``store()``, so it has to be passed per call -- do not hoist it into the
+  fixtures until that is fixed.
+
 Env vars (loaded from .env locally, injected via CI):
 - LANGCACHE_WITH_ATTRIBUTES_API_KEY
 - LANGCACHE_WITH_ATTRIBUTES_CACHE_ID
@@ -13,7 +40,10 @@ Env vars (loaded from .env locally, injected via CI):
 - LANGCACHE_NO_ATTRIBUTES_URL
 """
 
+import asyncio
 import os
+import time
+import uuid
 
 import pytest
 from dotenv import load_dotenv
@@ -34,6 +64,11 @@ REQUIRED_NO_ATTRS_VARS = (
     "LANGCACHE_NO_ATTRIBUTES_URL",
 )
 
+# TTL for entries whose own lifetime is not under test, so the shared caches
+# drain on their own. Comfortably outlasts the slowest test that reads back what
+# it wrote, while keeping concurrent runs' leftovers short-lived.
+TEST_ENTRY_TTL = 60
+
 
 def _require_env_vars(var_names: tuple[str, ...]) -> dict[str, str]:
     missing = [name for name in var_names if not os.getenv(name)]
@@ -44,6 +79,28 @@ def _require_env_vars(var_names: tuple[str, ...]) -> dict[str, str]:
         )
 
     return {name: os.environ[name] for name in var_names}
+
+
+@pytest.fixture
+def scope() -> str:
+    """Token unique to each test invocation; see the module docstring for why."""
+
+    return uuid.uuid4().hex[:12]
+
+
+@pytest.fixture(autouse=True)
+def _ban_whole_cache_flush(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the no-flush rule mechanical rather than a convention."""
+
+    for method in ("delete", "adelete", "clear", "aclear"):
+        monkeypatch.setattr(
+            LangCacheSemanticCache,
+            method,
+            lambda *args, **kwargs: pytest.fail(
+                "Whole-cache flush is banned in this suite -- it wipes other "
+                "workers' and other CI runs' entries. See the module docstring."
+            ),
+        )
 
 
 @pytest.fixture
@@ -77,162 +134,159 @@ def langcache_no_attrs() -> LangCacheSemanticCache:
 @pytest.mark.requires_api_keys
 class TestLangCacheSemanticCacheIntegrationWithAttributes:
     def test_store_and_check_sync(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "What is Redis?"
-        response = "Redis is an in-memory data store."
+        prompt = f"What is Redis? [{scope}]"
+        response = f"Redis is an in-memory data store. [{scope}]"
 
-        entry_id = langcache_with_attrs.store(prompt=prompt, response=response)
+        entry_id = langcache_with_attrs.store(
+            prompt=prompt, response=response, ttl=TEST_ENTRY_TTL
+        )
         assert entry_id
 
-        hits = langcache_with_attrs.check(prompt=prompt, num_results=1)
-        assert hits
-        assert hits[0]["response"] == response
-        assert hits[0]["prompt"] == prompt
+        # Deliberately unfiltered: exact retrieval of a just-stored prompt is
+        # what this test is for, and the scoped prompt is what makes the exact
+        # strategy (tried before semantic) able to single it out.
+        hits = langcache_with_attrs.check(prompt=prompt)
+        assert any(
+            hit["prompt"] == prompt and hit["response"] == response for hit in hits
+        ), f"scoped entry not returned; got {hits}"
 
     def test_store_with_per_entry_ttl_expires(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
         """Per-entry TTL should cause individual entries to expire."""
 
-        prompt = "Per-entry TTL test"
-        response = "This entry should expire quickly."
+        prompt = f"Per-entry TTL test [{scope}]"
+        response = f"This entry should expire quickly. [{scope}]"
+        # Filtering on a scoped attribute makes the result set provably this
+        # test's own, so neither assertion depends on how the service ranks a
+        # concurrent run's near-identical prompt.
+        metadata = {"user_id": f"tenant_ttl_{scope}"}
 
+        # The TTL has to outlast a store round trip plus a search round trip
+        # against a shared managed service, or the entry can expire before the
+        # pre-expiry assertion runs.
         entry_id = langcache_with_attrs.store(
             prompt=prompt,
             response=response,
-            ttl=2,
+            metadata=metadata,
+            ttl=5,
         )
         assert entry_id
 
         # Immediately after storing, the entry should be retrievable.
-        hits = langcache_with_attrs.check(prompt=prompt, num_results=5)
-        assert any(hit["response"] == response for hit in hits)
+        hits = langcache_with_attrs.check(prompt=prompt, attributes=metadata)
+        assert any(
+            hit["response"] == response for hit in hits
+        ), f"entry not retrievable before its TTL elapsed; got {hits}"
 
         # Wait for TTL to elapse and confirm the entry is no longer returned.
-        import time
+        time.sleep(6)
 
-        time.sleep(3)
-
-        hits_after_ttl = langcache_with_attrs.check(prompt=prompt, num_results=5)
+        hits_after_ttl = langcache_with_attrs.check(
+            prompt=prompt, attributes=metadata, num_results=5
+        )
         assert not any(hit["response"] == response for hit in hits_after_ttl)
 
     @pytest.mark.asyncio
     async def test_store_and_check_async(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "What is Redis async?"
-        response = "Redis is an in-memory data store (async)."
+        prompt = f"What is Redis async? [{scope}]"
+        response = f"Redis is an in-memory data store (async). [{scope}]"
 
-        entry_id = await langcache_with_attrs.astore(prompt=prompt, response=response)
+        entry_id = await langcache_with_attrs.astore(
+            prompt=prompt, response=response, ttl=TEST_ENTRY_TTL
+        )
         assert entry_id
 
-        hits = await langcache_with_attrs.acheck(prompt=prompt, num_results=1)
-        assert hits
-        assert hits[0]["response"] == response
-        assert hits[0]["prompt"] == prompt
+        hits = await langcache_with_attrs.acheck(prompt=prompt)
+        assert any(
+            hit["prompt"] == prompt and hit["response"] == response for hit in hits
+        ), f"scoped entry not returned; got {hits}"
 
     @pytest.mark.asyncio
     async def test_astore_with_per_entry_ttl_expires(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
         """Async per-entry TTL should cause individual entries to expire."""
 
-        prompt = "Async per-entry TTL test"
-        response = "This async entry should expire quickly."
+        prompt = f"Async per-entry TTL test [{scope}]"
+        response = f"This async entry should expire quickly. [{scope}]"
+        metadata = {"user_id": f"tenant_ttl_async_{scope}"}
 
         entry_id = await langcache_with_attrs.astore(
             prompt=prompt,
             response=response,
-            ttl=2,
+            metadata=metadata,
+            ttl=5,
         )
         assert entry_id
 
-        hits = await langcache_with_attrs.acheck(prompt=prompt, num_results=5)
-        assert any(hit["response"] == response for hit in hits)
+        hits = await langcache_with_attrs.acheck(prompt=prompt, attributes=metadata)
+        assert any(
+            hit["response"] == response for hit in hits
+        ), f"entry not retrievable before its TTL elapsed; got {hits}"
 
-        import asyncio
-
-        await asyncio.sleep(3)
+        await asyncio.sleep(6)
 
         hits_after_ttl = await langcache_with_attrs.acheck(
             prompt=prompt,
+            attributes=metadata,
             num_results=5,
         )
         assert not any(hit["response"] == response for hit in hits_after_ttl)
 
     def test_store_with_metadata_and_check_with_attributes(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "Explain Redis search."
-        response = "Redis provides full-text search via Redis Search."
+        prompt = f"Explain Redis search. [{scope}]"
+        response = f"Redis provides full-text search via Redis Search. [{scope}]"
         # Use attribute names that are actually configured on this cache.
-        metadata = {"user_id": "tenant_a"}
+        metadata = {"user_id": f"tenant_a_{scope}"}
 
         entry_id = langcache_with_attrs.store(
             prompt=prompt,
             response=response,
             metadata=metadata,
+            ttl=TEST_ENTRY_TTL,
         )
         assert entry_id
 
         hits = langcache_with_attrs.check(
             prompt=prompt,
-            attributes={"user_id": "tenant_a"},
+            attributes=metadata,
             num_results=3,
         )
-        assert hits
-        assert any(hit["response"] == response for hit in hits)
-
-    def test_delete_and_clear_alias(
-        self, langcache_with_attrs: LangCacheSemanticCache
-    ) -> None:
-        """delete() and clear() should flush the whole cache."""
-
-        prompt = "Delete me"
-        response = "You won't see me again."
-
-        langcache_with_attrs.store(prompt=prompt, response=response)
-        hits_before = langcache_with_attrs.check(prompt=prompt, num_results=5)
-        assert hits_before
-
-        # delete() and clear() both flush the whole cache
-        langcache_with_attrs.delete()
-        hits_after_delete = langcache_with_attrs.check(prompt=prompt, num_results=5)
-
-        # It is possible for other tests or data to exist; we only assert that
-        # the original response is no longer present if any hits are returned.
-        assert not any(hit["response"] == response for hit in hits_after_delete)
-
-        langcache_with_attrs.store(prompt=prompt, response=response)
-        langcache_with_attrs.clear()
-        hits_after_clear = langcache_with_attrs.check(prompt=prompt, num_results=5)
-        assert not any(hit["response"] == response for hit in hits_after_clear)
+        assert any(
+            hit["response"] == response for hit in hits
+        ), f"attribute-filtered read did not return the scoped entry; got {hits}"
 
     def test_delete_by_id_and_by_attributes(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "Delete by id"
-        response = "Entry to delete by id."
-        metadata = {"user_id": "tenant_delete"}
+        prompt = f"Delete by id [{scope}]"
+        response = f"Entry to delete by id. [{scope}]"
+        metadata = {"user_id": f"tenant_delete_{scope}"}
 
         entry_id = langcache_with_attrs.store(
             prompt=prompt,
             response=response,
             metadata=metadata,
+            ttl=TEST_ENTRY_TTL,
         )
         assert entry_id
 
         hits = langcache_with_attrs.check(
-            prompt=prompt, attributes=metadata, num_results=1
+            prompt=prompt, attributes=metadata, num_results=5
         )
-        assert hits
-        assert hits[0]["entry_id"] == entry_id
+        assert any(hit["entry_id"] == entry_id for hit in hits)
 
         # delete by id
         langcache_with_attrs.delete_by_id(entry_id)
         hits_after_id_delete = langcache_with_attrs.check(
-            prompt=prompt, attributes=metadata, num_results=3
+            prompt=prompt, attributes=metadata, num_results=5
         )
         assert not any(hit["entry_id"] == entry_id for hit in hits_after_id_delete)
 
@@ -242,24 +296,28 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
                 prompt=f"{prompt} {i}",
                 response=f"{response} {i}",
                 metadata=metadata,
+                ttl=TEST_ENTRY_TTL,
             )
 
         delete_result = langcache_with_attrs.delete_by_attributes(attributes=metadata)
         assert isinstance(delete_result, dict)
-        assert delete_result.get("deleted_entries_count", 0) >= 1
+        # The attribute value is scope-unique, so all three stored entries must
+        # be deleted -- not merely one of them.
+        assert delete_result.get("deleted_entries_count", 0) >= 3
 
     @pytest.mark.asyncio
     async def test_async_delete_variants(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "Async delete by attributes"
-        response = "Async delete candidate"
-        metadata = {"user_id": "tenant_async"}
+        prompt = f"Async delete by attributes [{scope}]"
+        response = f"Async delete candidate [{scope}]"
+        metadata = {"user_id": f"tenant_async_{scope}"}
 
         entry_id = await langcache_with_attrs.astore(
             prompt=prompt,
             response=response,
             metadata=metadata,
+            ttl=TEST_ENTRY_TTL,
         )
         assert entry_id
 
@@ -277,34 +335,29 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
                 prompt=f"{prompt} {i}",
                 response=f"{response} {i}",
                 metadata=metadata,
+                ttl=TEST_ENTRY_TTL,
             )
 
         delete_result = await langcache_with_attrs.adelete_by_attributes(
             attributes=metadata
         )
         assert isinstance(delete_result, dict)
-        assert delete_result.get("deleted_entries_count", 0) >= 1
-
-        # Finally, aclear() should flush the cache.
-        await langcache_with_attrs.aclear()
-        hits_after_clear = await langcache_with_attrs.acheck(
-            prompt=prompt, num_results=5
-        )
-        assert not any(hit["response"] == response for hit in hits_after_clear)
+        assert delete_result.get("deleted_entries_count", 0) >= 2
 
     def test_attribute_value_with_comma_and_slash_is_encoded_for_llm_string(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
         """llm_string attribute values with commas/slashes are client-encoded."""
 
-        prompt = "Attribute encoding for llm_string"
-        response = "Response for encoded llm_string."
+        prompt = f"Attribute encoding for llm_string [{scope}]"
+        response = f"Response for encoded llm_string. [{scope}]"
 
-        raw_llm_string = "tenant,with/slash"
+        raw_llm_string = f"tenant,with/slash_{scope}"
         entry_id = langcache_with_attrs.store(
             prompt=prompt,
             response=response,
             metadata={"llm_string": raw_llm_string},
+            ttl=TEST_ENTRY_TTL,
         )
         assert entry_id
 
@@ -315,16 +368,17 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
             attributes={"llm_string": raw_llm_string},
             num_results=3,
         )
-        assert hits
-        # Response must match, and metadata should contain the original value
-        # (the client handles encoding/decoding around the LangCache API).
-        assert any(hit["response"] == response for hit in hits)
+        # One hit must match on both counts: the response, and the metadata
+        # round-tripped back to its original value (the client handles
+        # encoding/decoding around the LangCache API).
         assert any(
-            hit.get("metadata", {}).get("llm_string") == raw_llm_string for hit in hits
-        )
+            hit["response"] == response
+            and hit.get("metadata", {}).get("llm_string") == raw_llm_string
+            for hit in hits
+        ), f"encoded llm_string did not round-trip; got {hits}"
 
     def test_attribute_value_with_all_tokenizer_separators_round_trip_and_filter(
-        self, langcache_with_attrs: LangCacheSemanticCache
+        self, langcache_with_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
         """All tokenizer separator characters should round-trip via filters.
 
@@ -335,15 +389,16 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
         """
 
         separators = ",.<>{}[]\"':;!@#$%^&*()-+=~"
-        raw_llm_string = f"tenant {separators} value"
+        raw_llm_string = f"tenant {separators} value {scope}"
 
-        prompt = "Attribute encoding for all tokenizer separators"
-        response = "Response for all tokenizer separators."
+        prompt = f"Attribute encoding for all tokenizer separators [{scope}]"
+        response = f"Response for all tokenizer separators. [{scope}]"
 
         entry_id = langcache_with_attrs.store(
             prompt=prompt,
             response=response,
             metadata={"llm_string": raw_llm_string},
+            ttl=TEST_ENTRY_TTL,
         )
         assert entry_id
 
@@ -372,6 +427,7 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
         self,
         langcache_with_attrs: LangCacheSemanticCache,
         raw_value: str,
+        scope: str,
     ) -> None:
         """Backslash and question-mark values should round-trip via filters.
 
@@ -380,6 +436,10 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
         filterable and round-trip correctly.
         """
 
+        # Joined with an underscore: unlike "-", it is not a text separator and
+        # survives percent-encoding untouched, so scoping adds no character
+        # beyond the ones this test exists to pin down.
+        raw_value = f"{raw_value}_{scope}"
         prompt = f"Special chars attribute {raw_value}"
         response = f"Response for {raw_value}"
 
@@ -387,6 +447,7 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
             prompt=prompt,
             response=response,
             metadata={"llm_string": raw_value},
+            ttl=TEST_ENTRY_TTL,
         )
         assert entry_id
 
@@ -413,16 +474,19 @@ class TestLangCacheSemanticCacheIntegrationWithAttributes:
 @pytest.mark.requires_api_keys
 class TestLangCacheSemanticCacheIntegrationWithoutAttributes:
     def test_error_on_store_with_metadata_when_no_attributes_configured(
-        self, langcache_no_attrs: LangCacheSemanticCache
+        self, langcache_no_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "Attributes not configured"
+        prompt = f"Attributes not configured [{scope}]"
         response = "This should fail due to missing attributes configuration."
 
+        # Scoped and TTL'd even though the store is expected to raise: if this
+        # cache is ever given attributes, the write would start succeeding.
         with pytest.raises(RuntimeError) as exc:
             langcache_no_attrs.store(
                 prompt=prompt,
                 response=response,
-                metadata={"tenant": "tenant_without_attrs"},
+                metadata={"tenant": f"tenant_without_attrs_{scope}"},
+                ttl=TEST_ENTRY_TTL,
             )
 
         assert "attributes are not configured for this cache" in str(exc.value).lower()
@@ -441,14 +505,20 @@ class TestLangCacheSemanticCacheIntegrationWithoutAttributes:
         assert "attributes are not configured for this cache" in str(exc.value).lower()
 
     def test_basic_store_and_check_works_without_attributes(
-        self, langcache_no_attrs: LangCacheSemanticCache
+        self, langcache_no_attrs: LangCacheSemanticCache, scope: str
     ) -> None:
-        prompt = "Plain cache without attributes"
-        response = "This should be cached successfully."
+        prompt = f"Plain cache without attributes [{scope}]"
+        response = f"This should be cached successfully. [{scope}]"
 
-        entry_id = langcache_no_attrs.store(prompt=prompt, response=response)
+        entry_id = langcache_no_attrs.store(
+            prompt=prompt, response=response, ttl=TEST_ENTRY_TTL
+        )
         assert entry_id
 
+        # This cache has no attributes configured, so a scoped filter is not
+        # available here -- the unique prompt and the exact search strategy are
+        # the only isolation this test can get.
         hits = langcache_no_attrs.check(prompt=prompt)
-        assert hits
-        assert any(hit["response"] == response for hit in hits)
+        assert any(
+            hit["response"] == response for hit in hits
+        ), f"scoped entry not returned; got {hits}"

--- a/tests/unit/test_langcache_semantic_cache.py
+++ b/tests/unit/test_langcache_semantic_cache.py
@@ -2,7 +2,7 @@
 
 import builtins
 import importlib.util
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
@@ -11,16 +11,24 @@ from redisvl.extensions.cache.llm.langcache import LangCacheSemanticCache
 
 @pytest.fixture
 def mock_langcache_client():
-    """Create a mock LangCache client via the wrapper factory method."""
-    with patch.object(LangCacheSemanticCache, "_create_client") as mock_create_client:
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
+    """Create a mock LangCache client via the wrapper factory method.
 
-        # Mock context manager
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=None)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+    Autospecced against the real SDK class, so a renamed method or a changed
+    signature fails here rather than being silently auto-vivified. That matters
+    more than usual: whole-cache flush has no live-service coverage anywhere
+    (see the module docstring in
+    tests/integration/test_langcache_semantic_cache_integration.py), so these
+    mocks are the only thing standing between an SDK change and a broken
+    delete()/clear().
+    """
+
+    # Local import: at module scope this would break collection in an
+    # environment without the optional langcache dependency.
+    from langcache import LangCache
+
+    with patch.object(LangCacheSemanticCache, "_create_client") as mock_create_client:
+        mock_client = create_autospec(LangCache, instance=True)
+        mock_create_client.return_value = mock_client
 
         yield mock_create_client, mock_client
 
@@ -124,7 +132,7 @@ class TestLangCacheSemanticCache:
         # Mock the async set method - returns a Pydantic model with entry_id
         mock_response = MagicMock()
         mock_response.entry_id = "entry-456"
-        mock_client.set_async = AsyncMock(return_value=mock_response)
+        mock_client.set_async.return_value = mock_response
 
         cache = LangCacheSemanticCache(
             name="test",
@@ -175,10 +183,9 @@ class TestLangCacheSemanticCache:
         """astore() should pass per-entry TTL as ttl_millis to LangCache client."""
         _, mock_client = mock_langcache_client
 
-        # Ensure set_async is an AsyncMock so it can be awaited.
         mock_response = MagicMock()
         mock_response.entry_id = "entry-999"
-        mock_client.set_async = AsyncMock(return_value=mock_response)
+        mock_client.set_async.return_value = mock_response
 
         cache = LangCacheSemanticCache(
             name="test",
@@ -262,7 +269,7 @@ class TestLangCacheSemanticCache:
 
         mock_response = MagicMock()
         mock_response.data = [mock_entry]
-        mock_client.search_async = AsyncMock(return_value=mock_response)
+        mock_client.search_async.return_value = mock_response
 
         cache = LangCacheSemanticCache(
             name="test",
@@ -376,67 +383,67 @@ class TestLangCacheSemanticCache:
             "topic": r"programming,with/encoding\and?",
         }
 
-        def test_store_with_empty_metadata_does_not_send_attributes(
-            self, mock_langcache_client
-        ):
-            """Empty metadata {} should not be forwarded as attributes to the SDK."""
-            _, mock_client = mock_langcache_client
+    def test_store_with_empty_metadata_does_not_send_attributes(
+        self, mock_langcache_client
+    ):
+        """Empty metadata {} should not be forwarded as attributes to the SDK."""
+        _, mock_client = mock_langcache_client
 
-            mock_response = MagicMock()
-            mock_response.entry_id = "entry-empty"
-            mock_client.set.return_value = mock_response
+        mock_response = MagicMock()
+        mock_response.entry_id = "entry-empty"
+        mock_client.set.return_value = mock_response
 
-            cache = LangCacheSemanticCache(
-                name="test",
-                server_url="https://api.example.com",
-                cache_id="test-cache",
-                api_key="test-key",
-            )
+        cache = LangCacheSemanticCache(
+            name="test",
+            server_url="https://api.example.com",
+            cache_id="test-cache",
+            api_key="test-key",
+        )
 
-            entry_id = cache.store(
-                prompt="Q?",
-                response="A",
-                metadata={},  # should be ignored
-            )
+        entry_id = cache.store(
+            prompt="Q?",
+            response="A",
+            metadata={},  # should be ignored
+        )
 
-            assert entry_id == "entry-empty"
-            # Ensure attributes kwarg was NOT sent when metadata is {}
-            _, call_kwargs = mock_client.set.call_args
-            assert "attributes" not in call_kwargs
+        assert entry_id == "entry-empty"
+        # Ensure attributes kwarg was NOT sent when metadata is {}
+        _, call_kwargs = mock_client.set.call_args
+        assert "attributes" not in call_kwargs
 
-        def test_check_with_empty_attributes_does_not_send_attributes(
-            self, mock_langcache_client
-        ):
-            """Empty attributes {} should not be forwarded to the SDK search call."""
-            _, mock_client = mock_langcache_client
+    def test_check_with_empty_attributes_does_not_send_attributes(
+        self, mock_langcache_client
+    ):
+        """Empty attributes {} should not be forwarded to the SDK search call."""
+        _, mock_client = mock_langcache_client
 
-            mock_entry = MagicMock()
-            mock_entry.model_dump.return_value = {
-                "id": "e1",
-                "prompt": "Q?",
-                "response": "A",
-                "similarity": 1.0,
-                "created_at": 0.0,
-                "updated_at": 0.0,
-                "attributes": {},
-            }
-            mock_response = MagicMock()
-            mock_response.data = [mock_entry]
-            mock_client.search.return_value = mock_response
+        mock_entry = MagicMock()
+        mock_entry.model_dump.return_value = {
+            "id": "e1",
+            "prompt": "Q?",
+            "response": "A",
+            "similarity": 1.0,
+            "created_at": 0.0,
+            "updated_at": 0.0,
+            "attributes": {},
+        }
+        mock_response = MagicMock()
+        mock_response.data = [mock_entry]
+        mock_client.search.return_value = mock_response
 
-            cache = LangCacheSemanticCache(
-                name="test",
-                server_url="https://api.example.com",
-                cache_id="test-cache",
-                api_key="test-key",
-            )
+        cache = LangCacheSemanticCache(
+            name="test",
+            server_url="https://api.example.com",
+            cache_id="test-cache",
+            api_key="test-key",
+        )
 
-            results = cache.check(prompt="Q?", attributes={})  # should be ignored
-            assert results and results[0]["entry_id"] == "e1"
+        results = cache.check(prompt="Q?", attributes={})  # should be ignored
+        assert results and results[0]["entry_id"] == "e1"
 
-            # Ensure attributes kwarg was NOT sent when attributes is {}
-            _, call_kwargs = mock_client.search.call_args
-            assert "attributes" not in call_kwargs
+        # Ensure attributes kwarg was NOT sent when attributes is {}
+        _, call_kwargs = mock_client.search.call_args
+        assert "attributes" not in call_kwargs
 
     def test_delete(self, mock_langcache_client):
         """Test deleting the entire cache using flush()."""
@@ -457,8 +464,6 @@ class TestLangCacheSemanticCache:
     async def test_adelete(self, mock_langcache_client):
         """Test async deleting the entire cache using flush()."""
         _, mock_client = mock_langcache_client
-
-        mock_client.flush_async = AsyncMock()
 
         cache = LangCacheSemanticCache(
             name="test",
@@ -490,8 +495,6 @@ class TestLangCacheSemanticCache:
     async def test_aclear(self, mock_langcache_client):
         """Test that async clear() calls adelete() which uses flush()."""
         _, mock_client = mock_langcache_client
-
-        mock_client.flush_async = AsyncMock()
 
         cache = LangCacheSemanticCache(
             name="test",
@@ -565,7 +568,7 @@ class TestLangCacheSemanticCache:
 
         mock_response = MagicMock()
         mock_response.model_dump.return_value = {"deleted_entries_count": 3}
-        mock_client.delete_query_async = AsyncMock(return_value=mock_response)
+        mock_client.delete_query_async.return_value = mock_response
 
         cache = LangCacheSemanticCache(
             name="test",


### PR DESCRIPTION
## Motivation

The LangCache integration suite fails semi-randomly in the Service Tests job, on pull requests that touch nothing related to LangCache, and a different test fails each time. A reproducible defect fails the same test every run, so the pattern itself points at a shared resource, not at any one branch: #716 saw `test_store_and_check_async` fail on `assert []`, its stored entry gone; #718 saw two different tests fail, and a third on re-run.

Two things combine to cause it. `TestLangCacheSemanticCacheIntegrationWithAttributes` flushed the entire managed cache, through `delete()`, `clear()` and `aclear()`, and the suite runs under `pytest -n auto`, so a flush on one xdist worker wiped entries another worker had stored moments earlier. The fixtures then bind to a single `cache_id` from repo secrets, which every CI run reaches concurrently: pull requests, fork pull requests, pushes to main, and the nightly cron. Runs on separate branches therefore flushed each other.

## Changes

### Whole-cache flushes are removed, and blocked from returning

`test_delete_and_clear_alias` is deleted and the trailing `aclear()` is removed from `test_async_delete_variants`. An autouse fixture patches `delete`, `adelete`, `clear` and `aclear` to fail the test, so the rule is now mechanical, not a convention recorded in a docstring.

This trades away live coverage of the flush endpoint, which is a constraint and not a preference: no cache shared with other runs can safely be flushed, and a dedicated flushable `cache_id` would collide identically once two runs used it. The wrappers themselves are four one-line calls into the SDK and keep their mocked unit coverage; the flush HTTP path is deliberately untested.

### Every write is scoped and expiring

A per-test `scope` token, from `uuid4().hex[:12]`, is threaded into every prompt, response and attribute value, so no test can observe or delete another's entries. Every entry carries a 60-second TTL, which lets the shared caches drain now that nothing flushes them. The TTL is passed per call, not set once on the fixtures, because `store()` ignores a constructor TTL entirely. That defect is filed separately, and the module docstring records it so the repetition is not tidied away into the fixtures.

### The TTL-expiry tests no longer depend on result ranking

`num_results` is a client-side slice: `_build_search_kwargs` never sends `max_results`, and the installed SDK documents its own default as one result. Raising it therefore buys no headroom against a concurrent run's semantically identical prompt competing for that single slot. Filtering on a scope-unique attribute does, because the service can only return entries matching it.

```python
# Before: reads back whichever single entry the service ranks first.
hits = langcache_with_attrs.check(prompt=prompt, num_results=5)

# After: the result set is provably this test's own.
hits = langcache_with_attrs.check(prompt=prompt, attributes=metadata)
```

Both tests also move from a two-second TTL to five, with the sleep from three seconds to six. Two seconds had to cover a store round trip and a search round trip against a shared managed service, so the assertion that the entry exists was racing its own TTL.

Secondary changes:

- Delete-by-attribute assertions tighten from `>= 1` to the number of entries actually stored, which scope-unique attributes make knowable.
- Scope tokens join punctuation-heavy attribute values with `_` rather than `-`, which survives percent-encoding and is a RediSearch text separator.
- The unit-test SDK mock is autospecced, so a renamed method or a changed signature fails there instead of being auto-vivified.
- Two unit tests were indented into another test and so were never collected. Dedenting them adds both to the run, and the file now collects 26, having also lost a name-checking test that autospec subsumes.
- CONTRIBUTING.md gains a paragraph on namespacing writes to shared, stateful external services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes; no production LangCache client behavior is modified.
> 
> **Overview**
> Stops flaky **LangCache** integration failures caused by many workers and CI jobs sharing the same managed `cache_id`.
> 
> **Whole-cache flush is removed from live tests** and enforced with an autouse fixture that makes `delete`/`clear` (sync and async) fail if called. Integration cases that flushed the cache are dropped; flush behavior stays covered only in **unit** mocks (now **autospecced** against the real SDK). Two previously nested unit tests are dedented so they actually run.
> 
> **Writes are isolated**: per-test `scope` tokens in prompts/responses/attributes, **60s TTL** on routine stores, and assertions that look for *your* scoped row in `hits` (not `hits[0]`). TTL-expiry tests use **scoped attribute filters**, longer TTL/sleep, and tighter delete-by-attribute counts.
> 
> **CONTRIBUTING.md** adds guidance to namespace data and never flush shared external services, pointing at the integration module docstring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d378d058b745b98362def37970183b5dba5386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->