### PR TITLE
ci: make the redis:latest matrix legs advisory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
     name: Python ${{ matrix.python-version }} - redis-py ${{ matrix.redis-py-version }} [${{ matrix.redis-image }}]
     runs-on: ubuntu-latest
     needs: service-tests
-    # `redis:latest` legs are advisory. See the `experimental` include below.
     continue-on-error: ${{ matrix.experimental || false }}
     env:
       HF_HOME: ${{ github.workspace }}/hf_cache
@@ -78,17 +77,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         redis-py-version: ["6.x", "7.x", "8.x"]
-        # `redis:latest` is a floating tag: its contents change with no commit
-        # to this repository, so a failure on it cannot be reproduced from a
-        # SHA and `git bisect` over CI results is meaningless. It has already
-        # cost us twice -- the Redis 8.8 RediSearch worker default that opened
-        # an FT.SEARCH nil-field race (see tests/docker-compose.yml), and the
-        # Redis 8.10 FT.CURSOR abort in the aggregate-cursor path under bulk-op
-        # load, which no client-side workaround addresses.
-        #
-        # Keep the leg for early warning of server regressions, but mark it
-        # advisory via the include below so it informs without blocking merges.
-        # Blocking coverage comes from the pinned tags only.
+        # `redis:latest` floats, so a failure on it is not reproducible from a
+        # SHA; it is advisory below. Pinned tags carry the blocking coverage.
         redis-image: ["redis:8.2", "redis:8.4", "redis:latest"]
         include:
           - redis-image: "redis:latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
     name: Python ${{ matrix.python-version }} - redis-py ${{ matrix.redis-py-version }} [${{ matrix.redis-image }}]
     runs-on: ubuntu-latest
     needs: service-tests
+    # `redis:latest` legs are advisory. See the `experimental` include below.
+    continue-on-error: ${{ matrix.experimental || false }}
     env:
       HF_HOME: ${{ github.workspace }}/hf_cache
       REDIS_IMAGE: ${{ matrix.redis-image }}
@@ -76,7 +78,21 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         redis-py-version: ["6.x", "7.x", "8.x"]
+        # `redis:latest` is a floating tag: its contents change with no commit
+        # to this repository, so a failure on it cannot be reproduced from a
+        # SHA and `git bisect` over CI results is meaningless. It has already
+        # cost us twice -- the Redis 8.8 RediSearch worker default that opened
+        # an FT.SEARCH nil-field race (see tests/docker-compose.yml), and the
+        # Redis 8.10 FT.CURSOR abort in the aggregate-cursor path under bulk-op
+        # load, which no client-side workaround addresses.
+        #
+        # Keep the leg for early warning of server regressions, but mark it
+        # advisory via the include below so it informs without blocking merges.
+        # Blocking coverage comes from the pinned tags only.
         redis-image: ["redis:8.2", "redis:8.4", "redis:latest"]
+        include:
+          - redis-image: "redis:latest"
+            experimental: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Motivation

A third of the test matrix ran against `redis:latest`, a floating tag whose contents change with no commit to this repository. A failure on those legs could not be reproduced from a SHA, which makes bisecting over CI results meaningless, and it gated merges on server-side changes nobody here had made.

The tag has already cost this project twice. Redis 8.8 changed the RediSearch worker default and opened an `FT.SEARCH` nil-field race, pinned away with `--search-workers 0` in `tests/docker-compose.yml`. Redis 8.10 aborts in the aggregate-cursor path under bulk-op load, for which no client-side workaround exists.

## Changes

The `redis:latest` legs become advisory rather than blocking. A matrix `include` entry tags them with `experimental: true`, and the job reads that flag through `continue-on-error`. The leg still runs, so a server regression still surfaces early, but it no longer gates a merge. Blocking coverage now comes from the pinned tags alone.

The `include` entry matches an existing `redis-image` value, so it adds a key to the combinations that already exist rather than creating new ones. Parsing the workflow confirms the expansion is unchanged at 45 jobs: 15 advisory and 30 blocking.

## Notes

Blocking coverage of a newer server would need a concrete pinned tag added as a fourth matrix value. That is a coverage decision rather than part of this fix, so it is deliberately left out.
