### PR TITLE
fix: SemanticCache fails to connect to Sentinel instances with quoted passwords

### DIFF
--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -969,6 +969,6 @@ class RedisConnectionFactory:
             if len(path_parts) > 2:
                 db = path_parts[2]
 
-        username = unquote(parsed_url.username or "")
-        password = unquote(parsed_url.password or "")
+        username = unquote(parsed_url.username) if parsed_url.username else None
+        password = unquote(parsed_url.password) if parsed_url.password else None
         return sentinel_list, service_name, db, username, password

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -1,6 +1,6 @@
 import os
 from typing import Any, Sequence, TypeVar, overload
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qs, unquote, urlencode, urlparse, urlunparse
 from warnings import warn
 
 from redis import Redis, RedisCluster
@@ -969,4 +969,6 @@ class RedisConnectionFactory:
             if len(path_parts) > 2:
                 db = path_parts[2]
 
-        return sentinel_list, service_name, db, parsed_url.username, parsed_url.password
+        username = unquote(parsed_url.username or "")
+        password = unquote(parsed_url.password or "")
+        return sentinel_list, service_name, db, username, password

--- a/tests/unit/test_sentinel_url.py
+++ b/tests/unit/test_sentinel_url.py
@@ -15,6 +15,7 @@ the sync SentinelConnectionPool, causing runtime failures.
 """
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import quote
 
 import pytest
 from redis.exceptions import ConnectionError
@@ -256,3 +257,24 @@ class TestSentinelUrlParsingEdgeCases:
             master_for_kwargs = mock_async_sentinel.return_value.master_for.call_args[1]
             assert master_for_kwargs["decode_responses"] is True
             assert master_for_kwargs["socket_timeout"] == 5.0
+
+    def test_sentinel_url_parse_quoted_username_password(self):
+        """Verify unquoted username and password are correctly passed to Sentinel."""
+        unquoted_password = "test!$34"
+        unquoted_username = "testUser#4"
+        sentinel_url = (
+            f"redis+sentinel://{quote(unquoted_username, safe='')}:"
+            f"{quote(unquoted_password, safe='')}@host1:26379/mymaster"
+        )
+
+        with patch("redisvl.redis.connection.Sentinel") as mock_sentinel:
+            mock_sentinel.return_value.master_for.return_value = MagicMock()
+            RedisConnectionFactory.get_redis_connection(sentinel_url)
+
+            call_kwargs = mock_sentinel.call_args[1]
+            assert call_kwargs["sentinel_kwargs"] == {
+                "username": unquoted_username,
+                "password": unquoted_password,
+            }
+            assert call_kwargs["password"] == unquoted_password
+            assert call_kwargs["username"] == unquoted_username


### PR DESCRIPTION
# Summary
Fixes https://github.com/redis/redis-vl-python/issues/731 - `SemanticCache` throws an `AuthenticationError` when attempting to connect to a Redis Sentinel URL with quoted passwords

# Root Cause
`RedisConnectionFactory._parse_sentinel_url` retrieves the username and password from the parsed URL and never unquotes them:
```
parsed_url = urlparse(url)
...
return sentinel_list, service_name, db, parsed_url.username, parsed_url.password
``` 

# Suggested Fix
Unquote the username and password
```
username = unquote(parsed_url.username)
password = unquote(parsed_url.password)
return sentinel_list, service_name, db, username, password
```

### PR Checklist

Before submitting your PR, ensure:

- [ ] Code follows our style guidelines (`make lint` passes)
- [ ] Tests pass (`make test` passes)
- [ ] Documentation is updated if needed
- [ ] Commit messages are clear and descriptive
- [ ] PR description explains what changes were made and why
- [ ] Appropriate `auto:*` label is applied to indicate the change type

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Sentinel URL credential parsing with a focused unit test; behavior only differs when credentials contain URL-encoded characters.
> 
> **Overview**
> Fixes **SemanticCache** (and other Sentinel URL clients) failing with **AuthenticationError** when `redis+sentinel://` URLs use percent-encoded usernames or passwords (e.g. `!`, `$`, `#`).
> 
> **`_parse_sentinel_url`** now runs **`unquote`** on parsed username and password before they are passed into **`Sentinel` / `AsyncSentinel`** via **`sentinel_kwargs`** and master connection kwargs. A unit test builds a Sentinel URL with **`quote`**-encoded credentials and asserts the decoded values reach the mocked **`Sentinel`** constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293e4632e8285c966470796101d0aabfbc764977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->